### PR TITLE
Add owner/editor collaboration roles and a per-group change log for map groups

### DIFF
--- a/apps/api/src/lib/db/migrations/0035_map_group_collaboration.sql
+++ b/apps/api/src/lib/db/migrations/0035_map_group_collaboration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "map_group_changes" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"map_group_id" integer NOT NULL,
+	"user_id" text NOT NULL,
+	"entity_type" text NOT NULL,
+	"entity_id" integer,
+	"entity_label" text,
+	"operation" text NOT NULL,
+	"old_value" jsonb,
+	"new_value" jsonb,
+	"created_at" integer NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "map_group_permissions" ADD COLUMN "role" text DEFAULT 'owner' NOT NULL;--> statement-breakpoint
+ALTER TABLE "map_group_changes" ADD CONSTRAINT "map_group_changes_map_group_id_map_groups_id_fk" FOREIGN KEY ("map_group_id") REFERENCES "public"."map_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "map_group_changes" ADD CONSTRAINT "map_group_changes_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "map_group_changes_group_created_idx" ON "map_group_changes" USING btree ("map_group_id","created_at" DESC NULLS LAST,"id" DESC NULLS LAST);

--- a/apps/api/src/lib/db/migrations/meta/0035_snapshot.json
+++ b/apps/api/src/lib/db/migrations/meta/0035_snapshot.json
@@ -1,0 +1,1947 @@
+{
+  "id": "31f95612-5b3e-4bea-b773-8a8b2e7f29b2",
+  "prevId": "56867a61-251e-4cb2-a424-4d72affa9bc3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cache": {
+      "name": "cache",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.levels": {
+      "name": "levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "levels_unique": {
+          "name": "levels_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "levels_map_group_id_map_groups_id_fk": {
+          "name": "levels_map_group_id_map_groups_id_fk",
+          "tableFrom": "levels",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_data": {
+      "name": "map_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_panoids": {
+          "name": "last_updated_panoids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "map_data_unique": {
+          "name": "map_data_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_data_map_id_maps_id_fk": {
+          "name": "map_data_map_id_maps_id_fk",
+          "tableFrom": "map_data",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_filters": {
+      "name": "map_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_like": {
+          "name": "tag_like",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_exclude": {
+          "name": "is_exclude",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "map_filters_unique": {
+          "name": "map_filters_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_like",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_filters_map_id_maps_id_fk": {
+          "name": "map_filters_map_id_maps_id_fk",
+          "tableFrom": "map_filters",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_group_changes": {
+      "name": "map_group_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_label": {
+          "name": "entity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "map_group_changes_group_created_idx": {
+          "name": "map_group_changes_group_created_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_group_changes_map_group_id_map_groups_id_fk": {
+          "name": "map_group_changes_map_group_id_map_groups_id_fk",
+          "tableFrom": "map_group_changes",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_group_changes_user_id_user_id_fk": {
+          "name": "map_group_changes_user_id_user_id_fk",
+          "tableFrom": "map_group_changes",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_group_locations": {
+      "name": "map_group_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_on_street_view": {
+          "name": "is_on_street_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1730419200
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_tag": {
+          "name": "extra_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "map_group_locations_unique": {
+          "name": "map_group_locations_unique",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pano_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "map_group_locations_map_group_tag_idx": {
+          "name": "map_group_locations_map_group_tag_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extra_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "map_group_locations_map_group_modified_idx": {
+          "name": "map_group_locations_map_group_modified_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_group_locations_map_group_id_map_groups_id_fk": {
+          "name": "map_group_locations_map_group_id_map_groups_id_fk",
+          "tableFrom": "map_group_locations",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_group_permissions": {
+      "name": "map_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "map_group_permissions_unique": {
+          "name": "map_group_permissions_unique",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_group_permissions_map_group_id_map_groups_id_fk": {
+          "name": "map_group_permissions_map_group_id_map_groups_id_fk",
+          "tableFrom": "map_group_permissions",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_group_permissions_user_id_user_id_fk": {
+          "name": "map_group_permissions_user_id_user_id_fk",
+          "tableFrom": "map_group_permissions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_groups": {
+      "name": "map_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_include_locations_not_on_street_view": {
+          "name": "sync_include_locations_not_on_street_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_levels": {
+      "name": "map_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "map_levels_unique": {
+          "name": "map_levels_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_levels_map_id_maps_id_fk": {
+          "name": "map_levels_map_id_maps_id_fk",
+          "tableFrom": "map_levels",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_levels_level_id_levels_id_fk": {
+          "name": "map_levels_level_id_levels_id_fk",
+          "tableFrom": "map_levels",
+          "tableTo": "levels",
+          "columnsFrom": ["level_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_regions": {
+      "name": "map_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "map_region_unique": {
+          "name": "map_region_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_regions_map_id_maps_id_fk": {
+          "name": "map_regions_map_id_maps_id_fk",
+          "tableFrom": "map_regions",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_regions_region_id_regions_id_fk": {
+          "name": "map_regions_region_id_regions_id_fk",
+          "tableFrom": "map_regions",
+          "tableTo": "regions",
+          "columnsFrom": ["region_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maps": {
+      "name": "maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geoguessr_id": {
+          "name": "geoguessr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "ordering": {
+          "name": "ordering",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_html": {
+          "name": "footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1730419200
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "number_of_games_played": {
+          "name": "number_of_games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_games_played_diminished": {
+          "name": "number_of_games_played_diminished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "maps_map_group_modified_idx": {
+          "name": "maps_map_group_modified_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maps_map_group_id_map_groups_id_fk": {
+          "name": "maps_map_group_id_map_groups_id_fk",
+          "tableFrom": "maps",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maps_user_id_user_id_fk": {
+          "name": "maps_user_id_user_id_fk",
+          "tableFrom": "maps",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maps_geoguessr_id_unique": {
+          "name": "maps_geoguessr_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["geoguessr_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "map_group_id_not_null": {
+          "name": "map_group_id_not_null",
+          "value": "(\"maps\".\"is_personal\" AND \"maps\".\"map_group_id\" IS NULL)\n          OR (NOT \"maps\".\"is_personal\" AND \"maps\".\"map_group_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.meta_images": {
+      "name": "meta_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "meta_image_unique": {
+          "name": "meta_image_unique",
+          "columns": [
+            {
+              "expression": "meta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "image_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_images_meta_id_metas_id_fk": {
+          "name": "meta_images_meta_id_metas_id_fk",
+          "tableFrom": "meta_images",
+          "tableTo": "metas",
+          "columnsFrom": ["meta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_levels": {
+      "name": "meta_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "meta_levels_unique": {
+          "name": "meta_levels_unique",
+          "columns": [
+            {
+              "expression": "meta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_levels_meta_id_metas_id_fk": {
+          "name": "meta_levels_meta_id_metas_id_fk",
+          "tableFrom": "meta_levels",
+          "tableTo": "metas",
+          "columnsFrom": ["meta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meta_levels_level_id_levels_id_fk": {
+          "name": "meta_levels_level_id_levels_id_fk",
+          "tableFrom": "meta_levels",
+          "tableTo": "levels",
+          "columnsFrom": ["level_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_locations_count_view": {
+      "name": "meta_locations_count_view",
+      "schema": "",
+      "columns": {
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_locations_count_view_meta_id_metas_id_fk": {
+          "name": "meta_locations_count_view_meta_id_metas_id_fk",
+          "tableFrom": "meta_locations_count_view",
+          "tableTo": "metas",
+          "columnsFrom": ["meta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_suggestions": {
+      "name": "meta_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_nickname": {
+          "name": "author_nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'new'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metas": {
+      "name": "metas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_name": {
+          "name": "tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_html": {
+          "name": "note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_html": {
+          "name": "footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "note_from_plonkit": {
+          "name": "note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_image": {
+          "name": "has_image",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1730419200
+        }
+      },
+      "indexes": {
+        "metas_unique": {
+          "name": "metas_unique",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metas_map_group_modified_idx": {
+          "name": "metas_map_group_modified_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metas_map_group_id_map_groups_id_fk": {
+          "name": "metas_map_group_id_map_groups_id_fk",
+          "tableFrom": "metas",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering": {
+          "name": "ordering",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_locations": {
+      "name": "synced_locations",
+      "schema": "",
+      "columns": {
+        "synced_meta_id": {
+          "name": "synced_meta_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_tag": {
+          "name": "extra_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_locations_synced_meta_id_synced_metas_meta_id_fk": {
+          "name": "synced_locations_synced_meta_id_synced_metas_meta_id_fk",
+          "tableFrom": "synced_locations",
+          "tableTo": "synced_metas",
+          "columnsFrom": ["synced_meta_id"],
+          "columnsTo": ["meta_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "synced_locations_synced_meta_id_pano_id_pk": {
+          "name": "synced_locations_synced_meta_id_pano_id_pk",
+          "columns": ["synced_meta_id", "pano_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_map_metas": {
+      "name": "synced_map_metas",
+      "schema": "",
+      "columns": {
+        "map_id": {
+          "name": "map_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_meta_id": {
+          "name": "synced_meta_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_map_metas_map_id_maps_id_fk": {
+          "name": "synced_map_metas_map_id_maps_id_fk",
+          "tableFrom": "synced_map_metas",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "synced_map_metas_synced_meta_id_synced_metas_meta_id_fk": {
+          "name": "synced_map_metas_synced_meta_id_synced_metas_meta_id_fk",
+          "tableFrom": "synced_map_metas",
+          "tableTo": "synced_metas",
+          "columnsFrom": ["synced_meta_id"],
+          "columnsTo": ["meta_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "synced_map_metas_map_id_synced_meta_id_pk": {
+          "name": "synced_map_metas_map_id_synced_meta_id_pk",
+          "columns": ["map_id", "synced_meta_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_metas": {
+      "name": "synced_metas",
+      "schema": "",
+      "columns": {
+        "meta_id": {
+          "name": "meta_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_from_plonkit": {
+          "name": "note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_metas_map_group_id_map_groups_id_fk": {
+          "name": "synced_metas_map_group_id_map_groups_id_fk",
+          "tableFrom": "synced_metas",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_superadmin": {
+          "name": "is_superadmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_api_token_unique": {
+          "name": "user_api_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.location_metas_view": {
+      "columns": {
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_tag": {
+          "name": "extra_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_modified_at": {
+          "name": "meta_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "location_metas_view",
+      "schema": "public",
+      "isExisting": true,
+      "materialized": false
+    },
+    "public.map_locations_view": {
+      "columns": {
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_name": {
+          "name": "meta_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_name": {
+          "name": "tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note": {
+          "name": "meta_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_html": {
+          "name": "meta_note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_from_plonkit": {
+          "name": "meta_note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_modified_at": {
+          "name": "meta_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_modified_at": {
+          "name": "map_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "map_locations_view",
+      "schema": "public",
+      "isExisting": true,
+      "materialized": false
+    },
+    "public.map_metas_view": {
+      "columns": {
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_footer_html": {
+          "name": "map_footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geoguessr_id": {
+          "name": "geoguessr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_name": {
+          "name": "meta_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_tag": {
+          "name": "meta_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_html": {
+          "name": "meta_note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_image_urls": {
+          "name": "meta_image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_footer_html": {
+          "name": "meta_footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_from_plonkit": {
+          "name": "meta_note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "map_metas_view",
+      "schema": "public",
+      "isExisting": true,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/lib/db/migrations/meta/_journal.json
+++ b/apps/api/src/lib/db/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1763333034649,
       "tag": "0034_messy_hammerhead",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1785007158030,
+      "tag": "0035_map_group_collaboration",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/lib/db/schema.ts
+++ b/apps/api/src/lib/db/schema.ts
@@ -11,6 +11,7 @@ import {
   check,
   index,
   integer,
+  jsonb,
   pgTable,
   pgView,
   primaryKey,
@@ -298,6 +299,11 @@ export const mapGroupPermissions = pgTable(
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
+    // 'owner' default so permission rows inserted by pre-role code paths
+    // during a rolling deploy keep the historical full-access behavior
+    role: text('role', { enum: ['owner', 'editor'] })
+      .notNull()
+      .default('owner'),
   },
   (t) => ({
     mapGroupPermissionsUnique: uniqueIndex('map_group_permissions_unique').on(
@@ -306,6 +312,58 @@ export const mapGroupPermissions = pgTable(
     ),
   }),
 );
+export const mapGroupChanges = pgTable(
+  'map_group_changes',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    mapGroupId: integer('map_group_id')
+      .notNull()
+      .references(() => mapGroups.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    entityType: text('entity_type', {
+      enum: [
+        'meta',
+        'meta_image',
+        'meta_levels',
+        'location_batch',
+        'level',
+        'map',
+        'group',
+        'settings',
+        'sync',
+      ],
+    }).notNull(),
+    entityId: integer('entity_id'),
+    entityLabel: text('entity_label'),
+    operation: text('operation', {
+      enum: ['create', 'update', 'delete'],
+    }).notNull(),
+    oldValue: jsonb('old_value'),
+    newValue: jsonb('new_value'),
+    createdAt: integer('created_at').notNull(),
+  },
+  (t) => [
+    // matches the changes-page ORDER BY (created_at DESC, id DESC) so keyset
+    // pagination never sorts large same-second tie groups
+    index('map_group_changes_group_created_idx').on(
+      t.mapGroupId,
+      t.createdAt.desc(),
+      t.id.desc(),
+    ),
+  ],
+);
+export const mapGroupChangesRelations = relations(
+  mapGroupChanges,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [mapGroupChanges.userId],
+      references: [users.id],
+    }),
+  }),
+);
+
 export const mapGroupPermissionsRelations = relations(
   mapGroupPermissions,
   ({ one }) => ({

--- a/apps/api/src/lib/internal/changes.ts
+++ b/apps/api/src/lib/internal/changes.ts
@@ -1,0 +1,80 @@
+import { mapGroupChanges } from '@api/lib/db/schema';
+import type { db } from '@api/lib/drizzle';
+
+type Tx = Parameters<Parameters<typeof db.$primary.transaction>[0]>[0];
+type DbOrTx = Tx | typeof db.$primary;
+
+export type ChangeEntry = {
+  mapGroupId: number;
+  userId: string;
+  entityType:
+    | 'meta'
+    | 'meta_image'
+    | 'meta_levels'
+    | 'location_batch'
+    | 'level'
+    | 'map'
+    | 'group'
+    | 'settings'
+    | 'sync';
+  entityId?: number | null;
+  entityLabel?: string | null;
+  operation: 'create' | 'update' | 'delete';
+  oldValue?: unknown;
+  newValue?: unknown;
+  // override for entries that must sit exactly on a boundary (sync markers)
+  createdAt?: number;
+};
+
+export async function logChange(
+  dbOrTx: DbOrTx,
+  entries: ChangeEntry | ChangeEntry[],
+) {
+  // no-op updates (identical before/after) are not worth a log entry;
+  // value-less updates (e.g. sync markers) are always kept
+  const list = (Array.isArray(entries) ? entries : [entries]).filter(
+    (entry) =>
+      entry.operation !== 'update' ||
+      (entry.oldValue === undefined && entry.newValue === undefined) ||
+      JSON.stringify(entry.oldValue ?? null) !==
+        JSON.stringify(entry.newValue ?? null),
+  );
+  if (list.length === 0) {
+    return;
+  }
+  const createdAt = Math.floor(Date.now() / 1000);
+  const rows = list.map((entry) => ({
+    mapGroupId: entry.mapGroupId,
+    userId: entry.userId,
+    entityType: entry.entityType,
+    entityId: entry.entityId ?? null,
+    entityLabel: entry.entityLabel ?? null,
+    operation: entry.operation,
+    oldValue: entry.oldValue ?? null,
+    newValue: entry.newValue ?? null,
+    createdAt: entry.createdAt ?? createdAt,
+  }));
+  // chunked to stay well below the postgres bind-parameter limit on bulk logs
+  const BATCH_SIZE = 1000;
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    await dbOrTx.insert(mapGroupChanges).values(rows.slice(i, i + BATCH_SIZE));
+  }
+}
+
+// The subset of meta fields worth diffing in the change log (raw markdown, not
+// the rendered html).
+export function metaSnapshot(meta: {
+  tagName: string;
+  name: string;
+  note: string;
+  footer: string | null;
+  noteFromPlonkit?: boolean;
+}) {
+  return {
+    tagName: meta.tagName,
+    name: meta.name,
+    note: meta.note,
+    footer: meta.footer,
+    noteFromPlonkit: meta.noteFromPlonkit,
+  };
+}

--- a/apps/api/src/lib/internal/map-groups.ts
+++ b/apps/api/src/lib/internal/map-groups.ts
@@ -12,7 +12,7 @@ export async function createMapGroup(userId: string, name: string) {
       .returning({ id: mapGroups.id });
     await tx
       .insert(mapGroupPermissions)
-      .values({ mapGroupId: inserted[0].id, userId });
+      .values({ mapGroupId: inserted[0].id, userId, role: 'owner' });
     return inserted[0].id;
   });
 }

--- a/apps/api/src/lib/internal/metas-upload.ts
+++ b/apps/api/src/lib/internal/metas-upload.ts
@@ -1,5 +1,6 @@
 import { levels, metaImages, metaLevels, metas } from '@api/lib/db/schema';
 import { db } from '@api/lib/drizzle';
+import { logChange, metaSnapshot } from '@api/lib/internal/changes';
 import { markdown2Html } from '@api/lib/utils/markdown';
 import { and, eq, inArray, notInArray, sql } from 'drizzle-orm';
 
@@ -22,6 +23,7 @@ export type MetaUploadItem = {
 
 export async function uploadMetas(
   groupId: number,
+  userId: string,
   items: MetaUploadItem[],
   partialUpload: boolean,
   autoCreateLevels: boolean,
@@ -60,6 +62,47 @@ export async function uploadMetas(
       levelsData.map((level) => [level.name, level.id]),
     );
 
+    const oldMetas = await tx
+      .select()
+      .from(metas)
+      .where(
+        and(
+          eq(metas.mapGroupId, groupId),
+          inArray(
+            metas.tagName,
+            items.map((item) => item.tagName),
+          ),
+        ),
+      );
+    const oldMetaByTag = new Map(oldMetas.map((meta) => [meta.tagName, meta]));
+
+    // current level/image assignments of the updated metas, so the change log
+    // captures uploads that only reassign levels or swap images
+    const oldMetaIds = oldMetas.map((meta) => meta.id);
+    const oldLevelNamesByMetaId = new Map<number, string[]>();
+    const oldImagesByMetaId = new Map<number, string[]>();
+    if (oldMetaIds.length > 0) {
+      const oldMetaLevels = await tx
+        .select({ metaId: metaLevels.metaId, name: levels.name })
+        .from(metaLevels)
+        .innerJoin(levels, eq(levels.id, metaLevels.levelId))
+        .where(inArray(metaLevels.metaId, oldMetaIds));
+      for (const row of oldMetaLevels) {
+        const list = oldLevelNamesByMetaId.get(row.metaId) ?? [];
+        list.push(row.name);
+        oldLevelNamesByMetaId.set(row.metaId, list);
+      }
+      const oldMetaImages = await tx
+        .select({ metaId: metaImages.metaId, url: metaImages.image_url })
+        .from(metaImages)
+        .where(inArray(metaImages.metaId, oldMetaIds));
+      for (const row of oldMetaImages) {
+        const list = oldImagesByMetaId.get(row.metaId) ?? [];
+        list.push(row.url);
+        oldImagesByMetaId.set(row.metaId, list);
+      }
+    }
+
     const metasInsertResult = await tx
       .insert(metas)
       .values(metasInsertData)
@@ -75,15 +118,87 @@ export async function uploadMetas(
         },
       })
       .returning({ id: metas.id, tagName: metas.tagName });
+    const metaIdByTag = new Map(
+      metasInsertResult.map((row) => [row.tagName, row.id]),
+    );
+    await logChange(
+      tx,
+      items.map((item) => {
+        const oldMeta = oldMetaByTag.get(item.tagName);
+        const oldValue: Record<string, unknown> | null = oldMeta
+          ? { ...metaSnapshot(oldMeta) }
+          : null;
+        // mirror what the upsert actually persists (footer falls back to
+        // the column default '', noteFromPlonkit is untouched on conflict)
+        const newValue: Record<string, unknown> = {
+          ...metaSnapshot({
+            tagName: item.tagName,
+            name: item.metaName,
+            note: item.note,
+            footer: item.footer || '',
+            noteFromPlonkit: oldMeta?.noteFromPlonkit ?? false,
+          }),
+        };
+        // levels/images are only rewritten when the file provides them
+        if (item.levels != null) {
+          if (oldValue && oldMeta) {
+            oldValue.levels = [
+              ...(oldLevelNamesByMetaId.get(oldMeta.id) ?? []),
+            ].sort();
+          }
+          newValue.levels = [...item.levels].sort();
+        }
+        if (item.images != null) {
+          if (oldValue && oldMeta) {
+            oldValue.images = [
+              ...(oldImagesByMetaId.get(oldMeta.id) ?? []),
+            ].sort();
+          }
+          newValue.images = [...item.images].sort();
+        }
+        return {
+          mapGroupId: groupId,
+          userId,
+          entityType: 'meta' as const,
+          entityId: metaIdByTag.get(item.tagName),
+          entityLabel: item.tagName,
+          operation: oldMeta ? ('update' as const) : ('create' as const),
+          oldValue,
+          newValue,
+        };
+      }),
+    );
     if (!partialUpload) {
-      await tx.delete(metas).where(
-        and(
-          eq(metas.mapGroupId, groupId),
-          notInArray(
-            metas.id,
-            metasInsertResult.map((row) => row.id),
+      const deletedMetas = await tx
+        .delete(metas)
+        .where(
+          and(
+            eq(metas.mapGroupId, groupId),
+            notInArray(
+              metas.id,
+              metasInsertResult.map((row) => row.id),
+            ),
           ),
-        ),
+        )
+        .returning({
+          id: metas.id,
+          tagName: metas.tagName,
+          name: metas.name,
+          note: metas.note,
+          footer: metas.footer,
+          noteFromPlonkit: metas.noteFromPlonkit,
+        });
+      await logChange(
+        tx,
+        deletedMetas.map((meta) => ({
+          mapGroupId: groupId,
+          userId,
+          entityType: 'meta' as const,
+          entityId: meta.id,
+          entityLabel: meta.tagName,
+          operation: 'delete' as const,
+          oldValue: metaSnapshot(meta),
+        })),
       );
     }
     const metaTagNameToId: Map<string, number> = new Map(
@@ -117,6 +232,18 @@ export async function uploadMetas(
         insertedLevels.forEach((level) => {
           levelIdByName.set(level.name, level.id);
         });
+        await logChange(
+          tx,
+          insertedLevels.map((level) => ({
+            mapGroupId: groupId,
+            userId,
+            entityType: 'level' as const,
+            entityId: level.id,
+            entityLabel: level.name,
+            operation: 'create' as const,
+            newValue: { name: level.name, autoCreatedByUpload: true },
+          })),
+        );
       }
     }
 

--- a/apps/api/src/lib/internal/permissions.ts
+++ b/apps/api/src/lib/internal/permissions.ts
@@ -20,7 +20,12 @@ export async function ensureMapAccess(userId: string, mapId: number) {
   }
 }
 
-export async function ensurePermissions(userId: string, groupId: number) {
+// Resolves the caller's role in a group: 'owner' | 'editor'.
+// Superadmins are treated as owners of every group.
+export async function getGroupRole(
+  userId: string,
+  groupId: number,
+): Promise<'owner' | 'editor' | null> {
   const [permission, superadminUser] = await Promise.all([
     db.$primary.query.mapGroupPermissions.findFirst({
       where: and(
@@ -33,7 +38,23 @@ export async function ensurePermissions(userId: string, groupId: number) {
     }),
   ]);
 
-  if (!(permission || superadminUser)) {
+  if (superadminUser) {
+    return 'owner';
+  }
+  return permission?.role ?? null;
+}
+
+export async function ensurePermissions(userId: string, groupId: number) {
+  const role = await getGroupRole(userId, groupId);
+  if (!role) {
+    throw new PermissionsDeniedError();
+  }
+  return role;
+}
+
+export async function ensureOwner(userId: string, groupId: number) {
+  const role = await getGroupRole(userId, groupId);
+  if (role !== 'owner') {
     throw new PermissionsDeniedError();
   }
 }

--- a/apps/api/src/lib/internal/sync/index.ts
+++ b/apps/api/src/lib/internal/sync/index.ts
@@ -214,4 +214,5 @@ export async function syncMapGroup(group: {
       .set({ syncedAt: currentTimestamp })
       .where(eq(mapGroups.id, group.id));
   });
+  return currentTimestamp;
 }

--- a/apps/api/src/routes/internal/discord-bot.ts
+++ b/apps/api/src/routes/internal/discord-bot.ts
@@ -1,6 +1,7 @@
 import { maps } from '@api/lib/db/schema';
 import { db } from '@api/lib/drizzle';
 import { auth } from '@api/lib/internal/auth';
+import { logChange } from '@api/lib/internal/changes';
 import { ensurePermissions } from '@api/lib/internal/permissions';
 import { eq } from 'drizzle-orm';
 import { Elysia, t } from 'elysia';
@@ -35,6 +36,8 @@ export const discordBotRouter = new Elysia({ prefix: '/discord-bot' })
         });
       }
 
+      // any group member qualifies: the real gate is the Discord server
+      // restricting who can run /publish, this only verifies map ownership
       await ensurePermissions(body.discord_thread_author_id, map.mapGroupId);
 
       const errors: string[] = [];
@@ -54,10 +57,22 @@ export const discordBotRouter = new Elysia({ prefix: '/discord-bot' })
         });
       }
 
-      await db
-        .update(maps)
-        .set({ isPublished: true })
-        .where(eq(maps.geoguessrId, geoguessrId));
+      await db.$primary.transaction(async (tx) => {
+        await tx
+          .update(maps)
+          .set({ isPublished: true })
+          .where(eq(maps.geoguessrId, geoguessrId));
+        await logChange(tx, {
+          mapGroupId: map.mapGroupId!,
+          userId: body.discord_thread_author_id,
+          entityType: 'map',
+          entityId: map.id,
+          entityLabel: map.name,
+          operation: 'update',
+          oldValue: { isPublished: false },
+          newValue: { isPublished: true },
+        });
+      });
       return status(200);
     },
     {

--- a/apps/api/src/routes/internal/map-groups.ts
+++ b/apps/api/src/routes/internal/map-groups.ts
@@ -1,6 +1,7 @@
 import {
   levels,
   locationMetas,
+  mapGroupChanges,
   mapGroupLocations,
   mapGroupPermissions,
   mapGroups,
@@ -12,16 +13,29 @@ import {
 } from '@api/lib/db/schema';
 import { db } from '@api/lib/drizzle';
 import { auth } from '@api/lib/internal/auth';
+import { logChange } from '@api/lib/internal/changes';
 import { createMapGroup } from '@api/lib/internal/map-groups';
 import {
   MissingLevelsError,
   uploadMetas,
 } from '@api/lib/internal/metas-upload';
-import { ensurePermissions } from '@api/lib/internal/permissions';
+import { ensureOwner, ensurePermissions } from '@api/lib/internal/permissions';
 import { syncMapGroup } from '@api/lib/internal/sync';
 import { geoguessrMapJson } from '@api/lib/internal/utils';
 import { isPgError } from '@api/lib/utils/common';
-import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+} from 'drizzle-orm';
 import { Elysia, t } from 'elysia';
 
 export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
@@ -105,7 +119,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .get(
     '/:id/page',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      const role = await ensurePermissions(userId, groupId);
       const [group, user] = await Promise.all([
         db.$primary.query.mapGroups.findFirst({
           with: {
@@ -153,7 +167,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         return status(404);
       }
 
-      return { group, user };
+      return { group, user, role };
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -163,7 +177,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .get(
     '/:id/maps-page',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      const role = await ensurePermissions(userId, groupId);
 
       const group = await db.$primary.query.mapGroups.findFirst({
         with: {
@@ -209,7 +223,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         return status(500);
       }
 
-      return { group, levelList, regionList, user };
+      return { group, levelList, regionList, user, role };
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -219,7 +233,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .get(
     '/:id/levels-page',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      const role = await ensurePermissions(userId, groupId);
 
       const group = await db.$primary.query.mapGroups.findFirst({
         with: {
@@ -234,7 +248,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         return status(404);
       }
 
-      return { group };
+      return { group, role };
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -244,19 +258,50 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .put(
     '/:id/levels',
     async ({ params: { id: groupId }, body, userId }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
 
       const { id, name } = body;
       if (id === undefined) {
-        await db
-          .insert(levels)
-          .values({ name, mapGroupId: groupId })
-          .onConflictDoNothing();
+        await db.$primary.transaction(async (tx) => {
+          const inserted = await tx
+            .insert(levels)
+            .values({ name, mapGroupId: groupId })
+            .onConflictDoNothing()
+            .returning({ id: levels.id });
+          if (inserted.length) {
+            await logChange(tx, {
+              mapGroupId: groupId,
+              userId,
+              entityType: 'level',
+              entityId: inserted[0].id,
+              entityLabel: name,
+              operation: 'create',
+              newValue: { name },
+            });
+          }
+        });
       } else {
-        await db
-          .update(levels)
-          .set({ name })
-          .where(and(eq(levels.id, id), eq(levels.mapGroupId, groupId)));
+        const oldLevel = await db.$primary.query.levels.findFirst({
+          where: and(eq(levels.id, id), eq(levels.mapGroupId, groupId)),
+        });
+        await db.$primary.transaction(async (tx) => {
+          await tx
+            .update(levels)
+            .set({ name })
+            .where(and(eq(levels.id, id), eq(levels.mapGroupId, groupId)));
+          if (oldLevel) {
+            await logChange(tx, {
+              mapGroupId: groupId,
+              userId,
+              entityType: 'level',
+              entityId: id,
+              entityLabel: name,
+              operation: 'update',
+              oldValue: { name: oldLevel.name },
+              newValue: { name },
+            });
+          }
+        });
       }
     },
     {
@@ -271,12 +316,26 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .delete(
     '/:id/levels/:levelId',
     async ({ params: { id: groupId, levelId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
 
-      const deleted = await db
-        .delete(levels)
-        .where(and(eq(levels.id, levelId), eq(levels.mapGroupId, groupId)))
-        .returning({ id: levels.id });
+      const deleted = await db.$primary.transaction(async (tx) => {
+        const deletedRows = await tx
+          .delete(levels)
+          .where(and(eq(levels.id, levelId), eq(levels.mapGroupId, groupId)))
+          .returning({ id: levels.id, name: levels.name });
+        if (deletedRows.length) {
+          await logChange(tx, {
+            mapGroupId: groupId,
+            userId,
+            entityType: 'level',
+            entityId: levelId,
+            entityLabel: deletedRows[0].name,
+            operation: 'delete',
+            oldValue: { name: deletedRows[0].name },
+          });
+        }
+        return deletedRows;
+      });
       if (deleted.length === 0) {
         return status(404);
       }
@@ -288,9 +347,108 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
     },
   )
   .get(
+    '/:id/changes-page',
+    async ({ params: { id: groupId }, query, userId, status }) => {
+      const role = await ensurePermissions(userId, groupId);
+
+      const group = await db.$primary.query.mapGroups.findFirst({
+        columns: { id: true, name: true, syncedAt: true },
+        where: eq(mapGroups.id, groupId),
+      });
+      if (!group) {
+        return status(404);
+      }
+
+      const PAGE_SIZE = 100;
+
+      // keyset cursor over (created_at, id) desc, encoded "<createdAt>_<id>"
+      const MAX_INT = 2147483647;
+      let cursor: { createdAt: number; id: number } | null = null;
+      if (query.before) {
+        const parts = query.before.split('_').map(Number);
+        if (
+          parts.length !== 2 ||
+          !Number.isSafeInteger(parts[0]) ||
+          parts[0] < 0 ||
+          parts[0] > MAX_INT ||
+          !Number.isSafeInteger(parts[1]) ||
+          parts[1] < 0
+        ) {
+          return status(400, { message: 'Invalid cursor' });
+        }
+        cursor = { createdAt: parts[0], id: parts[1] };
+      }
+
+      // synced/unsynced boundary: synced_at, or (when a settings change has
+      // reset it to null) the latest sync marker so pending edits still show
+      // as unsynced instead of being dumped into history
+      let boundary = group.syncedAt;
+      if (boundary === null) {
+        const latestMarker = await db.$primary.query.mapGroupChanges.findFirst({
+          where: and(
+            eq(mapGroupChanges.mapGroupId, groupId),
+            eq(mapGroupChanges.entityType, 'sync'),
+          ),
+          orderBy: [desc(mapGroupChanges.createdAt), desc(mapGroupChanges.id)],
+          columns: { createdAt: true },
+        });
+        boundary = latestMarker?.createdAt ?? null;
+      }
+
+      const pageConditions = [eq(mapGroupChanges.mapGroupId, groupId)];
+      if (cursor) {
+        pageConditions.push(
+          sql`(${mapGroupChanges.createdAt}, ${mapGroupChanges.id}) < (${cursor.createdAt}, ${cursor.id})`,
+        );
+      } else if (boundary !== null) {
+        pageConditions.push(lte(mapGroupChanges.createdAt, boundary));
+      } else {
+        // no boundary at all (never synced, no markers): there is no synced
+        // history - everything belongs to the unsynced list
+        pageConditions.push(sql`false`);
+      }
+      const page = await db.$primary.query.mapGroupChanges.findMany({
+        where: and(...pageConditions),
+        orderBy: [desc(mapGroupChanges.createdAt), desc(mapGroupChanges.id)],
+        limit: PAGE_SIZE + 1,
+        with: { user: { columns: { username: true } } },
+      });
+      const hasMore = page.length > PAGE_SIZE;
+
+      // the first page always carries every unsynced entry on top of the
+      // paginated synced history
+      let unsyncedChanges: typeof page = [];
+      if (!cursor) {
+        const unsyncedConditions = [eq(mapGroupChanges.mapGroupId, groupId)];
+        if (boundary !== null) {
+          unsyncedConditions.push(gt(mapGroupChanges.createdAt, boundary));
+        }
+        unsyncedChanges = await db.$primary.query.mapGroupChanges.findMany({
+          where: and(...unsyncedConditions),
+          orderBy: [desc(mapGroupChanges.createdAt), desc(mapGroupChanges.id)],
+          limit: 500,
+          with: { user: { columns: { username: true } } },
+        });
+      }
+
+      return {
+        group,
+        role,
+        unsyncedChanges,
+        changes: page.slice(0, PAGE_SIZE),
+        hasMore,
+      };
+    },
+    {
+      params: t.Object({ id: t.Integer() }),
+      query: t.Object({ before: t.Optional(t.String()) }),
+      userId: true,
+    },
+  )
+  .get(
     '/:id/settings-page',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      const role = await ensurePermissions(userId, groupId);
 
       const group = await db.$primary.query.mapGroups.findFirst({
         extras: {
@@ -317,7 +475,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         return status(404);
       }
 
-      return { group };
+      return { group, role };
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -327,7 +485,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .delete(
     '/:id',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
       await db.delete(mapGroups).where(eq(mapGroups.id, groupId));
       return status(200);
     },
@@ -339,7 +497,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .post(
     '/:id/permissions',
     async ({ params: { id: groupId }, body, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
 
       const username = body.username.startsWith('@')
         ? body.username.slice(1)
@@ -347,7 +505,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
 
       const user = (
         await db.$primary
-          .select({ id: users.id })
+          .select({ id: users.id, username: users.username })
           .from(users)
           .where(eq(users.username, username))
       )[0];
@@ -375,44 +533,108 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         });
       }
 
-      await db
-        .insert(mapGroupPermissions)
-        .values({ mapGroupId: groupId, userId: user.id });
+      // role is optional so a not-yet-updated frontend can still share groups
+      // during a rolling deploy
+      const role = body.role ?? 'editor';
+      await db.$primary.insert(mapGroupPermissions).values({
+        mapGroupId: groupId,
+        userId: user.id,
+        role,
+      });
       return status(200);
     },
     {
       params: t.Object({ id: t.Integer() }),
-      body: t.Object({ username: t.String({ minLength: 1 }) }),
+      body: t.Object({
+        username: t.String({ minLength: 1 }),
+        role: t.Optional(t.Union([t.Literal('owner'), t.Literal('editor')])),
+      }),
+      userId: true,
+    },
+  )
+  .patch(
+    '/:id/permissions/:permissionId',
+    async ({ params: { id: groupId, permissionId }, body, userId, status }) => {
+      await ensureOwner(userId, groupId);
+
+      // the whole check-and-mutate runs in one transaction with the group's
+      // permission rows locked, so concurrent demotions can't race past the
+      // last-owner guard
+      const failure = await db.$primary.transaction(async (tx) => {
+        const permissions = await tx
+          .select()
+          .from(mapGroupPermissions)
+          .where(eq(mapGroupPermissions.mapGroupId, groupId))
+          .for('update');
+        const permission = permissions.find((p) => p.id === permissionId);
+        if (!permission) {
+          return 'Permission not found';
+        }
+        if (permission.userId === userId) {
+          return "Can't change your own role";
+        }
+        if (
+          permission.role === 'owner' &&
+          body.role === 'editor' &&
+          !permissions.some((p) => p.role === 'owner' && p.id !== permissionId)
+        ) {
+          return 'A group must keep at least one owner';
+        }
+
+        await tx
+          .update(mapGroupPermissions)
+          .set({ role: body.role })
+          .where(eq(mapGroupPermissions.id, permissionId));
+        return null;
+      });
+      if (failure) {
+        return status(400, { field: 'permissionId', message: failure });
+      }
+      return status(200);
+    },
+    {
+      params: t.Object({ id: t.Integer(), permissionId: t.Integer() }),
+      body: t.Object({
+        role: t.Union([t.Literal('owner'), t.Literal('editor')]),
+      }),
       userId: true,
     },
   )
   .delete(
     '/:id/permissions/:permissionId',
     async ({ params: { id: groupId, permissionId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
 
-      const permission = await db.$primary.query.mapGroupPermissions.findFirst({
-        where: and(
-          eq(mapGroupPermissions.id, permissionId),
-          eq(mapGroupPermissions.mapGroupId, groupId),
-        ),
+      // see PATCH above: locked check-and-mutate to prevent the last-owner
+      // guard from racing
+      const failure = await db.$primary.transaction(async (tx) => {
+        const permissions = await tx
+          .select()
+          .from(mapGroupPermissions)
+          .where(eq(mapGroupPermissions.mapGroupId, groupId))
+          .for('update');
+        const permission = permissions.find((p) => p.id === permissionId);
+        if (!permission) {
+          return 'Permission not found';
+        }
+        if (permission.userId === userId) {
+          return "Can't strip your own permissions";
+        }
+        if (
+          permission.role === 'owner' &&
+          !permissions.some((p) => p.role === 'owner' && p.id !== permissionId)
+        ) {
+          return 'A group must keep at least one owner';
+        }
+
+        await tx
+          .delete(mapGroupPermissions)
+          .where(eq(mapGroupPermissions.id, permissionId));
+        return null;
       });
-      if (!permission) {
-        return status(400, {
-          field: 'permissionId',
-          message: 'Permission not found',
-        });
+      if (failure) {
+        return status(400, { field: 'permissionId', message: failure });
       }
-      if (permission.userId === userId) {
-        return status(400, {
-          field: 'permissionId',
-          message: "Can't strip your own permissions",
-        });
-      }
-
-      await db
-        .delete(mapGroupPermissions)
-        .where(eq(mapGroupPermissions.id, permissionId));
       return status(200);
     },
     {
@@ -423,7 +645,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .get(
     '/:id',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      const role = await ensurePermissions(userId, groupId);
 
       const group = await db.$primary.query.mapGroups.findFirst({
         where: eq(mapGroups.id, groupId),
@@ -433,7 +655,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         return status(404);
       }
 
-      return group;
+      return { ...group, role };
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -443,16 +665,30 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .patch(
     '/:id',
     async ({ params: { id: groupId }, body, userId, status }) => {
-      await ensurePermissions(userId, groupId);
-      const updated = await db
-        .update(mapGroups)
-        .set({ name: body.name })
-        .where(eq(mapGroups.id, groupId))
-        .returning({ id: mapGroups.id });
-      if (updated.length) {
-        return status(200);
+      await ensureOwner(userId, groupId);
+      const oldGroup = await db.$primary.query.mapGroups.findFirst({
+        where: eq(mapGroups.id, groupId),
+      });
+      if (!oldGroup) {
+        return status(404);
       }
-      return status(404);
+      await db.$primary.transaction(async (tx) => {
+        await tx
+          .update(mapGroups)
+          .set({ name: body.name })
+          .where(eq(mapGroups.id, groupId));
+        await logChange(tx, {
+          mapGroupId: groupId,
+          userId,
+          entityType: 'group',
+          entityId: groupId,
+          entityLabel: body.name,
+          operation: 'update',
+          oldValue: { name: oldGroup.name },
+          newValue: { name: body.name },
+        });
+      });
+      return status(200);
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -463,28 +699,74 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .post(
     '/:id/locations/upload',
     async ({ params: { id: groupId }, body, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      const role = await ensurePermissions(userId, groupId);
+
+      if (role === 'editor') {
+        if (!body.scopeTag) {
+          return status(403, {
+            message: 'Editors can only upload locations for a specific meta',
+          });
+        }
+        if (body.uploadMode === 'full') {
+          return status(403, {
+            message: 'Editors cannot replace all locations in a group',
+          });
+        }
+      }
+      if (body.scopeTag && body.uploadMode === 'full') {
+        return status(400, {
+          message:
+            'Full replacement cannot be combined with a scoped upload - it would delete all other metas locations',
+        });
+      }
+
+      let locations = body.locations;
+      let ignoredCount = 0;
+      let scopedMetaId: number | null = null;
+      if (body.scopeTag) {
+        const scopedMeta = await db.$primary.query.metas.findFirst({
+          where: and(
+            eq(metas.mapGroupId, groupId),
+            eq(metas.tagName, body.scopeTag),
+          ),
+        });
+        if (!scopedMeta) {
+          return status(400, {
+            message: `There is no meta with tag "${body.scopeTag}" in this group`,
+          });
+        }
+
+        locations = body.locations.filter(
+          (location) => location.extraTag === body.scopeTag,
+        );
+        ignoredCount = body.locations.length - locations.length;
+        if (locations.length === 0) {
+          return status(400, {
+            message: `The uploaded file contains no locations with tag "${body.scopeTag}"`,
+          });
+        }
+        scopedMetaId = scopedMeta.id;
+      }
 
       const currentTimestamp = Math.floor(Date.now() / 1000);
-      const upsertValues = body.locations.map((location) => ({
+      const upsertValues = locations.map((location) => ({
         ...location,
         extraPanoDate: location.extraPanoDate ?? null,
         mapGroupId: groupId,
         updatedAt: currentTimestamp,
         modifiedAt: currentTimestamp, // default value - not being set on conflict
       }));
-      const usedTags = new Set(
-        body.locations.map((location) => location.extraTag),
-      );
+      const usedTags = new Set(locations.map((location) => location.extraTag));
 
       const BATCH_SIZE = 1000;
+      let affectedCount = 0;
       try {
         await db.$primary.transaction(async (trx) => {
           // Step 1: Batched upsert operation
           for (let i = 0; i < upsertValues.length; i += BATCH_SIZE) {
             const batch = upsertValues.slice(i, i + BATCH_SIZE);
 
-            await trx
+            const affected = await trx
               .insert(mapGroupLocations)
               .values(batch)
               .onConflictDoUpdate({
@@ -502,14 +784,21 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
                   extraPanoDate: sql`excluded.extra_pano_date`,
                   updatedAt: sql`excluded.updated_at`,
                 },
+                // scoped uploads must not steal panos already belonging to
+                // another meta's tag in this group
+                ...(body.scopeTag && {
+                  setWhere: eq(mapGroupLocations.extraTag, body.scopeTag),
+                }),
               })
               .returning({ id: mapGroupLocations.id });
+            affectedCount += affected.length;
           }
 
           // Step 2: Delete records based on upload mode
+          let deletedCount = 0;
           if (body.uploadMode === 'full') {
             // Full replacement: delete all locations not in current upload
-            await trx
+            const deleted = await trx
               .delete(mapGroupLocations)
               .where(
                 and(
@@ -519,10 +808,12 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
                     lt(mapGroupLocations.updatedAt, currentTimestamp),
                   ),
                 ),
-              );
+              )
+              .returning({ id: mapGroupLocations.id });
+            deletedCount = deleted.length;
           } else if (body.uploadMode === 'tagReplace') {
             // Tag-based replacement: delete only locations with tags present in upload
-            await trx
+            const deleted = await trx
               .delete(mapGroupLocations)
               .where(
                 and(
@@ -533,12 +824,32 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
                     lt(mapGroupLocations.updatedAt, currentTimestamp),
                   ),
                 ),
-              );
+              )
+              .returning({ id: mapGroupLocations.id });
+            deletedCount = deleted.length;
           }
           // For 'partial' mode: no deletions, just upserts
 
+          await logChange(trx, {
+            mapGroupId: groupId,
+            userId,
+            entityType: 'location_batch',
+            entityId: scopedMetaId,
+            entityLabel: body.scopeTag ?? `${usedTags.size} tags`,
+            operation: 'update',
+            newValue: {
+              uploadMode: body.uploadMode,
+              count: affectedCount,
+              deletedCount,
+              ignoredCount,
+              conflictCount: upsertValues.length - affectedCount,
+              tags: Array.from(usedTags).slice(0, 100),
+            },
+          });
+
           // Step 3: Insert tags into metas table
-          if (usedTags.size > 0) {
+          // (skipped for scoped uploads - the target meta is validated to exist)
+          if (!body.scopeTag && usedTags.size > 0) {
             const metaInsertValues = Array.from(usedTags).map((tagName) => ({
               mapGroupId: groupId,
               tagName: tagName,
@@ -546,10 +857,26 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
               note: '',
               modifiedAt: currentTimestamp,
             }));
-            await trx
+            const createdMetas = await trx
               .insert(metas)
               .values(metaInsertValues)
-              .onConflictDoNothing();
+              .onConflictDoNothing()
+              .returning({ id: metas.id, tagName: metas.tagName });
+            await logChange(
+              trx,
+              createdMetas.map((meta) => ({
+                mapGroupId: groupId,
+                userId,
+                entityType: 'meta' as const,
+                entityId: meta.id,
+                entityLabel: meta.tagName,
+                operation: 'create' as const,
+                newValue: {
+                  tagName: meta.tagName,
+                  createdByLocationUpload: true,
+                },
+              })),
+            );
           }
         });
       } catch (error) {
@@ -564,7 +891,11 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         throw error;
       }
 
-      return { count: upsertValues.length };
+      return {
+        count: affectedCount,
+        ignoredCount,
+        conflictCount: upsertValues.length - affectedCount,
+      };
     },
     {
       params: t.Object({ id: t.Integer() }),
@@ -574,6 +905,7 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
           t.Literal('full'),
           t.Literal('tagReplace'),
         ]),
+        scopeTag: t.Optional(t.String({ minLength: 1 })),
         locations: t.Array(
           t.Object({
             lat: t.Number(),
@@ -594,11 +926,12 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .post(
     '/:id/metas/upload',
     async ({ params: { id: groupId }, body, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
 
       try {
         await uploadMetas(
           groupId,
+          userId,
           body.metas,
           body.partialUpload,
           body.autoCreateLevels,
@@ -634,14 +967,25 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .post(
     '/:id/sync',
     async ({ params: { id: groupId }, userId, status }) => {
-      await ensurePermissions(userId, groupId);
+      await ensureOwner(userId, groupId);
       const group = await db.$primary.query.mapGroups.findFirst({
         where: eq(mapGroups.id, groupId),
       });
       if (!group) {
         return status(404);
       }
-      await syncMapGroup(group);
+      const syncedAt = await syncMapGroup(group);
+      // stamped with the sync's own timestamp so the marker sits exactly on
+      // the synced/unsynced boundary instead of classifying itself unsynced
+      await logChange(db.$primary, {
+        mapGroupId: groupId,
+        userId,
+        entityType: 'sync',
+        entityId: groupId,
+        entityLabel: 'changes published',
+        operation: 'update',
+        createdAt: syncedAt,
+      });
       return;
     },
     {
@@ -811,17 +1155,43 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
   .post(
     '/:id/settings',
     async ({ params: { id: groupId }, body, userId, status }) => {
-      await ensurePermissions(userId, groupId);
-      const updated = await db
-        .update(mapGroups)
-        // need to reset syncedAt
-        .set({ ...body, syncedAt: null })
-        .where(eq(mapGroups.id, groupId))
-        .returning({ id: mapGroups.id });
-      if (updated.length) {
+      await ensureOwner(userId, groupId);
+      const oldGroup = await db.$primary.query.mapGroups.findFirst({
+        where: eq(mapGroups.id, groupId),
+      });
+      if (!oldGroup) {
+        return status(404);
+      }
+      // a no-op save must not invalidate the group's sync state
+      if (
+        oldGroup.syncIncludeLocationsNotOnStreetView ===
+        body.syncIncludeLocationsNotOnStreetView
+      ) {
         return status(200);
       }
-      return status(404);
+      await db.$primary.transaction(async (tx) => {
+        await tx
+          .update(mapGroups)
+          // need to reset syncedAt
+          .set({ ...body, syncedAt: null })
+          .where(eq(mapGroups.id, groupId));
+        await logChange(tx, {
+          mapGroupId: groupId,
+          userId,
+          entityType: 'settings',
+          entityId: groupId,
+          operation: 'update',
+          oldValue: {
+            syncIncludeLocationsNotOnStreetView:
+              oldGroup.syncIncludeLocationsNotOnStreetView,
+          },
+          newValue: {
+            syncIncludeLocationsNotOnStreetView:
+              body.syncIncludeLocationsNotOnStreetView,
+          },
+        });
+      });
+      return status(200);
     },
     {
       params: t.Object({ id: t.Number() }),

--- a/apps/api/src/routes/internal/maps/group.ts
+++ b/apps/api/src/routes/internal/maps/group.ts
@@ -1,4 +1,5 @@
 import {
+  levels,
   mapFilters,
   mapLevels,
   mapLocations,
@@ -8,7 +9,8 @@ import {
 } from '@api/lib/db/schema';
 import { db } from '@api/lib/drizzle';
 import { auth } from '@api/lib/internal/auth';
-import { ensurePermissions } from '@api/lib/internal/permissions';
+import { logChange } from '@api/lib/internal/changes';
+import { ensureOwner, ensurePermissions } from '@api/lib/internal/permissions';
 import {
   geoguessrMapJson,
   isPopularMap,
@@ -24,7 +26,7 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
   .put(
     '/',
     async ({ body, userId, status }) => {
-      await ensurePermissions(userId, body.mapGroupId);
+      await ensureOwner(userId, body.mapGroupId);
 
       const {
         id,
@@ -46,17 +48,89 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
         return status(500);
       }
 
+      const [groupLevels, allRegions] = await Promise.all([
+        db.$primary.query.levels.findMany({
+          where: eq(levels.mapGroupId, dataNoId.mapGroupId),
+          columns: { id: true, name: true },
+        }),
+        db.$primary.query.regions.findMany({
+          columns: { id: true, name: true },
+        }),
+      ]);
+      const levelNameById = new Map(
+        groupLevels.map((level) => [level.id, level.name]),
+      );
+      const levelNames = (ids: number[]) =>
+        ids
+          .map((levelId) => levelNameById.get(levelId) ?? `#${levelId}`)
+          .sort();
+      const regionNameById = new Map(
+        allRegions.map((region) => [region.id, region.name]),
+      );
+      const regionNames = (ids: number[]) =>
+        ids
+          .map((regionId) => regionNameById.get(regionId) ?? `#${regionId}`)
+          .sort();
+
       let geoguessrIdChanged: boolean;
+      let savedData: typeof maps.$inferSelect | undefined;
+      let oldMapDetails: Record<string, unknown> | null = null;
       if (id) {
-        const savedData = await db.$primary.query.maps.findFirst({
+        savedData = await db.$primary.query.maps.findFirst({
           where: eq(maps.id, id),
         });
         if (!savedData || savedData.mapGroupId === null) {
           return status(404);
         }
         // also require permission on the map's current group, not just the target
-        await ensurePermissions(userId, savedData.mapGroupId);
+        await ensureOwner(userId, savedData.mapGroupId);
         geoguessrIdChanged = savedData.geoguessrId !== dataNoId.geoguessrId;
+
+        const [oldLevels, oldFilters, oldRegions] = await Promise.all([
+          db.$primary.query.mapLevels.findMany({
+            where: eq(mapLevels.mapId, id),
+          }),
+          db.$primary.query.mapFilters.findMany({
+            where: eq(mapFilters.mapId, id),
+          }),
+          db.$primary.query.mapRegions.findMany({
+            where: eq(mapRegions.mapId, id),
+          }),
+        ]);
+        if (savedData.mapGroupId !== dataNoId.mapGroupId) {
+          // the old level assignments belong to the source group
+          const sourceGroupLevels = await db.$primary.query.levels.findMany({
+            where: eq(levels.mapGroupId, savedData.mapGroupId),
+            columns: { id: true, name: true },
+          });
+          for (const level of sourceGroupLevels) {
+            levelNameById.set(level.id, level.name);
+          }
+        }
+        oldMapDetails = {
+          mapGroupId: savedData.mapGroupId,
+          name: savedData.name,
+          geoguessrId: savedData.geoguessrId,
+          description: savedData.description,
+          isPublished: savedData.isPublished,
+          isShared: savedData.isShared,
+          authors: savedData.authors,
+          footer: savedData.footer,
+          difficulty: savedData.difficulty,
+          ordering: savedData.ordering,
+          autoUpdate: savedData.autoUpdate,
+          isVerified: savedData.isVerified,
+          regions: regionNames(oldRegions.map((mr) => mr.regionId)),
+          levels: levelNames(oldLevels.map((ml) => ml.levelId)),
+          includeFilters: oldFilters
+            .filter((f) => !f.isExclude)
+            .map((f) => f.tagLike)
+            .sort(),
+          excludeFilters: oldFilters
+            .filter((f) => f.isExclude)
+            .map((f) => f.tagLike)
+            .sort(),
+        };
       } else {
         geoguessrIdChanged = true;
       }
@@ -163,6 +237,74 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
               ),
             );
 
+          // log what was actually persisted: role-gated fields fall back to
+          // the previous value (or the column default on create)
+          const newMapDetails = {
+            mapGroupId: dataNoId.mapGroupId,
+            name: dataNoId.name,
+            geoguessrId: dataNoId.geoguessrId,
+            description: dataNoId.description,
+            isPublished:
+              user.isSuperadmin || user.isTrusted
+                ? dataNoId.isPublished
+                : (savedData?.isPublished ?? false),
+            isShared: dataNoId.isShared,
+            authors: dataNoId.authors,
+            footer: dataNoId.footer,
+            difficulty: dataNoId.difficulty,
+            ordering: user.isSuperadmin
+              ? dataNoId.ordering
+              : (savedData?.ordering ?? 0),
+            autoUpdate: user.isSuperadmin
+              ? dataNoId.autoUpdate
+              : (savedData?.autoUpdate ?? false),
+            isVerified: user.isSuperadmin
+              ? dataNoId.isVerified
+              : (savedData?.isVerified ?? false),
+            regions: regionNames(regionIds),
+            levels: levelNames(levelIds),
+            includeFilters: [...includeFilters].sort(),
+            excludeFilters: [...excludeFilters].sort(),
+          };
+          if (savedData && savedData.mapGroupId !== dataNoId.mapGroupId) {
+            // moved between groups: log the departure and the arrival
+            await logChange(tx, [
+              {
+                mapGroupId: savedData.mapGroupId!,
+                userId,
+                entityType: 'map',
+                entityId: mapId,
+                entityLabel: savedData.name,
+                operation: 'delete',
+                oldValue: oldMapDetails,
+                newValue: { movedToGroupId: dataNoId.mapGroupId },
+              },
+              {
+                mapGroupId: dataNoId.mapGroupId,
+                userId,
+                entityType: 'map',
+                entityId: mapId,
+                entityLabel: dataNoId.name,
+                operation: 'create',
+                newValue: {
+                  ...newMapDetails,
+                  movedFromGroupId: savedData.mapGroupId,
+                },
+              },
+            ]);
+          } else {
+            await logChange(tx, {
+              mapGroupId: dataNoId.mapGroupId,
+              userId,
+              entityType: 'map',
+              entityId: mapId,
+              entityLabel: dataNoId.name,
+              operation: id === undefined ? 'create' : 'update',
+              oldValue: oldMapDetails,
+              newValue: newMapDetails,
+            });
+          }
+
           return mapId;
         });
         return { id: mapId };
@@ -208,9 +350,25 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
       if (!map || map.mapGroupId === null) {
         return status(404);
       }
-      await ensurePermissions(userId, map.mapGroupId);
+      await ensureOwner(userId, map.mapGroupId);
 
-      await db.delete(maps).where(eq(maps.id, mapId));
+      await db.$primary.transaction(async (tx) => {
+        await tx.delete(maps).where(eq(maps.id, mapId));
+        await logChange(tx, {
+          mapGroupId: map.mapGroupId!,
+          userId,
+          entityType: 'map',
+          entityId: mapId,
+          entityLabel: map.name,
+          operation: 'delete',
+          oldValue: {
+            name: map.name,
+            geoguessrId: map.geoguessrId,
+            description: map.description,
+            isPublished: map.isPublished,
+          },
+        });
+      });
       return status(200);
     },
     {

--- a/apps/api/src/routes/internal/metas.ts
+++ b/apps/api/src/routes/internal/metas.ts
@@ -9,6 +9,7 @@ import {
 } from '@api/lib/db/schema';
 import { db } from '@api/lib/drizzle';
 import { auth } from '@api/lib/internal/auth';
+import { logChange, metaSnapshot } from '@api/lib/internal/changes';
 import { ensurePermissions } from '@api/lib/internal/permissions';
 import { generateRandomString, isUniqueViolation } from '@api/lib/utils/common';
 import { markdown2Html } from '@api/lib/utils/markdown';
@@ -20,8 +21,8 @@ import sharp from 'sharp';
 type Tx = Parameters<Parameters<typeof db.$primary.transaction>[0]>[0];
 
 // Copies a meta (its images, its tag's locations, and optionally its level
-// assignments) into another group inside the given transaction. Returns true if
-// the meta was inserted, false if one with the same tag already existed there.
+// assignments) into another group inside the given transaction. Returns the new
+// meta id, or null if one with the same tag already existed there.
 // copyLevels is false for /copy and true for /share, preserving their behaviors.
 async function copyMetaToGroup(
   tx: Tx,
@@ -29,7 +30,7 @@ async function copyMetaToGroup(
   targetGroupId: number,
   currentTimestamp: number,
   copyLevels: boolean,
-): Promise<boolean> {
+): Promise<number | null> {
   const { id, mapGroupId, ...cleanedMeta } = meta;
 
   const insertResult = await tx
@@ -42,7 +43,7 @@ async function copyMetaToGroup(
     .onConflictDoNothing()
     .returning({ insertedId: metas.id });
   if (insertResult.length === 0) {
-    return false;
+    return null;
   }
   const newMetaId = insertResult[0].insertedId;
 
@@ -113,7 +114,7 @@ async function copyMetaToGroup(
     }
   }
 
-  return true;
+  return newMetaId;
 }
 
 class ImageNotFoundError extends Error {
@@ -174,6 +175,15 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
           .update(metas)
           .set({ modifiedAt: Math.floor(Date.now() / 1000) })
           .where(eq(metas.id, params.id));
+        await logChange(tx, {
+          mapGroupId: meta.mapGroupId,
+          userId,
+          entityType: 'meta_image',
+          entityId: meta.id,
+          entityLabel: meta.tagName,
+          operation: 'create',
+          newValue: { imageUrl },
+        });
       });
       return {
         imageUrl: imageUrl,
@@ -238,6 +248,15 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
           .update(metas)
           .set({ modifiedAt: Math.floor(Date.now() / 1000) })
           .where(eq(metas.id, params.id));
+        await logChange(tx, {
+          mapGroupId: meta.mapGroupId,
+          userId,
+          entityType: 'meta_image',
+          entityId: meta.id,
+          entityLabel: meta.tagName,
+          operation: 'update',
+          newValue: { reorderedImages: body.updates.length },
+        });
       });
 
       return status(200, { message: 'Image order updated successfully.' });
@@ -274,14 +293,44 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
       const footerHtml = await markdown2Html(dataNoId.footer);
       const currentTimestamp = Math.floor(Date.now() / 1000);
 
+      const groupLevels = await db.$primary.query.levels.findMany({
+        where: eq(levels.mapGroupId, body.mapGroupId),
+        columns: { id: true, name: true },
+      });
+      const levelNameById = new Map(
+        groupLevels.map((level) => [level.id, level.name]),
+      );
+      const levelNames = (ids: number[]) =>
+        ids
+          .map((levelId) => levelNameById.get(levelId) ?? `#${levelId}`)
+          .sort();
+
+      let savedData: Meta | undefined;
+      let savedLevelIds: number[] = [];
       if (id !== undefined) {
-        const savedData = await db.$primary.query.metas.findFirst({
+        savedData = await db.$primary.query.metas.findFirst({
           where: eq(metas.id, id),
         });
         if (!savedData) {
           return status(404);
         }
         await ensurePermissions(userId, savedData.mapGroupId);
+        savedLevelIds = (
+          await db.$primary
+            .select({ levelId: metaLevels.levelId })
+            .from(metaLevels)
+            .where(eq(metaLevels.metaId, id))
+        ).map((row) => row.levelId);
+        if (savedData.mapGroupId !== body.mapGroupId) {
+          // the old level assignments belong to the source group
+          const sourceGroupLevels = await db.$primary.query.levels.findMany({
+            where: eq(levels.mapGroupId, savedData.mapGroupId),
+            columns: { id: true, name: true },
+          });
+          for (const level of sourceGroupLevels) {
+            levelNameById.set(level.id, level.name);
+          }
+        }
       }
 
       try {
@@ -324,6 +373,54 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
               .insert(metaLevels)
               .values(levelIds.map((levelId) => ({ levelId, metaId })))
               .onConflictDoNothing();
+          }
+          const oldSnapshot = savedData
+            ? {
+                ...metaSnapshot(savedData),
+                levels: levelNames(savedLevelIds),
+              }
+            : null;
+          const newSnapshot = {
+            ...metaSnapshot(dataNoId),
+            levels: levelNames(levelIds),
+          };
+          if (savedData && savedData.mapGroupId !== body.mapGroupId) {
+            // moved between groups: log the departure and the arrival
+            await logChange(tx, [
+              {
+                mapGroupId: savedData.mapGroupId,
+                userId,
+                entityType: 'meta',
+                entityId: metaId,
+                entityLabel: savedData.tagName,
+                operation: 'delete',
+                oldValue: oldSnapshot,
+                newValue: { movedToGroupId: body.mapGroupId },
+              },
+              {
+                mapGroupId: body.mapGroupId,
+                userId,
+                entityType: 'meta',
+                entityId: metaId,
+                entityLabel: dataNoId.tagName,
+                operation: 'create',
+                newValue: {
+                  ...newSnapshot,
+                  movedFromGroupId: savedData.mapGroupId,
+                },
+              },
+            ]);
+          } else {
+            await logChange(tx, {
+              mapGroupId: body.mapGroupId,
+              userId,
+              entityType: 'meta',
+              entityId: metaId,
+              entityLabel: dataNoId.tagName,
+              operation: id === undefined ? 'create' : 'update',
+              oldValue: oldSnapshot,
+              newValue: newSnapshot,
+            });
           }
           return metaId;
         });
@@ -371,7 +468,21 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
       }
       await ensurePermissions(userId, mapGroupIds[0]);
 
-      await db.delete(metas).where(inArray(metas.id, body.ids));
+      await db.$primary.transaction(async (tx) => {
+        await tx.delete(metas).where(inArray(metas.id, body.ids));
+        await logChange(
+          tx,
+          metasToDelete.map((meta) => ({
+            mapGroupId: meta.mapGroupId,
+            userId,
+            entityType: 'meta' as const,
+            entityId: meta.id,
+            entityLabel: meta.tagName,
+            operation: 'delete' as const,
+            oldValue: metaSnapshot(meta),
+          })),
+        );
+      });
       return status(200);
     },
     {
@@ -443,7 +554,10 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
               .insert(metaLevels)
               .values(metaLevelInserts)
               .onConflictDoNothing()
-              .returning({ id: metaLevels.id })
+              .returning({
+                metaId: metaLevels.metaId,
+                levelId: metaLevels.levelId,
+              })
           : [];
         if (inserted.length === 0) {
           return 0;
@@ -456,6 +570,39 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
           .update(mapGroups)
           .set({ syncedAt: null })
           .where(inArray(mapGroups.id, uniqueMapGroupIds));
+        const insertedMetaIds = new Set(inserted.map((row) => row.metaId));
+        const insertedLevelIds = new Set(inserted.map((row) => row.levelId));
+        await logChange(
+          tx,
+          uniqueMapGroupIds.flatMap((mapGroupId) => {
+            const groupMetas = selectedMetas.filter(
+              (meta) =>
+                meta.mapGroupId === mapGroupId && insertedMetaIds.has(meta.id),
+            );
+            if (groupMetas.length === 0) {
+              return [];
+            }
+            return [
+              {
+                mapGroupId,
+                userId,
+                entityType: 'meta_levels' as const,
+                entityLabel: `${groupMetas.length} metas`,
+                operation: 'update' as const,
+                newValue: {
+                  metaTags: groupMetas.map((meta) => meta.tagName),
+                  levelNames: selectedLevels
+                    .filter(
+                      (level) =>
+                        level.mapGroupId === mapGroupId &&
+                        insertedLevelIds.has(level.id),
+                    )
+                    .map((level) => level.name),
+                },
+              },
+            ];
+          }),
+        );
         return inserted.length;
       });
 
@@ -508,11 +655,32 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
 
       for (const meta of metasToShare) {
         try {
-          const inserted = await db.$primary.transaction((tx) =>
-            copyMetaToGroup(tx, meta, targetGroupId, currentTimestamp, true),
-          );
+          const newMetaId = await db.$primary.transaction(async (tx) => {
+            const insertedId = await copyMetaToGroup(
+              tx,
+              meta,
+              targetGroupId,
+              currentTimestamp,
+              true,
+            );
+            if (insertedId !== null) {
+              await logChange(tx, {
+                mapGroupId: targetGroupId,
+                userId,
+                entityType: 'meta',
+                entityId: insertedId,
+                entityLabel: meta.tagName,
+                operation: 'create',
+                newValue: {
+                  ...metaSnapshot(meta),
+                  sharedFromGroupId: meta.mapGroupId,
+                },
+              });
+            }
+            return insertedId;
+          });
           // count only after the transaction commits, so a rollback isn't reported as success
-          if (inserted) {
+          if (newMetaId !== null) {
             successfulCopies.push(meta.id);
           }
         } catch (error) {
@@ -552,9 +720,29 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
       const currentTimestamp = Math.floor(Date.now() / 1000);
 
       // copyLevels is false here: /copy intentionally does not copy level assignments
-      await db.$primary.transaction((tx) =>
-        copyMetaToGroup(tx, meta, targetGroupId, currentTimestamp, false),
-      );
+      await db.$primary.transaction(async (tx) => {
+        const insertedId = await copyMetaToGroup(
+          tx,
+          meta,
+          targetGroupId,
+          currentTimestamp,
+          false,
+        );
+        if (insertedId !== null) {
+          await logChange(tx, {
+            mapGroupId: targetGroupId,
+            userId,
+            entityType: 'meta',
+            entityId: insertedId,
+            entityLabel: meta.tagName,
+            operation: 'create',
+            newValue: {
+              ...metaSnapshot(meta),
+              sharedFromGroupId: meta.mapGroupId,
+            },
+          });
+        }
+      });
       return status(200);
     },
     {
@@ -585,6 +773,15 @@ export const metasRouter = new Elysia({ prefix: '/metas' })
           .update(metas)
           .set({ modifiedAt: Math.floor(Date.now() / 1000) })
           .where(eq(metas.id, savedImage[0].metas.id));
+        await logChange(tx, {
+          mapGroupId: savedImage[0].metas.mapGroupId,
+          userId,
+          entityType: 'meta_image',
+          entityId: savedImage[0].metas.id,
+          entityLabel: savedImage[0].metas.tagName,
+          operation: 'delete',
+          oldValue: { imageUrl: savedImage[0].meta_images.image_url },
+        });
       });
 
       return { imageId };

--- a/apps/frontend/src/lib/components/DashNavBar.svelte
+++ b/apps/frontend/src/lib/components/DashNavBar.svelte
@@ -10,9 +10,10 @@
   interface Props {
     groupId: number;
     groupName: string;
+    canRename?: boolean;
   }
 
-  let { groupId, groupName }: Props = $props();
+  let { groupId, groupName, canRename = true }: Props = $props();
   let groupRenameDialogOpen = $state(false);
 
   const navItems = [
@@ -44,6 +45,11 @@
       tooltipText: 'View usage stats. (Temporarily unavailable - will be added back soon)'
     },
     {
+      name: 'Changes',
+      slug: 'changes',
+      tooltipText: 'A log of who changed what in this group: metas, locations, levels and maps.'
+    },
+    {
       name: 'Settings',
       slug: 'settings'
     }
@@ -53,12 +59,14 @@
 <div class="border-b border-gray-200 mb-4">
   <span class="text-sm font-semibold text-muted-foreground flex group">
     Group: {groupName || '<No name>'}
-    <button onclick={() => (groupRenameDialogOpen = true)} class=" items-center h-full"
-      ><Icon
-        icon="ic:baseline-edit"
-        class="hidden group-hover:block ml-1 mt-[2px]"
-        width="14"
-        height="14" /></button>
+    {#if canRename}
+      <button onclick={() => (groupRenameDialogOpen = true)} class=" items-center h-full"
+        ><Icon
+          icon="ic:baseline-edit"
+          class="hidden group-hover:block ml-1 mt-[2px]"
+          width="14"
+          height="14" /></button>
+    {/if}
   </span>
   <NavTabs basePath={`/map-making/groups/${groupId}`} items={navItems} />
 </div>

--- a/apps/frontend/src/lib/form-schema.ts
+++ b/apps/frontend/src/lib/form-schema.ts
@@ -35,7 +35,8 @@ export const mapUploadSchema = z.object({
     .refine((file) => file.type === 'application/json', {
       error: 'File must be a JSON file.'
     }),
-  uploadMode: z.enum(['partial', 'full', 'tagReplace']).prefault('partial')
+  uploadMode: z.enum(['partial', 'full', 'tagReplace']).prefault('partial'),
+  scopeTag: z.string().optional()
 });
 
 export const metasUploadContentSchema = z

--- a/apps/frontend/src/lib/utils/text-diff.ts
+++ b/apps/frontend/src/lib/utils/text-diff.ts
@@ -1,0 +1,92 @@
+export type DiffLine = { type: 'same' | 'add' | 'del'; text: string };
+
+// Above this many changed lines we skip the LCS (O(n*m) memory) and render a
+// plain replace-all diff.
+const MAX_LCS_LINES = 1500;
+
+// Simple LCS-based line diff, sufficient for meta notes (small texts).
+export function diffLines(oldText: string, newText: string): DiffLine[] {
+  if (oldText === newText) {
+    return oldText.split('\n').map((text) => ({ type: 'same' as const, text }));
+  }
+  if (oldText === '') {
+    return newText.split('\n').map((text) => ({ type: 'add' as const, text }));
+  }
+  if (newText === '') {
+    return oldText.split('\n').map((text) => ({ type: 'del' as const, text }));
+  }
+
+  const oldLines = oldText.split('\n');
+  const newLines = newText.split('\n');
+
+  // strip common prefix/suffix so the DP only covers the changed middle
+  let start = 0;
+  while (
+    start < oldLines.length &&
+    start < newLines.length &&
+    oldLines[start] === newLines[start]
+  ) {
+    start++;
+  }
+  let oldEnd = oldLines.length;
+  let newEnd = newLines.length;
+  while (oldEnd > start && newEnd > start && oldLines[oldEnd - 1] === newLines[newEnd - 1]) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  const prefix: DiffLine[] = oldLines
+    .slice(0, start)
+    .map((text) => ({ type: 'same' as const, text }));
+  const suffix: DiffLine[] = oldLines
+    .slice(oldEnd)
+    .map((text) => ({ type: 'same' as const, text }));
+  const oldMid = oldLines.slice(start, oldEnd);
+  const newMid = newLines.slice(start, newEnd);
+
+  if (oldMid.length > MAX_LCS_LINES || newMid.length > MAX_LCS_LINES) {
+    return [
+      ...prefix,
+      ...oldMid.map((text) => ({ type: 'del' as const, text })),
+      ...newMid.map((text) => ({ type: 'add' as const, text })),
+      ...suffix
+    ];
+  }
+
+  const n = oldMid.length;
+  const m = newMid.length;
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] =
+        oldMid[i] === newMid[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const middle: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (oldMid[i] === newMid[j]) {
+      middle.push({ type: 'same', text: oldMid[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      middle.push({ type: 'del', text: oldMid[i] });
+      i++;
+    } else {
+      middle.push({ type: 'add', text: newMid[j] });
+      j++;
+    }
+  }
+  while (i < n) {
+    middle.push({ type: 'del', text: oldMid[i] });
+    i++;
+  }
+  while (j < m) {
+    middle.push({ type: 'add', text: newMid[j] });
+    j++;
+  }
+
+  return [...prefix, ...middle, ...suffix];
+}

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.server.ts
@@ -40,6 +40,16 @@ const copyMetaSchema = z.object({
 
 export type CopyMetaSchema = typeof copyMetaSchema;
 
+// upload error messages are rendered with {@html} in the dialog, and some now
+// embed the user-supplied scopeTag - escape to keep that sink safe
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- data is validated by Zod schema immediately after this function
 function normalizeMapJsonFormat(jsonData: any) {
   if (Array.isArray(jsonData)) {
@@ -92,7 +102,7 @@ export const load = async ({ params, locals }) => {
   if (apiError || !data) {
     throwApiError(apiError, { 404: 'No group' });
   }
-  const { group, user } = data;
+  const { group, user, role } = data;
 
   const locationsNotOnStreetViewCount = api.internal['locations'].count
     .get({ query: { groupId: group.id, isOnStreetView: false } })
@@ -107,6 +117,7 @@ export const load = async ({ params, locals }) => {
 
   return {
     group,
+    role,
     locationsNotOnStreetViewCount,
     metaForm,
     mapUploadForm,
@@ -320,20 +331,33 @@ export const actions = {
 
     const { data, error: apiError } = await api.internal['map-groups']({
       id: groupId
-    }).locations.upload.post({ uploadMode: form.data.uploadMode, locations });
+    }).locations.upload.post({
+      uploadMode: form.data.uploadMode,
+      scopeTag: form.data.scopeTag || undefined,
+      locations
+    });
 
     if (apiError || !data) {
-      if ((apiError?.status as number) === 409) {
+      const status = apiError?.status as number;
+      const value = apiError?.value as { message?: string } | undefined;
+      if (status === 409) {
         return setError(
           form,
           'file',
           'The uploaded file contains duplicate panoId values. Please remove duplicates and try again.'
         );
       }
+      if ((status === 400 || status === 403) && value?.message) {
+        return setError(form, 'file', escapeHtml(value.message));
+      }
       throwApiError(apiError, { 500: 'Failed to upload locations' });
     }
 
-    return message(form, { numberOfLocations: data.count });
+    return message(form, {
+      numberOfLocations: data.count,
+      ignoredCount: data.ignoredCount,
+      conflictCount: data.conflictCount
+    });
   },
   uploadMetas: async ({ request, params }) => {
     const groupId = getGroupId(params);

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
@@ -50,11 +50,27 @@
   let selectedMeta = $derived(metas.find((meta) => meta.id == selectedMetaId) ?? null);
   let metaIds = $derived(metas.map((m) => m.id));
 
-  let numberOfLocationsUploaded = $state(0);
+  type UploadResult = { count: number; ignoredCount: number; conflictCount: number };
+  let uploadResult = $state<UploadResult | null>(null);
+  let isOwner = $derived(data.role === 'owner');
 
   $effect(() => {
-    if (numberOfLocationsUploaded != 0) {
-      toast.push(`Successfully uploaded ${numberOfLocationsUploaded} locations!`, {
+    if (!uploadResult) return;
+    const { count, ignoredCount, conflictCount } = uploadResult;
+    const suffixes = [
+      ignoredCount > 0 ? `${ignoredCount} locations with other tags were ignored` : '',
+      conflictCount > 0
+        ? `${conflictCount} locations were skipped because they already belong to another meta`
+        : ''
+    ].filter(Boolean);
+    const suffix = suffixes.length ? ` (${suffixes.join('; ')})` : '';
+    if (count === 0) {
+      toast.push(`No locations were uploaded${suffix}`, {
+        duration: 8000,
+        theme: { '--toastBackground': 'red', '--toastColor': 'white' }
+      });
+    } else {
+      toast.push(`Successfully uploaded ${count} locations!${suffix}`, {
         duration: 5000
       });
     }
@@ -147,7 +163,7 @@
 {/snippet}
 
 <div>
-  <DashNavBar groupId={data.group.id} groupName={data.group.name}></DashNavBar>
+  <DashNavBar groupId={data.group.id} groupName={data.group.name} canRename={isOwner}></DashNavBar>
   <div class="flex flex-wrap items-center">
     <div class="grow flex items-center justify-end">
       {#await data.locationsNotOnStreetViewCount then locationsNotOnStreetViewCount}
@@ -197,7 +213,15 @@
           };
         }}>
         {#if browser}
-          {#if data.group.hasUnsyncedData}
+          {#if !isOwner}
+            {#if data.group.hasUnsyncedData}
+              <Tooltip content="There are unsynced changes. Only group owners can sync them live.">
+                <Button variant="ghost" class="ml-3 opacity-50" type="button" disabled>
+                  Sync UserScript
+                </Button>
+              </Tooltip>
+            {/if}
+          {:else if data.group.hasUnsyncedData}
             <Tooltip
               content="People playing your map will only see changes after you synchronize the changes!">
               <Button
@@ -248,21 +272,23 @@
               </div>
             </DropdownMenu.Item>
 
-            <DropdownMenu.Item onclick={() => (isMetasUploadDialogOpen = true)}>
-              <div class="flex items-center gap-2">
-                <Icon
-                  icon="mi:document"
-                  width="1rem"
-                  height="1rem"
-                  class="text-gray-800 dark:text-gray-300" />
-                <Icon
-                  icon="material-symbols:upload-rounded"
-                  width="1rem"
-                  height="1rem"
-                  class="text-gray-800 dark:text-gray-300" />
-                <span>Upload metas</span>
-              </div>
-            </DropdownMenu.Item>
+            {#if isOwner}
+              <DropdownMenu.Item onclick={() => (isMetasUploadDialogOpen = true)}>
+                <div class="flex items-center gap-2">
+                  <Icon
+                    icon="mi:document"
+                    width="1rem"
+                    height="1rem"
+                    class="text-gray-800 dark:text-gray-300" />
+                  <Icon
+                    icon="material-symbols:upload-rounded"
+                    width="1rem"
+                    height="1rem"
+                    class="text-gray-800 dark:text-gray-300" />
+                  <span>Upload metas</span>
+                </div>
+              </DropdownMenu.Item>
+            {/if}
 
             <DropdownMenu.Item
               onclick={() =>
@@ -396,10 +422,16 @@
 
 <MapUploadDialog
   bind:isUploadDialogOpen={isMapUploadDialogOpen}
-  bind:numberOfLocationsUploaded
-  data={data.mapUploadForm} />
+  bind:uploadResult
+  data={data.mapUploadForm}
+  role={data.role}
+  metaTags={metas.map((meta) => meta.tagName)} />
 
-<MetasUploadDialog bind:isUploadDialogOpen={isMetasUploadDialogOpen} data={data.metasUploadForm} />
+{#if isOwner}
+  <MetasUploadDialog
+    bind:isUploadDialogOpen={isMetasUploadDialogOpen}
+    data={data.metasUploadForm} />
+{/if}
 
 <MassActionDialogs
   bind:isAddLevelsDialogOpen

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/MapUploadDialog.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/MapUploadDialog.svelte
@@ -6,30 +6,55 @@
   import { Input } from '$lib/components/ui/input';
   import * as Dialog from '$lib/components/ui/dialog/index';
   import * as Form from '$lib/components/ui/form';
+  import * as Command from '$lib/components/ui/command';
+  import { Popover, PopoverTrigger, PopoverContent } from '$lib/components/ui/popover';
   import { type MapUploadSchema } from '$lib/form-schema';
   import { Button } from '$lib/components/ui/button';
+  import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
+  import Check from '@lucide/svelte/icons/check';
   import UploadModeInfo from './UploadModeInfo.svelte';
   import { createPasteUpload } from './paste-upload.svelte';
 
   interface Props {
     isUploadDialogOpen: boolean;
-    numberOfLocationsUploaded: number;
+    uploadResult: { count: number; ignoredCount: number; conflictCount: number } | null;
     data: SuperValidated<Infer<MapUploadSchema>>;
+    role: 'owner' | 'editor';
+    metaTags: string[];
   }
   let {
     isUploadDialogOpen = $bindable(),
-    numberOfLocationsUploaded = $bindable(),
-    data
+    uploadResult = $bindable(),
+    data,
+    role,
+    metaTags
   }: Props = $props();
+  const isEditor = $derived(role === 'editor');
+  let scopeTagPopoverOpen = $state(false);
   // svelte-ignore state_referenced_locally
   const form = superForm(data, {
     onResult({ result }) {
       if (result.type == 'success') {
-        numberOfLocationsUploaded = result.data?.form.message.numberOfLocations || 0;
+        const message = result.data?.form.message;
+        // fresh object every time so the toast effect fires even for
+        // conflict-only or repeated outcomes
+        uploadResult = {
+          count: message?.numberOfLocations || 0,
+          ignoredCount: message?.ignoredCount || 0,
+          conflictCount: message?.conflictCount || 0
+        };
         isUploadDialogOpen = false;
       }
     },
     onSubmit({ formData, cancel }) {
+      if (isEditor && !formData.get('scopeTag')) {
+        errors.update((e) => ({
+          ...e,
+          scopeTag: ['Select the meta to upload for first']
+        }));
+        cancel();
+        return;
+      }
       if ((uploadMode === 'full' || uploadMode === 'tagReplace') && !confirmFullUpload()) {
         cancel();
         isUploadDialogOpen = false;
@@ -38,7 +63,7 @@
     }
   });
 
-  const { form: formData, enhance, submit, reset } = form;
+  const { form: formData, errors, enhance, submit, reset } = form;
   const uploadMode = $derived($formData.uploadMode);
   const file = fileProxy(form, 'file');
 
@@ -67,7 +92,12 @@
     <Dialog.Header>
       <Dialog.Title>Upload Locations</Dialog.Title>
       <Dialog.Description>
-        Upload map JSON from map-making.app to add or update locations in this group.
+        {#if isEditor}
+          Upload map JSON from map-making.app to add or update locations for a specific meta. Only
+          locations tagged with the selected meta will be taken from the file.
+        {:else}
+          Upload map JSON from map-making.app to add or update locations in this group.
+        {/if}
       </Dialog.Description>
     </Dialog.Header>
 
@@ -114,24 +144,82 @@
                     onclick={() => ($formData.uploadMode = 'tagReplace')}>
                     <RadioGroupItem value="tagReplace" />
                     <span class="text-sm font-normal">
-                      Tag-based replacement - Replace only locations with uploaded tags
+                      {#if isEditor}
+                        Replacement - Replace all locations of the selected meta
+                      {:else}
+                        Tag-based replacement - Replace only locations with uploaded tags
+                      {/if}
                     </span>
                   </button>
-                  <button
-                    type="button"
-                    class="flex items-center space-x-2 cursor-pointer text-left"
-                    onclick={() => ($formData.uploadMode = 'full')}>
-                    <RadioGroupItem value="full" />
-                    <span class="text-sm font-normal">
-                      Full replacement - Replace all locations in the group
-                    </span>
-                  </button>
+                  {#if !isEditor}
+                    <button
+                      type="button"
+                      class="flex items-center space-x-2 cursor-pointer text-left"
+                      onclick={() => ($formData.uploadMode = 'full')}>
+                      <RadioGroupItem value="full" />
+                      <span class="text-sm font-normal">
+                        Full replacement - Replace all locations in the group
+                      </span>
+                    </button>
+                  {/if}
                 </RadioGroup>
               </div>
             {/snippet}
           </Form.Control>
           <Form.FieldErrors />
         </Form.Field>
+        {#if isEditor}
+          <Form.Field {form} name="scopeTag">
+            <Form.Control>
+              {#snippet children({ props })}
+                <div class="space-y-2">
+                  <label for={props.id} class="text-sm font-medium">Meta</label>
+                  <input type="hidden" name="scopeTag" value={$formData.scopeTag ?? ''} />
+                  <Popover bind:open={scopeTagPopoverOpen}>
+                    <PopoverTrigger>
+                      {#snippet child({ props: triggerProps })}
+                        <Button
+                          {...props}
+                          {...triggerProps}
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={scopeTagPopoverOpen}
+                          class="w-full justify-between font-normal">
+                          {$formData.scopeTag || 'Select the meta to upload for'}
+                          <ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      {/snippet}
+                    </PopoverTrigger>
+                    <PopoverContent align="start" class="w-(--bits-popover-anchor-width) p-0">
+                      <Command.Root>
+                        <Command.Input placeholder="Search metas..." />
+                        <Command.List class="max-h-52">
+                          <Command.Empty>No meta found.</Command.Empty>
+                          {#each metaTags as tag (tag)}
+                            <Command.Item
+                              value={tag}
+                              onSelect={() => {
+                                $formData.scopeTag = tag;
+                                errors.update((e) => ({ ...e, scopeTag: undefined }));
+                                scopeTagPopoverOpen = false;
+                              }}>
+                              <Check
+                                class="mr-2 h-4 w-4 {$formData.scopeTag === tag
+                                  ? 'opacity-100'
+                                  : 'opacity-0'}" />
+                              {tag}
+                            </Command.Item>
+                          {/each}
+                        </Command.List>
+                      </Command.Root>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              {/snippet}
+            </Form.Control>
+            <Form.FieldErrors />
+          </Form.Field>
+        {/if}
         <Form.Field {form} name="file">
           <Form.Control>
             {#snippet children({ props })}
@@ -142,6 +230,7 @@
                   type="file"
                   accept="application/json"
                   name="file"
+                  disabled={isEditor && !$formData.scopeTag}
                   bind:files={$file}
                   onchange={() => submit()} />
               </div>

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/changes/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/changes/+page.server.ts
@@ -1,0 +1,22 @@
+import { getGroupId } from '../utils';
+import { api, throwApiError } from '$lib/api';
+
+export const load = async ({ params }) => {
+  const id = getGroupId(params);
+
+  const { data, error: apiError } = await api.internal['map-groups']({ id })['changes-page'].get({
+    query: {}
+  });
+
+  if (apiError || !data) {
+    throwApiError(apiError, { 404: 'No group' });
+  }
+
+  return {
+    group: data.group,
+    unsyncedChanges: data.unsyncedChanges,
+    changes: data.changes,
+    hasMore: data.hasMore,
+    role: data.role
+  };
+};

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/changes/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/changes/+page.svelte
@@ -1,0 +1,413 @@
+<script lang="ts">
+  import DashNavBar from '$lib/components/DashNavBar.svelte';
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
+  import Icon from '@iconify/svelte';
+  import { diffLines } from '$lib/utils/text-diff';
+  import { SvelteSet } from 'svelte/reactivity';
+
+  let { data } = $props();
+
+  type Change = (typeof data.changes)[number];
+  type JsonRecord = Record<string, unknown>;
+
+  const entityTypeLabels: Record<string, string> = {
+    meta: 'Meta',
+    meta_image: 'Image',
+    meta_levels: 'Level assignment',
+    location_batch: 'Locations',
+    level: 'Level',
+    map: 'Map',
+    group: 'Group',
+    settings: 'Settings',
+    sync: 'Sync'
+  };
+
+  const operationLabels: Record<string, string> = {
+    create: 'created',
+    update: 'edited',
+    delete: 'deleted'
+  };
+
+  const operationClasses: Record<string, string> = {
+    create: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    update: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    delete: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+  };
+
+  const expandedIds = new SvelteSet<number>();
+  const expandedSections = new SvelteSet<string>();
+
+  // svelte-ignore state_referenced_locally
+  let hasMore = $state(data.hasMore);
+  let olderChanges = $state<Change[]>([]);
+  let loadingMore = $state(false);
+  let loadError = $state(false);
+
+  let authorFilter = $state('all');
+
+  // the component is reused when navigating between groups - reset the
+  // pagination and UI state so one group's history can't leak into another's
+  // svelte-ignore state_referenced_locally
+  let loadedGroupId = $state(data.group.id);
+  $effect(() => {
+    if (data.group.id !== loadedGroupId) {
+      loadedGroupId = data.group.id;
+      olderChanges = [];
+      hasMore = data.hasMore;
+      loadError = false;
+      authorFilter = 'all';
+      expandedIds.clear();
+      expandedSections.clear();
+    }
+  });
+
+  let allSynced = $derived([...data.changes, ...olderChanges]);
+
+  // sync markers are section headers, not filterable entries - excluding them
+  // keeps sync-only users out of the author dropdown
+  let authors = $derived(
+    [
+      ...new Set(
+        [...data.unsyncedChanges, ...allSynced]
+          .filter((change) => change.entityType !== 'sync')
+          .map((change) => change.user.username)
+      )
+    ].sort((a, b) => a.localeCompare(b))
+  );
+
+  function matchesAuthor(change: Change) {
+    return authorFilter === 'all' || change.user.username === authorFilter;
+  }
+
+  let unsyncedFiltered = $derived(data.unsyncedChanges.filter(matchesAuthor));
+
+  type Section = { key: string; marker: Change | null; entries: Change[] };
+
+  // synced history split into sections, each headed by a sync marker; entries
+  // above the newest marker belong to the latest sync (markers only exist
+  // since the change log was introduced)
+  let sections = $derived.by(() => {
+    const out: Section[] = [];
+    let current: Section | null = null;
+    for (const change of allSynced) {
+      if (change.entityType === 'sync') {
+        current = { key: `s${change.id}`, marker: change, entries: [] };
+        out.push(current);
+        continue;
+      }
+      if (!current) {
+        current = { key: 'latest', marker: null, entries: [] };
+        out.push(current);
+      }
+      current.entries.push(change);
+    }
+    return out;
+  });
+
+  let visibleSections = $derived(
+    sections
+      .map((section) => ({ ...section, entries: section.entries.filter(matchesAuthor) }))
+      .filter((section) => section.entries.length > 0)
+  );
+
+  function toggle(id: number) {
+    if (expandedIds.has(id)) {
+      expandedIds.delete(id);
+    } else {
+      expandedIds.add(id);
+    }
+  }
+
+  function toggleSection(key: string) {
+    if (expandedSections.has(key)) {
+      expandedSections.delete(key);
+    } else {
+      expandedSections.add(key);
+    }
+  }
+
+  function asRecord(value: unknown): JsonRecord {
+    return value && typeof value === 'object' ? (value as JsonRecord) : {};
+  }
+
+  function changedFields(change: Change) {
+    const oldValue = asRecord(change.oldValue);
+    const newValue = asRecord(change.newValue);
+    const keys = new Set([...Object.keys(oldValue), ...Object.keys(newValue)]);
+    return [...keys]
+      .filter((key) => JSON.stringify(oldValue[key]) !== JSON.stringify(newValue[key]))
+      .map((key) => ({ key, oldVal: oldValue[key], newVal: newValue[key] }));
+  }
+
+  function hasDetails(change: Change) {
+    return change.oldValue !== null || change.newValue !== null;
+  }
+
+  function formatValue(value: unknown): string {
+    if (value === null || value === undefined || value === '') return '(empty)';
+    if (Array.isArray(value)) return value.length ? value.join(', ') : '(none)';
+    return String(value);
+  }
+
+  function isMultiline(oldVal: unknown, newVal: unknown): boolean {
+    const text = `${typeof oldVal === 'string' ? oldVal : ''}${typeof newVal === 'string' ? newVal : ''}`;
+    return text.includes('\n') || text.length > 120;
+  }
+
+  function formatDay(createdAt: number) {
+    return new Date(createdAt * 1000).toLocaleDateString(undefined, {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  function formatTime(createdAt: number) {
+    return new Date(createdAt * 1000).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+  function formatDayTime(createdAt: number) {
+    return new Date(createdAt * 1000).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+  function sectionTitle(section: Section) {
+    if (section.marker) {
+      return `Synced ${formatDayTime(section.marker.createdAt)} by ${section.marker.user.username}`;
+    }
+    if (data.group.syncedAt !== null) {
+      return `Synced ${formatDayTime(data.group.syncedAt)}`;
+    }
+    return 'Earlier changes';
+  }
+
+  function sectionAuthors(entries: Change[]) {
+    const names = [...new Set(entries.map((change) => change.user.username))];
+    return names.length > 3
+      ? `${names.slice(0, 3).join(', ')} +${names.length - 3}`
+      : names.join(', ');
+  }
+
+  function groupByDay(entries: Change[]) {
+    const groups: { day: string; changes: Change[] }[] = [];
+    for (const change of entries) {
+      const day = formatDay(change.createdAt);
+      const last = groups.at(-1);
+      if (last && last.day === day) {
+        last.changes.push(change);
+      } else {
+        groups.push({ day, changes: [change] });
+      }
+    }
+    return groups;
+  }
+
+  async function loadOlder() {
+    const last = allSynced.at(-1);
+    if (!last || loadingMore) return;
+    const requestGroupId = data.group.id;
+    loadingMore = true;
+    loadError = false;
+    try {
+      const response = await fetch(
+        `/map-making/groups/${requestGroupId}/changes/feed?before=${last.createdAt}_${last.id}`
+      );
+      if (!response.ok) throw new Error(`feed request failed: ${response.status}`);
+      const payload: { changes: Change[]; hasMore: boolean } = await response.json();
+      // the user may have navigated to another group's log mid-flight
+      if (requestGroupId !== data.group.id) return;
+      olderChanges = [...olderChanges, ...payload.changes];
+      hasMore = payload.hasMore;
+    } catch {
+      if (requestGroupId === data.group.id) {
+        loadError = true;
+      }
+    } finally {
+      loadingMore = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>{data.group.name || '<No name>'} - Changes</title>
+</svelte:head>
+
+{#snippet entryList(entries: Change[])}
+  {#each groupByDay(entries) as dayGroup (dayGroup.day)}
+    <h5 class="mt-3 mb-1 text-xs font-semibold text-muted-foreground">{dayGroup.day}</h5>
+    <div class="space-y-1">
+      {#each dayGroup.changes as change (change.id)}
+        <div class="rounded-md border">
+          <svelte:element
+            this={hasDetails(change) ? 'button' : 'div'}
+            type={hasDetails(change) ? 'button' : undefined}
+            role={hasDetails(change) ? 'button' : undefined}
+            aria-expanded={hasDetails(change) ? expandedIds.has(change.id) : undefined}
+            class="w-full flex items-center gap-2 px-3 py-2 text-left text-sm {hasDetails(change)
+              ? 'cursor-pointer hover:bg-muted/50'
+              : ''}"
+            onclick={hasDetails(change) ? () => toggle(change.id) : undefined}>
+            <span class="text-muted-foreground tabular-nums w-12 shrink-0"
+              >{formatTime(change.createdAt)}</span>
+            <span class="font-medium">{change.user.username}</span>
+            <span
+              class="rounded px-1.5 py-0.5 text-xs font-medium {operationClasses[
+                change.operation
+              ]}">
+              {operationLabels[change.operation]}
+            </span>
+            <Badge variant="outline">{entityTypeLabels[change.entityType]}</Badge>
+            {#if change.entityLabel}
+              <span class="truncate">{change.entityLabel}</span>
+            {/if}
+            <span class="grow"></span>
+            {#if hasDetails(change)}
+              <Icon
+                icon={expandedIds.has(change.id)
+                  ? 'material-symbols:expand-less'
+                  : 'material-symbols:expand-more'}
+                class="shrink-0 text-muted-foreground" />
+            {/if}
+          </svelte:element>
+
+          {#if expandedIds.has(change.id)}
+            <div class="border-t px-3 py-2 space-y-2 text-sm">
+              {#each changedFields(change) as field (field.key)}
+                <div>
+                  <p class="text-xs font-semibold text-muted-foreground uppercase">{field.key}</p>
+                  {#if isMultiline(field.oldVal, field.newVal)}
+                    <pre
+                      class="mt-1 overflow-x-auto rounded bg-muted p-2 text-xs whitespace-pre-wrap">{#each diffLines(typeof field.oldVal === 'string' ? field.oldVal : '', typeof field.newVal === 'string' ? field.newVal : '') as line, index (index)}<span
+                          class={line.type === 'add'
+                            ? 'block bg-green-100 dark:bg-green-900/40'
+                            : line.type === 'del'
+                              ? 'block bg-red-100 line-through dark:bg-red-900/40'
+                              : 'block'}>{line.text || ' '}</span
+                        >{/each}</pre>
+                  {:else}
+                    <p class="mt-0.5">
+                      {#if change.operation !== 'create'}
+                        <span class="text-red-700 dark:text-red-400 line-through"
+                          >{formatValue(field.oldVal)}</span>
+                        <span class="text-muted-foreground mx-1">→</span>
+                      {/if}
+                      <span class="text-green-700 dark:text-green-400"
+                        >{formatValue(field.newVal)}</span>
+                    </p>
+                  {/if}
+                </div>
+              {:else}
+                <p class="text-muted-foreground">No field-level details for this change.</p>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/each}
+{/snippet}
+
+<div>
+  <DashNavBar groupId={data.group.id} groupName={data.group.name} canRename={data.role === 'owner'}
+  ></DashNavBar>
+
+  <div class="flex flex-wrap items-end justify-between gap-2">
+    <div>
+      <h4 class="text-lg font-semibold">Change log</h4>
+      <p class="text-sm text-muted-foreground">Who changed what in this group.</p>
+    </div>
+    <select
+      bind:value={authorFilter}
+      aria-label="Filter by author"
+      class="border-input bg-background h-8 rounded-md border px-2 text-sm">
+      <option value="all">All authors</option>
+      {#each authors as author (author)}
+        <option value={author}>{author}</option>
+      {/each}
+    </select>
+  </div>
+
+  {#if data.unsyncedChanges.length === 0 && allSynced.length === 0}
+    <p class="mt-8 text-center text-muted-foreground">
+      No changes recorded yet. Edits made from now on will show up here.
+    </p>
+  {/if}
+
+  {#if unsyncedFiltered.length > 0}
+    <div class="mt-4 rounded-lg border-2 border-blue-200 dark:border-blue-900 p-3">
+      <div class="flex items-center gap-2">
+        <span class="h-2 w-2 rounded-full bg-blue-500 animate-pulse"></span>
+        <h5 class="font-semibold">
+          Unsynced changes
+          <span class="text-muted-foreground font-normal">({unsyncedFiltered.length})</span>
+        </h5>
+      </div>
+      <p class="text-xs text-muted-foreground">Not visible to players until the next sync.</p>
+      {@render entryList(unsyncedFiltered)}
+    </div>
+  {:else if authorFilter === 'all' && allSynced.length > 0 && data.group.syncedAt !== null}
+    <p class="mt-4 text-sm text-muted-foreground">No unsynced changes - everything is published.</p>
+  {:else if authorFilter === 'all' && allSynced.length > 0}
+    <p class="mt-4 text-sm text-muted-foreground">
+      Sync status unknown - the group needs a sync (e.g. after a settings change).
+    </p>
+  {/if}
+
+  <div class="mt-4 space-y-2">
+    {#each visibleSections as section (section.key)}
+      <div class="rounded-lg border">
+        <button
+          type="button"
+          aria-expanded={expandedSections.has(section.key)}
+          class="w-full flex items-center gap-2 px-3 py-2 text-left cursor-pointer hover:bg-muted/50"
+          onclick={() => toggleSection(section.key)}>
+          <Icon
+            icon={expandedSections.has(section.key)
+              ? 'material-symbols:expand-less'
+              : 'material-symbols:expand-more'}
+            class="shrink-0 text-muted-foreground" />
+          <span class="font-medium text-sm">{sectionTitle(section)}</span>
+          <span class="text-sm text-muted-foreground">
+            {section.entries.length} change{section.entries.length === 1 ? '' : 's'} by {sectionAuthors(
+              section.entries
+            )}
+          </span>
+        </button>
+        {#if expandedSections.has(section.key)}
+          <div class="border-t px-3 pb-3">
+            {@render entryList(section.entries)}
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  {#if (data.unsyncedChanges.length > 0 || allSynced.length > 0) && unsyncedFiltered.length === 0 && visibleSections.length === 0}
+    <p class="mt-6 text-center text-muted-foreground">
+      {authorFilter !== 'all'
+        ? `No changes by ${authorFilter} in the loaded history.`
+        : 'No content changes in the loaded history - only sync markers.'}
+    </p>
+  {/if}
+
+  {#if hasMore}
+    <div class="mt-4 flex flex-col items-center gap-1">
+      <Button variant="outline" onclick={loadOlder} disabled={loadingMore}>
+        {loadingMore ? 'Loading...' : 'Load older changes'}
+      </Button>
+      {#if loadError}
+        <p class="text-sm text-destructive">Failed to load older changes - try again.</p>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/changes/feed/+server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/changes/feed/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import { getGroupId } from '../../utils';
+import { api, throwApiError } from '$lib/api';
+
+// pagination endpoint for the change log's "load older" button
+export const GET = async ({ params, url }) => {
+  const id = getGroupId(params);
+  const before = url.searchParams.get('before') ?? undefined;
+
+  const { data, error: apiError } = await api.internal['map-groups']({ id })['changes-page'].get({
+    query: { before }
+  });
+
+  if (apiError || !data) {
+    throwApiError(apiError, { 404: 'No group' });
+  }
+
+  return json({ changes: data.changes, hasMore: data.hasMore });
+};

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/levels/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/levels/+page.server.ts
@@ -17,6 +17,7 @@ export const load = async ({ params }) => {
   const levelForm = await superValidate(zod4(insertLevelsSchema));
   return {
     group: data.group,
+    role: data.role,
     levelForm
   };
 };

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/levels/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/levels/+page.svelte
@@ -7,6 +7,8 @@
   import { columns } from './columns';
   import LevelEditDialog from '$routes/(admin)/map-making/groups/[id]/levels/LevelEditDialog.svelte';
 
+  let isOwner = $derived(data.role === 'owner');
+  let tableColumns = $derived(isOwner ? columns : columns.filter((c) => c.id !== 'actions'));
   let levels = $derived(data.group.levels);
 
   let selectedLevelId = $state(-1);
@@ -24,15 +26,17 @@
 </script>
 
 <div>
-  <DashNavBar groupId={data.group.id} groupName={data.group.name}></DashNavBar>
+  <DashNavBar groupId={data.group.id} groupName={data.group.name} canRename={isOwner}></DashNavBar>
   <div class="flex flex-wrap items-center">
     <div class="grow flex items-center justify-end">
-      <Button onclick={addLevel}>Add level</Button>
+      {#if isOwner}
+        <Button onclick={addLevel}>Add level</Button>
+      {/if}
     </div>
   </div>
   <div class="mt-5">
     <BaseTable
-      {columns}
+      columns={tableColumns}
       data={levels}
       bind:selectedId={selectedLevelId}
       bind:isDialogOpen={isLevelDialogOpen}
@@ -40,8 +44,10 @@
   </div>
 </div>
 
-<LevelEditDialog
-  bind:isLevelDialogOpen
-  levelForm={data.levelForm}
-  mapGroupId={data.group.id}
-  {selectedLevel} />
+{#if isOwner}
+  <LevelEditDialog
+    bind:isLevelDialogOpen
+    levelForm={data.levelForm}
+    mapGroupId={data.group.id}
+    {selectedLevel} />
+{/if}

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/maps/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/maps/+page.server.ts
@@ -20,6 +20,7 @@ export const load = async ({ params }) => {
 
   return {
     group: data.group,
+    role: data.role,
     levelList: data.levelList,
     regionList: data.regionList,
     mapForm,

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/maps/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/maps/+page.svelte
@@ -7,6 +7,8 @@
 
   let { data } = $props();
 
+  let isOwner = $derived(data.role === 'owner');
+  let tableColumns = $derived(isOwner ? columns : columns.filter((c) => c.id !== 'actions'));
   let isMapDialogOpen = $state(false);
   let selectedMapId = $state(-1);
   let maps = $derived(data.group.maps);
@@ -35,16 +37,18 @@
 </script>
 
 <div>
-  <DashNavBar groupId={data.group.id} groupName={data.group.name}></DashNavBar>
+  <DashNavBar groupId={data.group.id} groupName={data.group.name} canRename={isOwner}></DashNavBar>
 
   <div class="flex flex-wrap items-center">
     <div class="grow flex items-center justify-end">
-      <Button onclick={addMap}>Add map</Button>
+      {#if isOwner}
+        <Button onclick={addMap}>Add map</Button>
+      {/if}
     </div>
   </div>
   <div class="mt-5">
     <BaseTable
-      {columns}
+      columns={tableColumns}
       data={maps}
       bind:selectedId={selectedMapId}
       bind:isDialogOpen={isMapDialogOpen}
@@ -52,11 +56,13 @@
     </BaseTable>
   </div>
 </div>
-<MapEditDialog
-  bind:isMapDialogOpen
-  mapForm={data.mapForm}
-  {levelChoices}
-  {regionChoices}
-  groupId={data.group.id}
-  {selectedMap}
-  user={data.user} />
+{#if isOwner}
+  <MapEditDialog
+    bind:isMapDialogOpen
+    mapForm={data.mapForm}
+    {levelChoices}
+    {regionChoices}
+    groupId={data.group.id}
+    {selectedMap}
+    user={data.user} />
+{/if}

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/settings/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/settings/+page.server.ts
@@ -9,12 +9,18 @@ const permissionDeleteSchema = z.object({
   permissionId: z.coerce.number().int()
 });
 
+const permissionRoleSchema = z.object({
+  permissionId: z.coerce.number().int(),
+  role: z.enum(['owner', 'editor'])
+});
+
 const settingsSchema = z.object({
   syncIncludeLocationsNotOnStreetView: z.boolean()
 });
 
 const permissionCreateSchema = z.object({
-  username: z.string().transform((val) => (val.startsWith('@') ? val.slice(1) : val))
+  username: z.string().transform((val) => (val.startsWith('@') ? val.slice(1) : val)),
+  role: z.enum(['owner', 'editor']).default('editor')
 });
 
 export const load = async ({ params, locals }) => {
@@ -34,6 +40,7 @@ export const load = async ({ params, locals }) => {
   );
   return {
     group,
+    role: data.role,
     user: locals.user!,
     permissionCreateForm,
     settingsForm
@@ -97,7 +104,8 @@ export const actions = {
     }
 
     const { error: apiError } = await api.internal['map-groups']({ id: groupId }).permissions.post({
-      username: form.data.username
+      username: form.data.username,
+      role: form.data.role
     });
 
     if (apiError) {
@@ -107,6 +115,39 @@ export const actions = {
       }
       throwApiError(apiError, { 500: 'Failed to create permission' });
     }
+  },
+  updatePermissionRole: async ({ request, params }) => {
+    const groupId = getGroupId(params);
+    const formData = await request.formData();
+    const rawData = Object.fromEntries(formData);
+
+    const parsed = permissionRoleSchema.safeParse(rawData);
+    if (!parsed.success) {
+      const { fieldErrors } = parsed.error.flatten();
+      return fail(400, {
+        errors: fieldErrors,
+        formData: rawData
+      });
+    }
+
+    const { error: apiError } = await api.internal['map-groups']({ id: groupId })
+      .permissions({ permissionId: parsed.data.permissionId })
+      .patch({ role: parsed.data.role });
+
+    if (apiError) {
+      const value = apiError.value as { field?: string; message?: string } | undefined;
+      if ((apiError.status as number) === 400 && value?.message) {
+        return fail(400, {
+          errors: { permissionId: [value.message] },
+          formData: rawData
+        });
+      }
+      throwApiError(apiError, { 500: 'Failed to update role' });
+    }
+
+    return {
+      success: true
+    };
   },
   updateSettings: async ({ params, request }) => {
     const form = await superValidate(request, zod4(settingsSchema));

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/settings/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
+  import { invalidateAll } from '$app/navigation';
   import DashNavBar from '$lib/components/DashNavBar.svelte';
   import Icon from '@iconify/svelte';
   import { Button } from '$lib/components/ui/button';
@@ -18,6 +19,7 @@
   let deleteDialogOpen = $state(false);
   let inputText = $state('');
   let groupNameMatches = $derived(inputText == data.group.name);
+  let isOwner = $derived(data.role === 'owner');
 
   function pluralize(word: string, count: number): string {
     return count == 1 ? word : `${word}s`;
@@ -50,7 +52,7 @@
 </script>
 
 <div>
-  <DashNavBar groupId={data.group.id} groupName={data.group.name}></DashNavBar>
+  <DashNavBar groupId={data.group.id} groupName={data.group.name} canRename={isOwner}></DashNavBar>
 
   <h4 class="text-lg font-semibold">Sharing</h4>
   <p>A list of users with access to this group</p>
@@ -59,6 +61,7 @@
     <Table.Header>
       <Table.Row>
         <Table.Head class="w-[300px]">Discord Username</Table.Head>
+        <Table.Head class="w-[140px]">Role</Table.Head>
         <Table.Head>Access</Table.Head>
       </Table.Row>
     </Table.Header>
@@ -67,7 +70,57 @@
         <Table.Row>
           <Table.Cell class="font-medium">{permission.user.username}</Table.Cell>
           <Table.Cell>
-            {#if permission.user.id !== data.user.id}
+            {#if isOwner && permission.user.id !== data.user.id}
+              <form
+                action="?/updatePermissionRole"
+                method="post"
+                use:enhance={({ formElement }) => {
+                  return async ({ result, update }) => {
+                    if (result.type === 'failure') {
+                      const failureData = result.data as
+                        | { errors?: Record<string, string[]> }
+                        | undefined;
+                      toast.error(
+                        Object.values(failureData?.errors ?? {}).flat()[0] ??
+                          'Failed to update role'
+                      );
+                      // restore the select to the real role
+                      const select = formElement.querySelector('select');
+                      if (select) select.value = permission.role;
+                      await invalidateAll();
+                      return;
+                    }
+                    await update();
+                  };
+                }}>
+                <input type="hidden" name="permissionId" value={permission.id} />
+                <select
+                  name="role"
+                  value={permission.role}
+                  onchange={(e) => {
+                    const select = e.currentTarget;
+                    if (
+                      select.value === 'owner' &&
+                      !confirm(
+                        `Make ${permission.user.username} an owner? Owners can sync, manage members and delete the group.`
+                      )
+                    ) {
+                      select.value = permission.role;
+                      return;
+                    }
+                    select.form?.requestSubmit();
+                  }}
+                  class="border-input bg-background h-8 rounded-md border px-2 text-sm">
+                  <option value="owner">owner</option>
+                  <option value="editor">editor</option>
+                </select>
+              </form>
+            {:else}
+              <span class="text-sm text-muted-foreground">{permission.role}</span>
+            {/if}
+          </Table.Cell>
+          <Table.Cell>
+            {#if isOwner && permission.user.id !== data.user.id}
               <form
                 action="?/deletePermission"
                 method="post"
@@ -85,66 +138,78 @@
     </Table.Body>
   </Table.Root>
 
-  <form action="?/createPermission" class="space-y-1" method="post" use:permissionCreateEnhance>
-    <div class="space-y-2">
-      <Label for="username">Share</Label>
-      <Input
-        id="username"
-        type="text"
-        name="username"
-        placeholder="Discord username"
-        aria-invalid={$permissionCreateErrors.username ? 'true' : undefined}
-        bind:value={$permissionCreateForm.username}
-        class="w-[208px]"
-        {...$permissionCreateConstraints.username} />
-      <p class="text-sm text-muted-foreground mt-2">
-        User must be in our database (logged into the dashboard least once)
-      </p>
-      {#if $permissionCreateErrors.username}
-        <Alert variant="destructive">
-          <AlertDescription>{$permissionCreateErrors.username}</AlertDescription>
-        </Alert>
-      {/if}
-    </div>
-    <Button type="submit" variant="outline">Share</Button>
-  </form>
-
-  <h4 class="text-lg font-semibold mt-6">Settings</h4>
-  <p>Configure map group settings</p>
-
-  <form action="?/updateSettings" method="post" class="space-y-4 mt-2" use:settingsEnhance>
-    <div class="flex items-center space-x-2">
-      <Switch
-        id="syncIncludeLocationsNotOnStreetView"
-        name="syncIncludeLocationsNotOnStreetView"
-        bind:checked={$settingsForm.syncIncludeLocationsNotOnStreetView} />
-      <Label for="syncIncludeLocationsNotOnStreetView" class="cursor-pointer">
-        Include locations not on Street View
-      </Label>
-    </div>
-    <p class="text-sm text-muted-foreground">
-      When enabled, locations that are not available on Street View will be included when syncing
-      with GeoGuessr.
-    </p>
-    <Button type="submit" variant="outline">Save Settings</Button>
-  </form>
-
-  <h4 class="text-lg font-semibold mt-6">Danger Zone</h4>
-
-  <Card class="border-red-300 dark:border-red-800 border-2 w-full max-w-lg mt-2">
-    <CardContent class="p-4">
-      <div class="flex justify-between items-center py-3 space-x-4">
-        <div>
-          <p class="font-semibold">Delete this map group</p>
-          <p class="text-sm text-muted-foreground">
-            Once you delete a group, there is no going back.
-          </p>
-          <p class="text-sm text-muted-foreground">Please be certain.</p>
+  {#if isOwner}
+    <form action="?/createPermission" class="space-y-1" method="post" use:permissionCreateEnhance>
+      <div class="space-y-2">
+        <Label for="username">Share</Label>
+        <div class="flex items-center space-x-2">
+          <Input
+            id="username"
+            type="text"
+            name="username"
+            placeholder="Discord username"
+            aria-invalid={$permissionCreateErrors.username ? 'true' : undefined}
+            bind:value={$permissionCreateForm.username}
+            class="w-[208px]"
+            {...$permissionCreateConstraints.username} />
+          <select
+            name="role"
+            bind:value={$permissionCreateForm.role}
+            class="border-input bg-background h-9 rounded-md border px-2 text-sm">
+            <option value="editor">editor</option>
+            <option value="owner">owner</option>
+          </select>
         </div>
-        <Button variant="destructive" onclick={() => (deleteDialogOpen = true)}>Delete</Button>
+        <p class="text-sm text-muted-foreground mt-2">
+          User must be in our database (logged into the dashboard least once). Editors can edit
+          content but can't sync, manage members or delete the group.
+        </p>
+        {#if $permissionCreateErrors.username}
+          <Alert variant="destructive">
+            <AlertDescription>{$permissionCreateErrors.username}</AlertDescription>
+          </Alert>
+        {/if}
       </div>
-    </CardContent>
-  </Card>
+      <Button type="submit" variant="outline">Share</Button>
+    </form>
+
+    <h4 class="text-lg font-semibold mt-6">Settings</h4>
+    <p>Configure map group settings</p>
+
+    <form action="?/updateSettings" method="post" class="space-y-4 mt-2" use:settingsEnhance>
+      <div class="flex items-center space-x-2">
+        <Switch
+          id="syncIncludeLocationsNotOnStreetView"
+          name="syncIncludeLocationsNotOnStreetView"
+          bind:checked={$settingsForm.syncIncludeLocationsNotOnStreetView} />
+        <Label for="syncIncludeLocationsNotOnStreetView" class="cursor-pointer">
+          Include locations not on Street View
+        </Label>
+      </div>
+      <p class="text-sm text-muted-foreground">
+        When enabled, locations that are not available on Street View will be included when syncing
+        with GeoGuessr.
+      </p>
+      <Button type="submit" variant="outline">Save Settings</Button>
+    </form>
+
+    <h4 class="text-lg font-semibold mt-6">Danger Zone</h4>
+
+    <Card class="border-red-300 dark:border-red-800 border-2 w-full max-w-lg mt-2">
+      <CardContent class="p-4">
+        <div class="flex justify-between items-center py-3 space-x-4">
+          <div>
+            <p class="font-semibold">Delete this map group</p>
+            <p class="text-sm text-muted-foreground">
+              Once you delete a group, there is no going back.
+            </p>
+            <p class="text-sm text-muted-foreground">Please be certain.</p>
+          </div>
+          <Button variant="destructive" onclick={() => (deleteDialogOpen = true)}>Delete</Button>
+        </div>
+      </CardContent>
+    </Card>
+  {/if}
 </div>
 
 <Dialog bind:open={deleteDialogOpen}>

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/stats/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/stats/+page.svelte
@@ -79,7 +79,10 @@
 </svelte:head>
 
 <div>
-  <DashNavBar groupId={data.group.id} groupName={data.group.name}></DashNavBar>
+  <DashNavBar
+    groupId={data.group.id}
+    groupName={data.group.name}
+    canRename={data.group.role === 'owner'}></DashNavBar>
 
   <div class="flex items-center justify-between mb-4">
     <h1 class="text-2xl font-semibold">Meta Request Statistics</h1>


### PR DESCRIPTION
Lets group owners hand out edit access without handing over control: editors can work on metas and locations, but only an owner decides when that work goes live, and a change log shows exactly what changed since the last sync.

## Roles

`map_group_permissions` gains a `role` column (`owner` | `editor`). All existing rows become owners.

Owners keep everything they have today. Editors can:

- create, edit and delete metas, their images and their level assignments
- upload locations **for one meta at a time** (`scopeTag` required, no full-replacement mode)

Editors cannot delete or rename the group, change settings, manage members, edit levels or maps, bulk-upload metas, or sync. `ensureOwner` gates each of those server-side, and the UI hides the controls (including the delete item inside the levels and maps action dropdowns).

A scoped upload only touches locations already tagged with the selected meta - the pano upsert carries a `setWhere` so it can't quietly re-tag another meta's locations, and the response reports how many rows were ignored or skipped as conflicts.

A group always keeps at least one owner. The check and the mutation run inside one transaction with `SELECT ... FOR UPDATE` on the group's permission rows, so concurrent demotions can't race past the guard.

Discord bot publishing stays open to any group member - the Discord server's role restriction on `/publish` is the real approval gate, and the API check on the thread starter only verifies map ownership.

## Change log

New `map_group_changes` table recording who changed what, with before/after snapshots. It's written from every mutation path: meta edits, images, level assignment, location batches, bulk uploads, levels, maps, rename, settings and syncs. No-op saves are filtered out centrally, so clicking Save without editing anything logs nothing.

A new **Changes** tab shows unsynced work in a box on top, then collapsible sections split on each sync marker, newest first. Filters for author and sync status, day sub-headers, expandable line-level diffs, and cursor-paginated older history so a busy group doesn't load its whole past on first paint.

Volume is modest: location uploads log one summary row no matter how many locations they carry, and bulk meta uploads log one row per *changed* meta. Measured against a production-sized dataset, a row costs ~831 bytes including the index.

## Notes for review

- Migration `0035` is additive. `role` defaults to `'owner'` rather than `'editor'` on purpose: during a rolling deploy an old API pod inserting a permission row would otherwise create a group nobody owns.
- `role` is optional on the share endpoint for the same reason - a not-yet-updated frontend can still share groups mid-deploy.
- `syncMapGroup()` now returns its timestamp so the sync marker lands exactly on the boundary it represents, instead of a moment after it.
- Not included, deliberately: revert buttons on the change log, retention pruning of old rows, and the per-map public update log. The `old_value` data needed for reverts is already captured.
