### PR TITLE
add a geoguessrId parameter to /maps endpoint to find matching regions for a single map more efficiently

### DIFF
--- a/apps/api/src/routes/maps.ts
+++ b/apps/api/src/routes/maps.ts
@@ -9,13 +9,23 @@ export const mapsRouter = new Elysia({ prefix: '/maps' })
   .get(
     '/',
     async ({ query }) => {
-      const { q, region, isShared } = query;
+      const { q, geoguessrId, region, isShared } = query;
 
       // Build filter conditions
       const conditions = [
         eq(maps.isPersonal, false), // Only non-personal maps
         eq(maps.isPublished, true), // Only published maps
       ];
+
+      // Find by geoguessrId
+      if (geoguessrId) {
+        const searchCondition = or(
+          eq(maps.geoguessrId, geoguessrId),
+        );
+        if (searchCondition) {
+          conditions.push(searchCondition);
+        }
+      }
 
       // Search filter (name or description)
       if (q) {
@@ -83,6 +93,7 @@ export const mapsRouter = new Elysia({ prefix: '/maps' })
     {
       query: t.Object({
         q: t.Optional(t.String()),
+        geoguessrId: t.Optional(t.String()),
         region: t.Optional(t.String()),
         isShared: t.Optional(t.Boolean()),
       }),


### PR DESCRIPTION
Since I need to find regions for a mapId, I added the parameter `geoguessrId` to the /maps endpoint.

It would probably be cleaner if we added a second endpoint `/maps/:id` to get the regions instead, but since it already features searching by name and description + since you added this public endpoint (in part) for me, I figured it would be alright to add the additional parameter `geoguessrId` .

-----

The alternative for my planned usage would be to find the map by name, but this would be less efficient for both API and Client because
* DB needs to do string comparison across all maps
* My Userscript needs to handle multiple matches by name, by detecting multiple results and comparing IDs to get the needed result

Thank you again!