### PR TITLE
test(api): expand backend coverage

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -3,3 +3,4 @@
 !/package.json
 !/bun.lock
 !/tsconfig.json
+**/*.test.ts

--- a/apps/api/src/lib/db/schema.db.test.ts
+++ b/apps/api/src/lib/db/schema.db.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import type { AnyPgTable } from 'drizzle-orm/pg-core';
 import { db } from '../drizzle';
-import { mapGroupLocations, mapGroups, maps, metas } from './schema';
+import {
+  levels,
+  mapData,
+  mapFilters,
+  mapGroupLocations,
+  mapGroups,
+  mapLevels,
+  mapLocations,
+  mapRegions,
+  maps,
+  metaImages,
+  metaLevels,
+  metas,
+  regions,
+  syncedLocations,
+  syncedMapMetas,
+  syncedMetas,
+} from './schema';
 
 function rejectsWith(operation: () => Promise<unknown>, constraint: string) {
   return operation()
@@ -15,6 +34,10 @@ function rejectsWith(operation: () => Promise<unknown>, constraint: string) {
         expect.objectContaining({ constraint_name: constraint }),
       );
     });
+}
+
+async function countRows(table: AnyPgTable) {
+  return (await db.select().from(table)).length;
 }
 
 describe('map group assignment invariant', () => {
@@ -130,5 +153,316 @@ describe('unique location constraints', () => {
     await rejectsWith(async () => {
       await db.insert(metas).values(meta).returning();
     }, 'metas_unique');
+  });
+});
+
+describe('group deletion cascade', () => {
+  test('deleting a group removes its maps, metas, locations, levels, and synced relations', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Cascade group' })
+      .returning({ id: mapGroups.id });
+    const groupId = group!.id;
+
+    const [level] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level' })
+      .returning({ id: levels.id });
+    const levelId = level!.id;
+
+    const [map] = await db
+      .insert(maps)
+      .values({
+        name: 'Group map',
+        geoguessrId: 'cascade-map',
+        isPersonal: false,
+        mapGroupId: groupId,
+      })
+      .returning({ id: maps.id });
+    const mapId = map!.id;
+
+    const [meta] = await db
+      .insert(metas)
+      .values({
+        mapGroupId: groupId,
+        tagName: 'cascade-tag',
+        name: 'Cascade meta',
+        note: 'note',
+      })
+      .returning({ id: metas.id });
+    const metaId = meta!.id;
+
+    // Unrelated row that must survive the group deletion.
+    const [region] = await db
+      .insert(regions)
+      .values({ name: 'Unrelated region' })
+      .returning({ id: regions.id });
+
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: groupId,
+      lat: 1,
+      lng: 2,
+      heading: 3,
+      pitch: 4,
+      zoom: 5,
+      panoId: 'cascade-pano',
+      extraTag: 'cascade-tag',
+    });
+
+    // Map-owned relations.
+    await db.insert(mapData).values({ mapId });
+    await db.insert(mapLevels).values({ mapId, levelId });
+    await db.insert(mapFilters).values({ mapId, tagLike: 'filter' });
+    await db.insert(mapRegions).values({ mapId, regionId: region!.id });
+
+    // Meta-owned relations.
+    await db.insert(metaLevels).values({ metaId, levelId });
+    await db.insert(metaImages).values({
+      metaId,
+      image_url: 'https://example.com/img.png',
+    });
+
+    // Synced relations.
+    await db.insert(syncedMetas).values({
+      metaId,
+      mapGroupId: groupId,
+      name: 'Synced meta',
+      note: 'note',
+      noteFromPlonkit: false,
+      footer: '',
+      images: [],
+    });
+    await db.insert(syncedLocations).values({
+      syncedMetaId: metaId,
+      lat: 1,
+      lng: 2,
+      heading: 3,
+      pitch: 4,
+      zoom: 5,
+      panoId: 'synced-pano',
+      extraTag: 'cascade-tag',
+    });
+    await db.insert(syncedMapMetas).values({ mapId, syncedMetaId: metaId });
+
+    await db.delete(mapGroups).where(eq(mapGroups.id, groupId));
+
+    const removedTables = [
+      ['map_groups', mapGroups],
+      ['maps', maps],
+      ['metas', metas],
+      ['map_group_locations', mapGroupLocations],
+      ['levels', levels],
+      ['map_levels', mapLevels],
+      ['map_filters', mapFilters],
+      ['map_regions', mapRegions],
+      ['map_data', mapData],
+      ['meta_levels', metaLevels],
+      ['meta_images', metaImages],
+      ['synced_metas', syncedMetas],
+      ['synced_locations', syncedLocations],
+      ['synced_map_metas', syncedMapMetas],
+    ] as const;
+
+    for (const [tableName, table] of removedTables) {
+      expect(await countRows(table), `${tableName} should be empty`).toBe(0);
+    }
+
+    // Unrelated rows survive the cascade.
+    expect(await countRows(regions)).toBe(1);
+  });
+});
+
+describe('mapLocations view', () => {
+  test('applies level, include, and exclude rules with exclude winning', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'View group' })
+      .returning({ id: mapGroups.id });
+    const groupId = group!.id;
+
+    const [levelA] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level A' })
+      .returning({ id: levels.id });
+    const [levelB] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level B' })
+      .returning({ id: levels.id });
+    const levelAId = levelA!.id;
+    const levelBId = levelB!.id;
+
+    const [metaA] = await db
+      .insert(metas)
+      .values({
+        mapGroupId: groupId,
+        tagName: 'alpha',
+        name: 'Alpha',
+        note: '',
+      })
+      .returning({ id: metas.id });
+    const [metaB] = await db
+      .insert(metas)
+      .values({ mapGroupId: groupId, tagName: 'beta', name: 'Beta', note: '' })
+      .returning({ id: metas.id });
+    // metaC has no levels and needs no returned id.
+    await db.insert(metas).values({
+      mapGroupId: groupId,
+      tagName: 'gamma',
+      name: 'Gamma',
+      note: '',
+    });
+
+    await db
+      .insert(metaLevels)
+      .values({ metaId: metaA!.id, levelId: levelAId });
+    await db
+      .insert(metaLevels)
+      .values({ metaId: metaB!.id, levelId: levelBId });
+
+    async function insertLocation(extraTag: string, panoId: string) {
+      await db.insert(mapGroupLocations).values({
+        mapGroupId: groupId,
+        extraTag,
+        panoId,
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+      });
+    }
+    await insertLocation('alpha', 'pano-alpha');
+    await insertLocation('beta', 'pano-beta');
+    await insertLocation('gamma', 'pano-gamma');
+    // Location without a matching meta must never appear in the view.
+    await insertLocation('unknown', 'pano-unknown');
+
+    async function insertMap(geoguessrId: string) {
+      const [map] = await db
+        .insert(maps)
+        .values({
+          name: geoguessrId,
+          geoguessrId,
+          isPersonal: false,
+          mapGroupId: groupId,
+        })
+        .returning({ id: maps.id });
+      return map!.id;
+    }
+
+    const mapPlain = await insertMap('plain');
+    const mapLeveled = await insertMap('leveled');
+    await db.insert(mapLevels).values({ mapId: mapLeveled, levelId: levelAId });
+
+    const mapInclude = await insertMap('include');
+    await db
+      .insert(mapFilters)
+      .values({ mapId: mapInclude, tagLike: 'alp%', isExclude: false });
+
+    const mapExclude = await insertMap('exclude');
+    await db
+      .insert(mapFilters)
+      .values({ mapId: mapExclude, tagLike: 'beta', isExclude: true });
+
+    const mapIncludeAndExclude = await insertMap('include-and-exclude');
+    await db
+      .insert(mapFilters)
+      .values({ mapId: mapIncludeAndExclude, tagLike: '%', isExclude: false });
+    await db.insert(mapFilters).values({
+      mapId: mapIncludeAndExclude,
+      tagLike: 'beta',
+      isExclude: true,
+    });
+
+    async function tagsFor(mapId: number) {
+      const rows = await db
+        .select()
+        .from(mapLocations)
+        .where(eq(mapLocations.mapId, mapId));
+      return rows.map((row) => row.tagName).sort();
+    }
+
+    // No levels or filters: every group location whose tag matches a meta.
+    expect(await tagsFor(mapPlain)).toEqual(['alpha', 'beta', 'gamma']);
+    // Level rule: only locations whose meta shares a map level appear.
+    expect(await tagsFor(mapLeveled)).toEqual(['alpha']);
+    // Include rule: only tags matching an include pattern appear.
+    expect(await tagsFor(mapInclude)).toEqual(['alpha']);
+    // Exclude rule: matching tags are removed, others remain.
+    expect(await tagsFor(mapExclude)).toEqual(['alpha', 'gamma']);
+    // Exclude wins even when the tag also matches an include pattern.
+    expect(await tagsFor(mapIncludeAndExclude)).toEqual(['alpha', 'gamma']);
+  });
+
+  test('projects joined location, meta, and map values', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Projection group' })
+      .returning({ id: mapGroups.id });
+    const groupId = group!.id;
+
+    const [meta] = await db
+      .insert(metas)
+      .values({
+        mapGroupId: groupId,
+        tagName: 'alpha',
+        name: 'Alpha meta',
+        note: 'note-alpha',
+        noteHtml: '<p>alpha</p>',
+        noteFromPlonkit: true,
+        modifiedAt: 2000,
+      })
+      .returning({ id: metas.id });
+
+    const [map] = await db
+      .insert(maps)
+      .values({
+        name: 'Projection map',
+        geoguessrId: 'projection-map',
+        isPersonal: false,
+        mapGroupId: groupId,
+        modifiedAt: 3000,
+      })
+      .returning({ id: maps.id });
+
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: groupId,
+      lat: 1.5,
+      lng: 2.5,
+      heading: 3.5,
+      pitch: 4.5,
+      zoom: 5.5,
+      panoId: 'pano-alpha',
+      extraTag: 'alpha',
+      extraPanoId: 'extra-pano',
+      extraPanoDate: '2020-01-01',
+      modifiedAt: 1000,
+    });
+
+    const [row] = await db
+      .select()
+      .from(mapLocations)
+      .where(eq(mapLocations.mapId, map!.id));
+
+    expect(row).toEqual({
+      mapId: map!.id,
+      lat: 1.5,
+      lng: 2.5,
+      heading: 3.5,
+      pitch: 4.5,
+      zoom: 5.5,
+      panoId: 'pano-alpha',
+      metaName: 'Alpha meta',
+      extraPanoId: 'extra-pano',
+      extraPanoDate: '2020-01-01',
+      tagName: 'alpha',
+      metaNote: 'note-alpha',
+      metaNoteHtml: '<p>alpha</p>',
+      metaNoteFromPlonkit: true,
+      metaId: meta!.id,
+      modifiedAt: 1000,
+      metaModifiedAt: 2000,
+      mapModifiedAt: 3000,
+    });
   });
 });

--- a/apps/api/src/lib/db/schema.db.test.ts
+++ b/apps/api/src/lib/db/schema.db.test.ts
@@ -466,3 +466,84 @@ describe('mapLocations view', () => {
     });
   });
 });
+
+describe('location modifiedAt trigger', () => {
+  test('no-op update preserves modifiedAt', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Trigger group' })
+      .returning({ id: mapGroups.id });
+
+    const [location] = await db
+      .insert(mapGroupLocations)
+      .values({
+        mapGroupId: group!.id,
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        panoId: 'pano-noop',
+        extraTag: 'tag',
+        modifiedAt: 1000,
+      })
+      .returning({ id: mapGroupLocations.id });
+
+    // Reassigning every column to its current value is a no-op update.
+    await db
+      .update(mapGroupLocations)
+      .set({
+        mapGroupId: group!.id,
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        panoId: 'pano-noop',
+        extraTag: 'tag',
+        modifiedAt: 1000,
+      })
+      .where(eq(mapGroupLocations.id, location!.id));
+
+    const [row] = await db
+      .select({ modifiedAt: mapGroupLocations.modifiedAt })
+      .from(mapGroupLocations)
+      .where(eq(mapGroupLocations.id, location!.id));
+
+    expect(row!.modifiedAt).toBe(1000);
+  });
+
+  test('meaningful row-data update advances modifiedAt', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Trigger group' })
+      .returning({ id: mapGroups.id });
+
+    const [location] = await db
+      .insert(mapGroupLocations)
+      .values({
+        mapGroupId: group!.id,
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        panoId: 'pano-meaningful',
+        extraTag: 'tag',
+        modifiedAt: 1000,
+      })
+      .returning({ id: mapGroupLocations.id });
+
+    await db
+      .update(mapGroupLocations)
+      .set({ extraTag: 'tag-changed' })
+      .where(eq(mapGroupLocations.id, location!.id));
+
+    const [row] = await db
+      .select({ modifiedAt: mapGroupLocations.modifiedAt })
+      .from(mapGroupLocations)
+      .where(eq(mapGroupLocations.id, location!.id));
+
+    expect(row!.modifiedAt).toBeGreaterThan(1000);
+  });
+});

--- a/apps/api/src/lib/internal/auth.unit.test.ts
+++ b/apps/api/src/lib/internal/auth.unit.test.ts
@@ -1,9 +1,31 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
 import { Elysia } from 'elysia';
-import { auth, bearer } from './auth';
 
 const originalAuthRequired = process.env.API_INTERNAL_AUTH_REQUIRED;
 const originalFrontendToken = process.env.FRONTEND_API_TOKEN;
+const originalBunFile = globalThis.Bun.file;
+const originalFetch = globalThis.fetch;
+const capturedErrors: unknown[] = [];
+
+// JWT verification reports claim-validation failures through Sentry. Mock that
+// external boundary before ./auth loads so the real onBeforeHandle path runs
+// with a recorded capture.
+mock.module('@sentry/bun', async () => ({
+  captureException: (error: unknown) => {
+    capturedErrors.push(error);
+  },
+}));
+
+const { auth, bearer } = await import('./auth');
+const jose = await import('jose');
 
 function restoreEnv(name: string, value: string | undefined) {
   if (value === undefined) {
@@ -116,5 +138,113 @@ describe('frontend token contract', () => {
     });
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ userId: 'discord-user-123' });
+  });
+});
+
+// Production JWT contract: auth(true) verifies Kubernetes JWTs against the
+// remote JWKS. These tests run the real `.use(auth(true))` flow with only
+// external boundaries mocked: service-account files (Bun.file), the JWKS
+// endpoint (fetch), and Sentry capture. The auth gate is re-enabled per test
+// (API_INTERNAL_AUTH_REQUIRED unset).
+//
+// The JWKS endpoint fetch count is shared across every test in this suite:
+// the memoized construction reuses one remote JWKS set, so the whole process
+// must fetch exactly once no matter how many auth(true) requests run (even
+// concurrently). A per-request construction would fetch once per request.
+let jwksFetches = 0;
+let privateKey: CryptoKey;
+let publicKey: CryptoKey;
+let jwks: () => unknown;
+
+beforeAll(async () => {
+  const pair = await jose.generateKeyPair('RS256');
+  publicKey = pair.publicKey;
+  privateKey = pair.privateKey;
+  const jwk = await jose.exportJWK(publicKey);
+  jwks = () => ({ keys: [{ ...jwk, kid: 'test-key' }] });
+});
+
+function jwtApp() {
+  return new Elysia()
+    .use(auth(true))
+    .get('/', ({ userId }) => ({ userId }), { userId: true });
+}
+
+describe('production JWT contract', () => {
+  beforeEach(() => {
+    delete process.env.API_INTERNAL_AUTH_REQUIRED;
+    capturedErrors.length = 0;
+    globalThis.Bun.file = ((_path: string) => ({
+      text: async () => 'test-ca',
+    })) as unknown as typeof Bun.file;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      if (String(input) === 'https://kubernetes.default.svc/openid/v1/jwks') {
+        jwksFetches += 1;
+        return new Response(JSON.stringify(jwks()), {
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return originalFetch(input, init);
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    restoreEnv('API_INTERNAL_AUTH_REQUIRED', originalAuthRequired);
+    globalThis.Bun.file = originalBunFile;
+    globalThis.fetch = originalFetch;
+  });
+
+  const sign = (claims: Record<string, unknown>) =>
+    new jose.SignJWT(claims)
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+  const hit = (token: string) => {
+    delete process.env.API_INTERNAL_AUTH_REQUIRED;
+    return jwtApp().handle(
+      new Request('http://localhost/', {
+        headers: {
+          authorization: `Bearer ${token}`,
+          'x-api-user-id': 'discord-user-123',
+        },
+      }),
+    );
+  };
+
+  test('verifies JWTs through the production JWKS flow', async () => {
+    const wrongAudience = await hit(await sign({ aud: 'not-the-api' }));
+    expect(wrongAudience.status).toBe(403);
+    expect(await wrongAudience.json()).toEqual(['JWT validation failed']);
+    expect(capturedErrors).toHaveLength(1);
+
+    const malformed = await hit('not-a-jwt');
+    expect(malformed.status).toBe(500);
+    expect(capturedErrors).toHaveLength(1);
+
+    const valid = await hit(await sign({ aud: 'api' }));
+    expect(valid.status).toBe(200);
+    expect(await valid.json()).toEqual({ userId: 'discord-user-123' });
+    expect(capturedErrors).toHaveLength(1);
+  });
+
+  test('memoizes JWKS construction across concurrent auth(true) requests', async () => {
+    const tokens = await Promise.all(
+      Array.from({ length: 5 }, () => sign({ aud: 'api' })),
+    );
+    const responses = await Promise.all(tokens.map(hit));
+    for (const response of responses) {
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ userId: 'discord-user-123' });
+    }
+
+    // All five concurrent requests verified through one shared remote JWKS
+    // set, which fetched the endpoint exactly once. Constructing the JWKS per
+    // request would fetch once per request.
+    expect(jwksFetches).toBe(1);
   });
 });

--- a/apps/api/src/lib/internal/changes.db.test.ts
+++ b/apps/api/src/lib/internal/changes.db.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import { asc } from 'drizzle-orm';
 import { mapGroupChanges, mapGroups, users } from '../db/schema';
 import { db } from '../drizzle';
-import { logChange } from './changes';
+import { type ChangeEntry, logChange } from './changes';
 
 async function seedUser(id: string) {
   await db.insert(users).values({ id, username: id });
@@ -16,7 +17,7 @@ async function seedGroup(name: string) {
 }
 
 async function changeRows() {
-  return db.select().from(mapGroupChanges);
+  return db.select().from(mapGroupChanges).orderBy(asc(mapGroupChanges.id));
 }
 
 describe('logChange', () => {
@@ -70,6 +71,50 @@ describe('logChange', () => {
     expect(await changeRows()).toHaveLength(0);
   });
 
+  test('mixed list filters no-op updates but inserts meaningful entries', async () => {
+    await seedUser('u');
+    const groupId = await seedGroup('Group');
+
+    await logChange(db, [
+      {
+        mapGroupId: groupId,
+        userId: 'u',
+        entityType: 'meta',
+        entityId: 7,
+        operation: 'update',
+        oldValue: { name: 'Meta' },
+        newValue: { name: 'Meta' },
+      },
+      {
+        mapGroupId: groupId,
+        userId: 'u',
+        entityType: 'meta',
+        entityId: 7,
+        operation: 'update',
+        oldValue: { name: 'Meta' },
+        newValue: { name: 'Renamed' },
+      },
+      {
+        mapGroupId: groupId,
+        userId: 'u',
+        entityType: 'meta_image',
+        entityId: 9,
+        operation: 'create',
+        newValue: { url: '/img.png' },
+      },
+    ]);
+
+    const rows = await changeRows();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.operation).sort()).toEqual([
+      'create',
+      'update',
+    ]);
+    const update = rows.find((row) => row.operation === 'update')!;
+    expect(update.oldValue).toEqual({ name: 'Meta' });
+    expect(update.newValue).toEqual({ name: 'Renamed' });
+  });
+
   test('retains value-less update (sync marker)', async () => {
     await seedUser('u');
     const groupId = await seedGroup('Group');
@@ -105,5 +150,56 @@ describe('logChange', () => {
     const rows = await changeRows();
     expect(rows).toHaveLength(1);
     expect(rows[0].newValue).toEqual({ enabled: false, count: 0, items: [] });
+  });
+
+  test('persists every entry when one call spans more than 1000 rows', async () => {
+    await seedUser('u');
+    const groupId = await seedGroup('Group');
+    const count = 1001;
+
+    const entries: ChangeEntry[] = Array.from({ length: count }, (_, i) => ({
+      mapGroupId: groupId,
+      userId: 'u',
+      entityType: 'meta',
+      entityId: i + 1,
+      operation: 'create',
+      newValue: { n: i + 1 },
+    }));
+
+    await logChange(db, entries);
+
+    const rows = await changeRows();
+    expect(rows).toHaveLength(count);
+    expect(rows.map((row) => row.entityId)).toEqual(
+      Array.from({ length: count }, (_, i) => i + 1),
+    );
+    expect(rows.map((row) => row.newValue)).toEqual(
+      Array.from({ length: count }, (_, i) => ({ n: i + 1 })),
+    );
+  });
+
+  test('late failure inside a transaction rolls back all logChange batches', async () => {
+    await seedUser('u');
+    const groupId = await seedGroup('Group');
+
+    // First batch of 1000 succeeds; the trailing entry carries a user id that
+    // violates the map_group_changes.user_id foreign key, failing the second
+    // batch.
+    const entries: ChangeEntry[] = Array.from({ length: 1001 }, (_, i) => ({
+      mapGroupId: groupId,
+      userId: i < 1000 ? 'u' : 'missing-user',
+      entityType: 'meta',
+      entityId: i + 1,
+      operation: 'create',
+      newValue: { n: i + 1 },
+    }));
+
+    await expect(
+      db.transaction(async (tx) => {
+        await logChange(tx, entries);
+      }),
+    ).rejects.toThrow();
+
+    expect(await changeRows()).toHaveLength(0);
   });
 });

--- a/apps/api/src/lib/internal/changes.db.test.ts
+++ b/apps/api/src/lib/internal/changes.db.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { asc } from 'drizzle-orm';
 import { mapGroupChanges, mapGroups, users } from '../db/schema';
 import { db } from '../drizzle';
-import { type ChangeEntry, logChange } from './changes';
+import { type ChangeEntry, logChange, metaSnapshot } from './changes';
 
 async function seedUser(id: string) {
   await db.insert(users).values({ id, username: id });
@@ -201,5 +201,25 @@ describe('logChange', () => {
     ).rejects.toThrow();
 
     expect(await changeRows()).toHaveLength(0);
+  });
+});
+
+describe('metaSnapshot', () => {
+  test('includes exact public audit fields and preserves false/null', () => {
+    const snapshot = metaSnapshot({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: null,
+      noteFromPlonkit: false,
+    });
+
+    expect(snapshot).toEqual({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: null,
+      noteFromPlonkit: false,
+    });
   });
 });

--- a/apps/api/src/lib/internal/metas-upload.db.test.ts
+++ b/apps/api/src/lib/internal/metas-upload.db.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import {
+  levels,
+  mapGroupChanges,
+  mapGroups,
+  metaImages,
+  metaLevels,
+  metas,
+  users,
+} from '../db/schema';
+import { db } from '../drizzle';
+import { uploadMetas } from './metas-upload';
+
+async function seedCreateFixture() {
+  await db.insert(users).values({ id: 'uploader', username: 'uploader' });
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Test group' })
+    .returning({ id: mapGroups.id });
+  const [levelA] = await db
+    .insert(levels)
+    .values({ name: 'Level A', mapGroupId: group!.id })
+    .returning({ id: levels.id });
+  const [levelB] = await db
+    .insert(levels)
+    .values({ name: 'Level B', mapGroupId: group!.id })
+    .returning({ id: levels.id });
+  return { groupId: group!.id, levelAId: levelA!.id, levelBId: levelB!.id };
+}
+
+describe('uploadMetas create', () => {
+  test('persists raw markdown, rendered html, levels, images, timestamp, and create change entry', async () => {
+    const { groupId, levelAId, levelBId } = await seedCreateFixture();
+    const before = Math.floor(Date.now() / 1000);
+
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level B', 'Level A'],
+          images: ['https://img.example/b.jpg', 'https://img.example/a.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+    const after = Math.floor(Date.now() / 1000);
+
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(meta).toBeDefined();
+    expect(meta).toMatchObject({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      noteHtml: '<p><strong>Capital:</strong> Washington</p>',
+      footer: 'See [source](https://example.com)',
+      footerHtml:
+        '<p>See <a href="https://example.com" rel="nofollow" target="_blank">source</a></p>',
+      noteFromPlonkit: false,
+    });
+
+    expect(meta.modifiedAt).toBeGreaterThanOrEqual(before);
+    expect(meta.modifiedAt).toBeLessThanOrEqual(after);
+
+    const metaLevelRows = await db
+      .select()
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta.id));
+    expect(metaLevelRows.map((row) => row.levelId).sort()).toEqual(
+      [levelAId, levelBId].sort(),
+    );
+
+    const imageRows = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta.id));
+    expect(imageRows.map((row) => row.image_url).sort()).toEqual([
+      'https://img.example/a.jpg',
+      'https://img.example/b.jpg',
+    ]);
+
+    const changes = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      userId: 'uploader',
+      entityType: 'meta',
+      entityId: meta.id,
+      entityLabel: 'us',
+      operation: 'create',
+      oldValue: null,
+    });
+    expect(changes[0].newValue).toEqual({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: 'See [source](https://example.com)',
+      noteFromPlonkit: false,
+      levels: ['Level A', 'Level B'],
+      images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+    });
+  });
+});
+
+describe('uploadMetas update', () => {
+  test('updates an existing meta in place: raw+rendered markdown, levels/images replacement, refreshed timestamp, and exact update change entry', async () => {
+    const { groupId, levelAId, levelBId } = await seedCreateFixture();
+
+    // First upload creates the meta.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level B', 'Level A'],
+          images: ['https://img.example/b.jpg', 'https://img.example/a.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const [createdMeta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    const createdModifiedAt = 1;
+    await db
+      .update(metas)
+      .set({ modifiedAt: createdModifiedAt })
+      .where(eq(metas.id, createdMeta!.id));
+
+    const before = Math.floor(Date.now() / 1000);
+    // Second upload with the same tagName updates the existing meta.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'USA',
+          note: '**Capital:** Washington, D.C.',
+          footer: '**Updated:** see [docs](https://docs.example.com)',
+          levels: ['Level A'],
+          images: ['https://img.example/d.jpg', 'https://img.example/c.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+    const after = Math.floor(Date.now() / 1000);
+
+    // Same row, upserted in place.
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(meta).toBeDefined();
+    expect(meta.id).toBe(createdMeta!.id);
+    expect(meta).toMatchObject({
+      tagName: 'us',
+      name: 'USA',
+      note: '**Capital:** Washington, D.C.',
+      noteHtml: '<p><strong>Capital:</strong> Washington, D.C.</p>',
+      footer: '**Updated:** see [docs](https://docs.example.com)',
+      footerHtml:
+        '<p><strong>Updated:</strong> see <a href="https://docs.example.com" rel="nofollow" target="_blank">docs</a></p>',
+      noteFromPlonkit: false,
+    });
+
+    // Timestamp is refreshed to the update upload time, strictly after the
+    // original create timestamp.
+    expect(meta.modifiedAt).toBeGreaterThan(createdModifiedAt);
+    expect(meta.modifiedAt).toBeGreaterThanOrEqual(before);
+    expect(meta.modifiedAt).toBeLessThanOrEqual(after);
+
+    // Levels replaced: only Level A remains assigned.
+    const metaLevelRows = await db
+      .select()
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta.id));
+    expect(metaLevelRows.map((row) => row.levelId).sort()).toEqual([levelAId]);
+
+    // Images replaced: old URLs are gone, new ones persisted.
+    const imageRows = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta.id));
+    expect(imageRows.map((row) => row.image_url).sort()).toEqual([
+      'https://img.example/c.jpg',
+      'https://img.example/d.jpg',
+    ]);
+
+    // Exactly two entries: the create from the first upload and the
+    // meaningful update from the second.
+    const changes = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changes).toHaveLength(2);
+    const update = changes.find((row) => row.operation === 'update')!;
+    expect(update).toMatchObject({
+      userId: 'uploader',
+      entityType: 'meta',
+      entityId: meta.id,
+      entityLabel: 'us',
+      operation: 'update',
+    });
+    expect(update.createdAt).toBeGreaterThanOrEqual(before);
+    expect(update.createdAt).toBeLessThanOrEqual(after);
+    expect(update.oldValue).toEqual({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: 'See [source](https://example.com)',
+      noteFromPlonkit: false,
+      levels: ['Level A', 'Level B'],
+      images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+    });
+    expect(update.newValue).toEqual({
+      tagName: 'us',
+      name: 'USA',
+      note: '**Capital:** Washington, D.C.',
+      footer: '**Updated:** see [docs](https://docs.example.com)',
+      noteFromPlonkit: false,
+      levels: ['Level A'],
+      images: ['https://img.example/c.jpg', 'https://img.example/d.jpg'],
+    });
+
+    // Level B itself is untouched, just unassigned from the meta.
+    const [levelB] = await db
+      .select()
+      .from(levels)
+      .where(eq(levels.id, levelBId));
+    expect(levelB).toMatchObject({ id: levelBId, name: 'Level B' });
+  });
+});
+
+describe('uploadMetas partial vs full', () => {
+  test('partial upload preserves omitted metas; full upload deletes omitted metas and cascades their level/image associations', async () => {
+    const { groupId, levelBId } = await seedCreateFixture();
+    const [levelC] = await db
+      .insert(levels)
+      .values({ name: 'Level C', mapGroupId: groupId })
+      .returning({ id: levels.id });
+    const levelCId = levelC!.id;
+
+    // Initial partial upload creates two metas with level/image associations.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+        },
+        {
+          tagName: 'ca',
+          metaName: 'Canada',
+          note: '**Capital:** Ottawa',
+          footer: 'See [ca](https://ca.example.com)',
+          levels: ['Level B', 'Level C'],
+          images: ['https://img.example/c.jpg', 'https://img.example/d.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const [caMeta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.tagName, 'ca'));
+    expect(caMeta).toBeDefined();
+
+    // Partial upload of only 'us' preserves the omitted 'ca' meta and its
+    // level/image associations untouched.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const [caAfterPartial] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.tagName, 'ca'));
+    expect(caAfterPartial).toMatchObject({
+      id: caMeta!.id,
+      tagName: 'ca',
+      name: 'Canada',
+    });
+    const caLevelsAfterPartial = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, caMeta!.id));
+    expect(caLevelsAfterPartial.map((row) => row.levelId).sort()).toEqual(
+      [levelBId, levelCId].sort(),
+    );
+    const caImagesAfterPartial = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, caMeta!.id));
+    expect(caImagesAfterPartial.map((row) => row.image_url).sort()).toEqual([
+      'https://img.example/c.jpg',
+      'https://img.example/d.jpg',
+    ]);
+
+    // Full upload of only 'us' deletes the omitted 'ca' meta; its
+    // metaLevels/metaImages rows cascade away while Level C itself survives.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+        },
+      ],
+      false,
+      false,
+    );
+
+    const metasAfterFull = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(metasAfterFull.map((meta) => meta.tagName)).toEqual(['us']);
+    const caAfterFull = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.tagName, 'ca'));
+    expect(caAfterFull).toHaveLength(0);
+    const caLevelsAfterFull = await db
+      .select()
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, caMeta!.id));
+    expect(caLevelsAfterFull).toHaveLength(0);
+    const caImagesAfterFull = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, caMeta!.id));
+    expect(caImagesAfterFull).toHaveLength(0);
+    const [levelCAfterFull] = await db
+      .select()
+      .from(levels)
+      .where(eq(levels.id, levelCId));
+    expect(levelCAfterFull).toMatchObject({ id: levelCId, name: 'Level C' });
+  });
+});

--- a/apps/api/src/lib/internal/metas-upload.db.test.ts
+++ b/apps/api/src/lib/internal/metas-upload.db.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import {
   levels,
   mapGroupChanges,
@@ -10,7 +10,7 @@ import {
   users,
 } from '../db/schema';
 import { db } from '../drizzle';
-import { uploadMetas } from './metas-upload';
+import { MissingLevelsError, uploadMetas } from './metas-upload';
 
 async function seedCreateFixture() {
   await db.insert(users).values({ id: 'uploader', username: 'uploader' });
@@ -251,6 +251,147 @@ describe('uploadMetas update', () => {
   });
 });
 
+describe('uploadMetas update logging', () => {
+  test('level/image-only update (scalars unchanged) logs meaningful before/after snapshot', async () => {
+    const { groupId, levelBId } = await seedCreateFixture();
+
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level A'],
+          images: ['https://img.example/a.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    // Same scalars; only levels and images differ.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level B'],
+          images: ['https://img.example/b.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    // Scalar fields untouched by the association-only update.
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(meta).toMatchObject({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: 'See [source](https://example.com)',
+    });
+    const levelRows = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta!.id));
+    expect(levelRows.map((row) => row.levelId)).toEqual([levelBId]);
+    const imageRows = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta!.id));
+    expect(imageRows.map((row) => row.image_url)).toEqual([
+      'https://img.example/b.jpg',
+    ]);
+
+    // One update entry, with the before/after snapshots capturing the
+    // association change even though every scalar is identical.
+    const changes = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changes).toHaveLength(2);
+    const update = changes.find((row) => row.operation === 'update')!;
+    expect(update).toMatchObject({
+      userId: 'uploader',
+      entityType: 'meta',
+      entityId: meta!.id,
+      entityLabel: 'us',
+      operation: 'update',
+    });
+    expect(update.oldValue).toEqual({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: 'See [source](https://example.com)',
+      noteFromPlonkit: false,
+      levels: ['Level A'],
+      images: ['https://img.example/a.jpg'],
+    });
+    expect(update.newValue).toEqual({
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      footer: 'See [source](https://example.com)',
+      noteFromPlonkit: false,
+      levels: ['Level B'],
+      images: ['https://img.example/b.jpg'],
+    });
+  });
+
+  test('scalar no-op re-upload (identical scalars, levels, images) creates no update log', async () => {
+    const { groupId, levelAId } = await seedCreateFixture();
+
+    const item = {
+      tagName: 'us',
+      metaName: 'United States',
+      note: '**Capital:** Washington',
+      footer: 'See [source](https://example.com)',
+      levels: ['Level A'],
+      images: ['https://img.example/a.jpg'],
+    };
+    await uploadMetas(groupId, 'uploader', [item], true, false);
+    await uploadMetas(groupId, 'uploader', [item], true, false);
+
+    // Only the create entry from the first upload; the identical re-upload
+    // logs nothing even though the meta row itself is rewritten.
+    const changes = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changes).toHaveLength(1);
+    expect(changes[0].operation).toBe('create');
+
+    // Level and image associations survive intact.
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    const levelRows = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta!.id));
+    expect(levelRows.map((row) => row.levelId)).toEqual([levelAId]);
+    const imageRows = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta!.id));
+    expect(imageRows.map((row) => row.image_url)).toEqual([
+      'https://img.example/a.jpg',
+    ]);
+  });
+});
+
 describe('uploadMetas partial vs full', () => {
   test('partial upload preserves omitted metas; full upload deletes omitted metas and cascades their level/image associations', async () => {
     const { groupId, levelBId } = await seedCreateFixture();
@@ -380,5 +521,618 @@ describe('uploadMetas partial vs full', () => {
       .from(levels)
       .where(eq(levels.id, levelCId));
     expect(levelCAfterFull).toMatchObject({ id: levelCId, name: 'Level C' });
+  });
+});
+
+describe('uploadMetas empty uploads', () => {
+  // Empty input currently reaches Drizzle's `.values([])` before upload mode
+  // semantics run. Keep desired behavior executable without blessing the error.
+  test.todo('empty full upload deletes all target-group metas; empty partial upload changes nothing', async () => {
+    const { groupId, levelAId, levelBId } = await seedCreateFixture();
+
+    // Unrelated group keeps a meta with the same tag to prove isolation.
+    const [otherGroup] = await db
+      .insert(mapGroups)
+      .values({ name: 'Other group' })
+      .returning({ id: mapGroups.id });
+    const otherGroupId = otherGroup!.id;
+    const [otherMeta] = await db
+      .insert(metas)
+      .values({
+        mapGroupId: otherGroupId,
+        tagName: 'us',
+        name: 'Other United States',
+        note: 'Other note',
+      })
+      .returning({ id: metas.id, tagName: metas.tagName });
+    expect(otherMeta).toBeDefined();
+
+    // Seed two target-group metas with level/image associations.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+        },
+        {
+          tagName: 'ca',
+          metaName: 'Canada',
+          note: '**Capital:** Ottawa',
+          footer: 'See [ca](https://ca.example.com)',
+          levels: ['Level A'],
+          images: ['https://img.example/c.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const targetMetas = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(targetMetas.map((meta) => meta.tagName).sort()).toEqual([
+      'ca',
+      'us',
+    ]);
+    const usMeta = targetMetas.find((meta) => meta.tagName === 'us')!;
+    const caMeta = targetMetas.find((meta) => meta.tagName === 'ca')!;
+    const usLevelRows = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, usMeta.id));
+    expect(usLevelRows.map((row) => row.levelId).sort()).toEqual([
+      levelAId,
+      levelBId,
+    ]);
+    const usImageRows = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, usMeta.id));
+    expect(usImageRows.map((row) => row.image_url).sort()).toEqual([
+      'https://img.example/a.jpg',
+      'https://img.example/b.jpg',
+    ]);
+
+    // Empty partial upload changes nothing: same metas, same associations,
+    // and no extra audit entries beyond the two creates.
+    await uploadMetas(groupId, 'uploader', [], true, false);
+
+    const targetAfterPartial = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(targetAfterPartial.map((meta) => meta.tagName).sort()).toEqual([
+      'ca',
+      'us',
+    ]);
+    const usLevelsAfterPartial = await db
+      .select()
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, usMeta.id));
+    expect(usLevelsAfterPartial).toHaveLength(2);
+    const changesAfterPartial = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changesAfterPartial).toHaveLength(2);
+
+    // Empty full upload deletes every target-group meta, cascades
+    // metaLevels/metaImages away, and logs one delete per meta; levels and
+    // the unrelated group survive.
+    await uploadMetas(groupId, 'uploader', [], false, false);
+
+    const targetAfterFull = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(targetAfterFull).toHaveLength(0);
+    const usLevelsAfterFull = await db
+      .select()
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, usMeta.id));
+    expect(usLevelsAfterFull).toHaveLength(0);
+    const usImagesAfterFull = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, usMeta.id));
+    expect(usImagesAfterFull).toHaveLength(0);
+    const caLevelsAfterFull = await db
+      .select()
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, caMeta.id));
+    expect(caLevelsAfterFull).toHaveLength(0);
+
+    const deleteChanges = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(
+        and(
+          eq(mapGroupChanges.mapGroupId, groupId),
+          eq(mapGroupChanges.operation, 'delete'),
+        ),
+      );
+    expect(deleteChanges.map((row) => row.entityLabel).sort()).toEqual([
+      'ca',
+      'us',
+    ]);
+
+    const levelRows = await db
+      .select()
+      .from(levels)
+      .where(eq(levels.mapGroupId, groupId));
+    expect(levelRows.map((row) => row.id).sort()).toEqual([levelAId, levelBId]);
+
+    const [otherAfterFull] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.id, otherMeta!.id));
+    expect(otherAfterFull).toMatchObject({
+      id: otherMeta!.id,
+      tagName: 'us',
+      name: 'Other United States',
+    });
+  });
+});
+
+describe('uploadMetas omitted vs empty levels/images', () => {
+  test('omitted levels/images preserve assignments; explicit empty arrays clear them', async () => {
+    const { groupId, levelAId, levelBId } = await seedCreateFixture();
+
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+
+    // Update omitting levels/images: existing assignments survive untouched.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+        },
+      ],
+      true,
+      false,
+    );
+
+    const levelRowsAfterOmit = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta!.id));
+    expect(levelRowsAfterOmit.map((row) => row.levelId).sort()).toEqual([
+      levelAId,
+      levelBId,
+    ]);
+    const imageRowsAfterOmit = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta!.id));
+    expect(imageRowsAfterOmit.map((row) => row.image_url).sort()).toEqual([
+      'https://img.example/a.jpg',
+      'https://img.example/b.jpg',
+    ]);
+
+    // Update with explicit empty arrays: assignments are cleared.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          footer: 'See [source](https://example.com)',
+          levels: [],
+          images: [],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const levelRowsAfterClear = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta!.id));
+    expect(levelRowsAfterClear).toHaveLength(0);
+    const imageRowsAfterClear = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta!.id));
+    expect(imageRowsAfterClear).toHaveLength(0);
+
+    // Levels themselves survive; only the assignments are gone.
+    const [levelA] = await db
+      .select()
+      .from(levels)
+      .where(eq(levels.id, levelAId));
+    expect(levelA).toMatchObject({ id: levelAId, name: 'Level A' });
+    const [levelB] = await db
+      .select()
+      .from(levels)
+      .where(eq(levels.id, levelBId));
+    expect(levelB).toMatchObject({ id: levelBId, name: 'Level B' });
+  });
+});
+
+describe('uploadMetas missing level without auto-create', () => {
+  test('rolls back scalar, association, deletion, and log changes', async () => {
+    const { groupId } = await seedCreateFixture();
+
+    // Baseline: two metas with associations and their create log entries.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg'],
+        },
+        {
+          tagName: 'ca',
+          metaName: 'Canada',
+          note: '**Capital:** Ottawa',
+          levels: ['Level A'],
+          images: ['https://img.example/c.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const metasBefore = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    const levelsBefore = await db.select().from(metaLevels);
+    const imagesBefore = await db.select().from(metaImages);
+    const changesBefore = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changesBefore).toHaveLength(2);
+
+    await expect(
+      uploadMetas(
+        groupId,
+        'uploader',
+        [
+          {
+            tagName: 'us',
+            metaName: 'USA',
+            note: '**Capital:** Washington, D.C.',
+            levels: ['Missing Level'],
+          },
+        ],
+        false,
+        false,
+      ),
+    ).rejects.toThrow(MissingLevelsError);
+
+    const metasAfter = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(metasAfter.sort((a, b) => a.id - b.id)).toEqual(
+      metasBefore.sort((a, b) => a.id - b.id),
+    );
+    expect(metasAfter.map((meta) => meta.tagName).sort()).toEqual(['ca', 'us']);
+    const levelsAfter = await db.select().from(metaLevels);
+    expect(levelsAfter.sort((a, b) => a.id - b.id)).toEqual(
+      levelsBefore.sort((a, b) => a.id - b.id),
+    );
+    const imagesAfter = await db.select().from(metaImages);
+    expect(imagesAfter.sort((a, b) => a.id - b.id)).toEqual(
+      imagesBefore.sort((a, b) => a.id - b.id),
+    );
+    const changesAfter = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changesAfter.sort((a, b) => a.id - b.id)).toEqual(
+      changesBefore.sort((a, b) => a.id - b.id),
+    );
+    expect(
+      changesAfter.filter((row) => row.operation === 'delete'),
+    ).toHaveLength(0);
+  });
+});
+
+describe('uploadMetas duplicate level conflict', () => {
+  test('duplicate level name in one meta rolls back scalar, association, deletion, and log changes', async () => {
+    const { groupId } = await seedCreateFixture();
+
+    // Baseline: two metas with associations and their create log entries.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          levels: ['Level A', 'Level B'],
+          images: ['https://img.example/a.jpg'],
+        },
+        {
+          tagName: 'ca',
+          metaName: 'Canada',
+          note: '**Capital:** Ottawa',
+          levels: ['Level A'],
+          images: ['https://img.example/c.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    const metasBefore = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    const levelsBefore = await db.select().from(metaLevels);
+    const imagesBefore = await db.select().from(metaImages);
+    const changesBefore = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    // Duplicate association fails after scalar, audit, and deletion writes.
+    await expect(
+      uploadMetas(
+        groupId,
+        'uploader',
+        [
+          {
+            tagName: 'us',
+            metaName: 'USA',
+            note: '**Capital:** Washington, D.C.',
+            levels: ['Level A', 'Level A'],
+          },
+        ],
+        false,
+        false,
+      ),
+    ).rejects.toThrow();
+
+    const metasAfter = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(metasAfter.sort((a, b) => a.id - b.id)).toEqual(
+      metasBefore.sort((a, b) => a.id - b.id),
+    );
+    const levelsAfter = await db.select().from(metaLevels);
+    expect(levelsAfter.sort((a, b) => a.id - b.id)).toEqual(
+      levelsBefore.sort((a, b) => a.id - b.id),
+    );
+    const imagesAfter = await db.select().from(metaImages);
+    expect(imagesAfter.sort((a, b) => a.id - b.id)).toEqual(
+      imagesBefore.sort((a, b) => a.id - b.id),
+    );
+    const changesAfter = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(changesAfter.sort((a, b) => a.id - b.id)).toEqual(
+      changesBefore.sort((a, b) => a.id - b.id),
+    );
+  });
+});
+
+describe('uploadMetas auto-create levels', () => {
+  test('creates one shared missing level and links every requesting meta to it', async () => {
+    const { groupId, levelAId, levelBId } = await seedCreateFixture();
+
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'United States',
+          note: '**Capital:** Washington',
+          levels: ['Shared Missing', 'Level A'],
+        },
+        {
+          tagName: 'ca',
+          metaName: 'Canada',
+          note: '**Capital:** Ottawa',
+          levels: ['Shared Missing', 'Level B'],
+        },
+      ],
+      true,
+      true,
+    );
+
+    const levelRows = await db
+      .select()
+      .from(levels)
+      .where(eq(levels.mapGroupId, groupId));
+    expect(levelRows.map((row) => row.name).sort()).toEqual([
+      'Level A',
+      'Level B',
+      'Shared Missing',
+    ]);
+    const [sharedLevel] = levelRows.filter(
+      (row) => row.name === 'Shared Missing',
+    );
+    expect(sharedLevel).toBeDefined();
+
+    const metaRows = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    const usMeta = metaRows.find((meta) => meta.tagName === 'us')!;
+    const caMeta = metaRows.find((meta) => meta.tagName === 'ca')!;
+
+    const usLevels = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, usMeta.id));
+    expect(usLevels.map((row) => row.levelId).sort()).toEqual([
+      levelAId,
+      sharedLevel!.id,
+    ]);
+    const caLevels = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, caMeta.id));
+    expect(caLevels.map((row) => row.levelId).sort()).toEqual([
+      levelBId,
+      sharedLevel!.id,
+    ]);
+  });
+});
+
+describe('uploadMetas group isolation', () => {
+  test('uploading group A does not alter group B when both reuse the same tag name and overlapping level/image values', async () => {
+    const { groupId, levelBId } = await seedCreateFixture();
+
+    // Group B mirrors group A: same tag name, same level names, same image URLs.
+    const [otherGroup] = await db
+      .insert(mapGroups)
+      .values({ name: 'Other group' })
+      .returning({ id: mapGroups.id });
+    const otherGroupId = otherGroup!.id;
+    const [otherLevelA] = await db
+      .insert(levels)
+      .values({ name: 'Level A', mapGroupId: otherGroupId })
+      .returning({ id: levels.id });
+    const [otherLevelB] = await db
+      .insert(levels)
+      .values({ name: 'Level B', mapGroupId: otherGroupId })
+      .returning({ id: levels.id });
+    const [otherMeta] = await db
+      .insert(metas)
+      .values({
+        mapGroupId: otherGroupId,
+        tagName: 'us',
+        name: 'Other United States',
+        note: 'Other note',
+        footer: 'Other footer',
+        noteHtml: '<p>Other note</p>',
+        footerHtml: '<p>Other footer</p>',
+      })
+      .returning();
+    await db.insert(metaLevels).values([
+      { metaId: otherMeta!.id, levelId: otherLevelA!.id },
+      { metaId: otherMeta!.id, levelId: otherLevelB!.id },
+    ]);
+    await db.insert(metaImages).values([
+      { metaId: otherMeta!.id, image_url: 'https://img.example/a.jpg' },
+      { metaId: otherMeta!.id, image_url: 'https://img.example/b.jpg' },
+    ]);
+    const [otherMetaBefore] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.id, otherMeta!.id));
+
+    // Create group A's own `us` meta with different values.
+    await uploadMetas(
+      groupId,
+      'uploader',
+      [
+        {
+          tagName: 'us',
+          metaName: 'USA',
+          note: '**Capital:** Washington, D.C.',
+          footer: '**Updated:** see [docs](https://docs.example.com)',
+          levels: ['Level B'],
+          images: ['https://img.example/d.jpg'],
+        },
+      ],
+      true,
+      false,
+    );
+
+    // Group A receives only its requested values.
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId));
+    expect(meta).toMatchObject({
+      tagName: 'us',
+      name: 'USA',
+      note: '**Capital:** Washington, D.C.',
+      footer: '**Updated:** see [docs](https://docs.example.com)',
+    });
+    const aLevelRows = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, meta!.id));
+    expect(aLevelRows.map((row) => row.levelId)).toEqual([levelBId]);
+    const aImageRows = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, meta!.id));
+    expect(aImageRows.map((row) => row.image_url)).toEqual([
+      'https://img.example/d.jpg',
+    ]);
+    const aChanges = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId));
+    expect(aChanges.map((row) => row.operation)).toEqual(['create']);
+
+    // Group B's meta is exactly preserved: same row, same scalars, same
+    // timestamp, same level/image associations.
+    const [otherMetaAfter] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.id, otherMeta!.id));
+    expect(otherMetaAfter).toEqual(otherMetaBefore);
+    const otherLevelRows = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, otherMeta!.id));
+    expect(otherLevelRows.map((row) => row.levelId).sort()).toEqual(
+      [otherLevelA!.id, otherLevelB!.id].sort(),
+    );
+    const otherImageRows = await db
+      .select({ image_url: metaImages.image_url })
+      .from(metaImages)
+      .where(eq(metaImages.metaId, otherMeta!.id));
+    expect(otherImageRows.map((row) => row.image_url).sort()).toEqual([
+      'https://img.example/a.jpg',
+      'https://img.example/b.jpg',
+    ]);
+
+    // No audit entries leak into group B.
+    const otherChanges = await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, otherGroupId));
+    expect(otherChanges).toHaveLength(0);
   });
 });

--- a/apps/api/src/lib/internal/sync/index.db.test.ts
+++ b/apps/api/src/lib/internal/sync/index.db.test.ts
@@ -1,0 +1,951 @@
+import { describe, expect, test } from 'bun:test';
+import { and, asc, eq, or } from 'drizzle-orm';
+import {
+  levels,
+  mapFilters,
+  mapGroupLocations,
+  mapGroups,
+  mapLevels,
+  maps,
+  metaImages,
+  metaLevels,
+  metas,
+  syncedLocations,
+  syncedMapMetas,
+  syncedMetas,
+} from '../../db/schema';
+import { db } from '../../drizzle';
+import { syncMapGroup } from './index';
+
+async function seedNullSyncedAtFixture(geoguessrId = 'full-sync-map') {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Full sync group' })
+    .returning({ id: mapGroups.id, syncedAt: mapGroups.syncedAt });
+  const groupId = group!.id;
+  expect(group!.syncedAt).toBeNull();
+
+  const [usMeta] = await db
+    .insert(metas)
+    .values({
+      mapGroupId: groupId,
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      noteHtml: '<p><strong>Capital:</strong> Washington</p>',
+      footer: 'See [source](https://example.com)',
+      footerHtml: '<p>See <a href="https://example.com">source</a></p>',
+      noteFromPlonkit: true,
+      modifiedAt: 100,
+    })
+    .returning({ id: metas.id });
+  const [jpMeta] = await db
+    .insert(metas)
+    .values({
+      mapGroupId: groupId,
+      tagName: 'Japan',
+      name: 'Japan',
+      note: '**Capital:** Tokyo',
+      noteHtml: '<p><strong>Capital:</strong> Tokyo</p>',
+      footer: '',
+      footerHtml: '',
+      noteFromPlonkit: false,
+      modifiedAt: 200,
+    })
+    .returning({ id: metas.id });
+
+  // Only the 'us' meta carries images; the image-less meta must sync with an
+  // empty image array.
+  await db.insert(metaImages).values([
+    { metaId: usMeta!.id, image_url: 'https://img.example/a.jpg', order: 0 },
+    { metaId: usMeta!.id, image_url: 'https://img.example/b.jpg', order: 1 },
+  ]);
+
+  await db.insert(mapGroupLocations).values([
+    {
+      mapGroupId: groupId,
+      lat: 38.9,
+      lng: -77,
+      heading: 1,
+      pitch: 2,
+      zoom: 3,
+      panoId: 'pano-us-1',
+      extraTag: 'us',
+      modifiedAt: 100,
+    },
+    {
+      mapGroupId: groupId,
+      lat: 35.6,
+      lng: 139.7,
+      heading: 4,
+      pitch: 5,
+      zoom: 6,
+      panoId: 'pano-jp-1',
+      extraTag: 'Japan',
+      modifiedAt: 200,
+    },
+    {
+      // No meta carries this tag, so full sync must not emit it.
+      mapGroupId: groupId,
+      lat: 0,
+      lng: 0,
+      heading: 0,
+      pitch: 0,
+      zoom: 0,
+      panoId: 'pano-orphan',
+      extraTag: 'NoSuchTag',
+      modifiedAt: 300,
+    },
+  ]);
+
+  // Map without levels or filters: every meta in the group is eligible.
+  const [map] = await db
+    .insert(maps)
+    .values({
+      mapGroupId: groupId,
+      name: 'World map',
+      geoguessrId,
+    })
+    .returning({ id: maps.id });
+
+  return {
+    groupId,
+    usMetaId: usMeta!.id,
+    jpMetaId: jpMeta!.id,
+    mapId: map!.id,
+  };
+}
+
+describe('syncMapGroup null syncedAt', () => {
+  test('full sync persists eligible metas, locations, map-meta associations, and the sync timestamp', async () => {
+    const { groupId, usMetaId, jpMetaId, mapId } =
+      await seedNullSyncedAtFixture();
+    const before = Math.floor(Date.now() / 1000);
+
+    const syncedAt = await syncMapGroup({ id: groupId, syncedAt: null });
+
+    const after = Math.floor(Date.now() / 1000);
+    expect(syncedAt).toBeGreaterThanOrEqual(before);
+    expect(syncedAt).toBeLessThanOrEqual(after);
+
+    // Returned timestamp is persisted on the group.
+    const [group] = await db
+      .select({ syncedAt: mapGroups.syncedAt })
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    expect(group!.syncedAt).toBe(syncedAt);
+
+    // Every group meta is synced with its exact payload.
+    const syncedMetaRows = await db
+      .select()
+      .from(syncedMetas)
+      .orderBy(asc(syncedMetas.metaId));
+    expect(syncedMetaRows).toEqual([
+      {
+        metaId: usMetaId,
+        mapGroupId: groupId,
+        name: 'United States',
+        // The sync payload stores the rendered html, not the raw markdown.
+        note: '<p><strong>Capital:</strong> Washington</p>',
+        noteFromPlonkit: true,
+        footer: '<p>See <a href="https://example.com">source</a></p>',
+        images: ['https://img.example/a.jpg', 'https://img.example/b.jpg'],
+      },
+      {
+        metaId: jpMetaId,
+        mapGroupId: groupId,
+        name: 'Japan',
+        note: '<p><strong>Capital:</strong> Tokyo</p>',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      },
+    ]);
+
+    // Only locations whose extra tag matches a group meta are synced; the
+    // orphan location stays out. Country derives from the tag name.
+    const syncedLocationRows = await db
+      .select()
+      .from(syncedLocations)
+      .orderBy(asc(syncedLocations.panoId));
+    expect(syncedLocationRows).toEqual([
+      {
+        syncedMetaId: jpMetaId,
+        lat: 35.6,
+        lng: 139.7,
+        heading: 4,
+        pitch: 5,
+        zoom: 6,
+        panoId: 'pano-jp-1',
+        extraTag: 'Japan',
+        extraPanoId: null,
+        extraPanoDate: null,
+        country: 'Japan',
+      },
+      {
+        syncedMetaId: usMetaId,
+        lat: 38.9,
+        lng: -77,
+        heading: 1,
+        pitch: 2,
+        zoom: 3,
+        panoId: 'pano-us-1',
+        extraTag: 'us',
+        extraPanoId: null,
+        extraPanoDate: null,
+        country: 'us',
+      },
+    ]);
+
+    // Every eligible meta is associated with the group's map.
+    const associationRows = await db
+      .select()
+      .from(syncedMapMetas)
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(associationRows).toEqual([
+      { mapId, syncedMetaId: usMetaId },
+      { mapId, syncedMetaId: jpMetaId },
+    ]);
+  });
+});
+
+describe('syncMapGroup incremental modifiedAt boundary', () => {
+  async function seedIncrementalFixture() {
+    const { groupId, usMetaId, jpMetaId } = await seedNullSyncedAtFixture();
+    // Baseline: run a full sync, then treat its timestamp as the boundary for
+    // the incremental sync under test.
+    const syncedAt = await syncMapGroup({ id: groupId, syncedAt: null });
+    return { groupId, usMetaId, jpMetaId, syncedAt };
+  }
+
+  test('re-syncs metas strictly above the boundary, leaves rows equal to it untouched', async () => {
+    const { groupId, usMetaId, jpMetaId, syncedAt } =
+      await seedIncrementalFixture();
+
+    // Meaningful change, but modifiedAt lands exactly on the sync boundary.
+    await db
+      .update(metas)
+      .set({ name: 'United States v2', modifiedAt: syncedAt })
+      .where(eq(metas.id, usMetaId));
+
+    // Meaningful change with modifiedAt strictly above the boundary.
+    await db
+      .update(metas)
+      .set({ name: 'Japan v2', modifiedAt: syncedAt + 10 })
+      .where(eq(metas.id, jpMetaId));
+
+    const timestamp = await syncMapGroup({ id: groupId, syncedAt });
+
+    // The incremental sync advances the group's timestamp like a full sync.
+    const [group] = await db
+      .select({ syncedAt: mapGroups.syncedAt })
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    expect(group!.syncedAt).toBe(timestamp);
+
+    // modifiedAt == syncedAt: the change must not reach the synced payload.
+    const [usRow] = await db
+      .select({ name: syncedMetas.name })
+      .from(syncedMetas)
+      .where(eq(syncedMetas.metaId, usMetaId));
+    expect(usRow!.name).toBe('United States');
+
+    // modifiedAt > syncedAt: the change must propagate.
+    const [jpRow] = await db
+      .select({ name: syncedMetas.name })
+      .from(syncedMetas)
+      .where(eq(syncedMetas.metaId, jpMetaId));
+    expect(jpRow!.name).toBe('Japan v2');
+  });
+
+  test('syncs locations strictly above the boundary, skips rows equal to it', async () => {
+    const { groupId, usMetaId, syncedAt } = await seedIncrementalFixture();
+
+    await db.insert(mapGroupLocations).values([
+      {
+        mapGroupId: groupId,
+        lat: 10,
+        lng: 11,
+        heading: 0,
+        pitch: 0,
+        zoom: 0,
+        panoId: 'pano-equal',
+        extraTag: 'us',
+        modifiedAt: syncedAt,
+      },
+      {
+        mapGroupId: groupId,
+        lat: 12.5,
+        lng: -8,
+        heading: 7,
+        pitch: 8,
+        zoom: 9,
+        panoId: 'pano-new',
+        extraTag: 'us',
+        extraPanoId: 'extra-1',
+        extraPanoDate: '2024-01-01',
+        modifiedAt: syncedAt + 10,
+      },
+    ]);
+
+    await syncMapGroup({ id: groupId, syncedAt });
+
+    const syncedLocationRows = await db
+      .select()
+      .from(syncedLocations)
+      .orderBy(asc(syncedLocations.panoId));
+    // pano-equal (modifiedAt == syncedAt) must stay out of the synced set.
+    expect(syncedLocationRows.map((row) => row.panoId)).toEqual([
+      'pano-jp-1',
+      'pano-new',
+      'pano-us-1',
+    ]);
+
+    // pano-new (modifiedAt > syncedAt) is synced with its full payload.
+    const newRow = syncedLocationRows.find((row) => row.panoId === 'pano-new');
+    expect(newRow).toEqual({
+      syncedMetaId: usMetaId,
+      lat: 12.5,
+      lng: -8,
+      heading: 7,
+      pitch: 8,
+      zoom: 9,
+      panoId: 'pano-new',
+      extraTag: 'us',
+      extraPanoId: 'extra-1',
+      extraPanoDate: '2024-01-01',
+      country: 'us',
+    });
+  });
+});
+
+describe('syncMapGroup street view setting', () => {
+  async function seedStreetViewFixture() {
+    // The sync_include_locations_not_on_street_view setting defaults to true,
+    // which includes every location regardless of is_on_street_view.
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Street view group' })
+      .returning({ id: mapGroups.id, syncedAt: mapGroups.syncedAt });
+    const groupId = group!.id;
+    expect(group!.syncedAt).toBeNull();
+
+    await db
+      .insert(metas)
+      .values({
+        mapGroupId: groupId,
+        tagName: 'us',
+        name: 'United States',
+        note: '',
+        noteHtml: '',
+        footer: '',
+        footerHtml: '',
+        noteFromPlonkit: false,
+        modifiedAt: 100,
+      })
+      .returning({ id: metas.id });
+
+    // One location per is_on_street_view state: true, null, false.
+    await db.insert(mapGroupLocations).values([
+      {
+        mapGroupId: groupId,
+        lat: 38.9,
+        lng: -77,
+        heading: 1,
+        pitch: 2,
+        zoom: 3,
+        panoId: 'pano-sv-true',
+        extraTag: 'us',
+        isOnStreetView: true,
+        modifiedAt: 100,
+      },
+      {
+        mapGroupId: groupId,
+        lat: 35.6,
+        lng: 139.7,
+        heading: 4,
+        pitch: 5,
+        zoom: 6,
+        panoId: 'pano-sv-null',
+        extraTag: 'us',
+        isOnStreetView: null,
+        modifiedAt: 100,
+      },
+      {
+        mapGroupId: groupId,
+        lat: 51.5,
+        lng: -0.1,
+        heading: 7,
+        pitch: 8,
+        zoom: 9,
+        panoId: 'pano-sv-false',
+        extraTag: 'us',
+        isOnStreetView: false,
+        modifiedAt: 100,
+      },
+    ]);
+
+    return { groupId };
+  }
+
+  test('setting true includes true/null/false rows; transition to false removes the false row', async () => {
+    const { groupId } = await seedStreetViewFixture();
+
+    // Setting true (default): every street-view state is eligible and synced.
+    const firstSyncedAt = await syncMapGroup({ id: groupId, syncedAt: null });
+    const afterFirstSync = await db
+      .select({ panoId: syncedLocations.panoId })
+      .from(syncedLocations)
+      .orderBy(asc(syncedLocations.panoId));
+    expect(afterFirstSync.map((row) => row.panoId)).toEqual([
+      'pano-sv-false',
+      'pano-sv-null',
+      'pano-sv-true',
+    ]);
+
+    // Setting false: the false row no longer matches the sync filter, so the
+    // next sync removes it while true and null rows stay.
+    await db
+      .update(mapGroups)
+      .set({ syncIncludeLocationsNotOnStreetView: false })
+      .where(eq(mapGroups.id, groupId));
+
+    await syncMapGroup({ id: groupId, syncedAt: firstSyncedAt });
+
+    const afterTransition = await db
+      .select({ panoId: syncedLocations.panoId })
+      .from(syncedLocations)
+      .orderBy(asc(syncedLocations.panoId));
+    expect(afterTransition.map((row) => row.panoId)).toEqual([
+      'pano-sv-null',
+      'pano-sv-true',
+    ]);
+  });
+});
+
+describe('syncMapGroup map-meta membership', () => {
+  async function seedMembershipFixture() {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Membership group' })
+      .returning({ id: mapGroups.id, syncedAt: mapGroups.syncedAt });
+    const groupId = group!.id;
+    expect(group!.syncedAt).toBeNull();
+
+    const [levelA] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level A' })
+      .returning({ id: levels.id });
+    const [levelB] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level B' })
+      .returning({ id: levels.id });
+    const levelAId = levelA!.id;
+    const levelBId = levelB!.id;
+
+    async function insertMeta(tagName: string, levelId: number) {
+      const [meta] = await db
+        .insert(metas)
+        .values({
+          mapGroupId: groupId,
+          tagName,
+          name: tagName,
+          note: '',
+          noteHtml: '',
+          footer: '',
+          footerHtml: '',
+          noteFromPlonkit: false,
+          modifiedAt: 100,
+        })
+        .returning({ id: metas.id });
+      const metaId = meta!.id;
+      await db.insert(metaLevels).values({ metaId, levelId });
+      return metaId;
+    }
+
+    // alpha and zeta share the map's level; alphb holds the other level, and
+    // beta matches no include pattern despite holding the map's level.
+    const alphaMetaId = await insertMeta('alpha', levelAId);
+    const alphbMetaId = await insertMeta('alphb', levelBId);
+    const betaMetaId = await insertMeta('beta', levelAId);
+    const zetaMetaId = await insertMeta('zeta', levelAId);
+
+    // Map with level A, include patterns 'alp%' and 'zet%', exclude 'zeta'.
+    const [map] = await db
+      .insert(maps)
+      .values({
+        mapGroupId: groupId,
+        name: 'Membership map',
+        geoguessrId: 'membership-map',
+      })
+      .returning({ id: maps.id });
+    const mapId = map!.id;
+    await db.insert(mapLevels).values({ mapId, levelId: levelAId });
+    await db
+      .insert(mapFilters)
+      .values({ mapId, tagLike: 'alp%', isExclude: false });
+    await db
+      .insert(mapFilters)
+      .values({ mapId, tagLike: 'zet%', isExclude: false });
+    await db
+      .insert(mapFilters)
+      .values({ mapId, tagLike: 'zeta', isExclude: true });
+
+    return { groupId, mapId, alphaMetaId, alphbMetaId, betaMetaId, zetaMetaId };
+  }
+
+  test('map membership combines levels, include filters, and exclude filters; exclude wins', async () => {
+    const { groupId, mapId, alphaMetaId, alphbMetaId, betaMetaId, zetaMetaId } =
+      await seedMembershipFixture();
+
+    await syncMapGroup({ id: groupId, syncedAt: null });
+
+    // Membership filtering happens at the map-meta association, not at the
+    // meta sync: every group meta is synced...
+    const syncedMetaIds = await db
+      .select({ metaId: syncedMetas.metaId })
+      .from(syncedMetas)
+      .where(eq(syncedMetas.mapGroupId, groupId))
+      .orderBy(asc(syncedMetas.metaId));
+    expect(syncedMetaIds.map((row) => row.metaId)).toEqual([
+      alphaMetaId,
+      alphbMetaId,
+      betaMetaId,
+      zetaMetaId,
+    ]);
+
+    // ...but only the meta passing every membership rule gets an association:
+    // - alpha: level A, include 'alp%', not excluded.
+    // - alphb: matches include 'alp%' but misses level A.
+    // - beta: holds level A but matches no include pattern.
+    // - zeta: level A and include 'zet%', but the exclude filter wins.
+    const associationRows = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, mapId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(associationRows).toEqual([{ mapId, syncedMetaId: alphaMetaId }]);
+  });
+});
+
+describe('syncMapGroup incremental update/delete propagation', () => {
+  test('propagates updated and deleted source metas/locations while other groups stay untouched', async () => {
+    const target = await seedNullSyncedAtFixture('target-map');
+    const other = await seedNullSyncedAtFixture('other-map');
+
+    // A second us-tagged location lets source-location deletion be exercised
+    // independently of the meta-deletion cascade.
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: target.groupId,
+      lat: 40.7,
+      lng: -74,
+      heading: 13,
+      pitch: 14,
+      zoom: 15,
+      panoId: 'pano-us-2',
+      extraTag: 'us',
+      modifiedAt: 100,
+    });
+
+    const targetSyncedAt = await syncMapGroup({
+      id: target.groupId,
+      syncedAt: null,
+    });
+    const otherSyncedAt = await syncMapGroup({
+      id: other.groupId,
+      syncedAt: null,
+    });
+    const otherMetasBefore = await db
+      .select()
+      .from(syncedMetas)
+      .where(eq(syncedMetas.mapGroupId, other.groupId))
+      .orderBy(asc(syncedMetas.metaId));
+    const otherLocationsBefore = await db
+      .select()
+      .from(syncedLocations)
+      .where(
+        or(
+          eq(syncedLocations.syncedMetaId, other.usMetaId),
+          eq(syncedLocations.syncedMetaId, other.jpMetaId),
+        ),
+      )
+      .orderBy(asc(syncedLocations.syncedMetaId));
+    const otherAssociationsBefore = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, other.mapId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+
+    // Target-group source mutations the incremental sync must propagate:
+    // updated meta, updated location, deleted meta, deleted location.
+    await db
+      .update(metas)
+      .set({ name: 'United States v2', modifiedAt: targetSyncedAt + 10 })
+      .where(eq(metas.id, target.usMetaId));
+    await db.delete(metas).where(eq(metas.id, target.jpMetaId));
+    await db
+      .update(mapGroupLocations)
+      .set({
+        lat: 51.5,
+        lng: -0.1,
+        heading: 10,
+        pitch: 11,
+        zoom: 12,
+        extraPanoId: 'extra-us-1',
+        extraPanoDate: '2025-06-01',
+      })
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, target.groupId),
+          eq(mapGroupLocations.panoId, 'pano-us-1'),
+        ),
+      );
+    await db
+      .delete(mapGroupLocations)
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, target.groupId),
+          eq(mapGroupLocations.panoId, 'pano-us-2'),
+        ),
+      );
+
+    // The other group also carries pending source changes above its own
+    // boundary; only the target group syncs, so they must not reach synced
+    // tables.
+    await db
+      .update(metas)
+      .set({ name: 'Other United States v2', modifiedAt: otherSyncedAt + 10 })
+      .where(eq(metas.id, other.usMetaId));
+    await db
+      .update(mapGroupLocations)
+      .set({ lat: 1.5, modifiedAt: otherSyncedAt + 10 })
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, other.groupId),
+          eq(mapGroupLocations.panoId, 'pano-jp-1'),
+        ),
+      );
+
+    await syncMapGroup({ id: target.groupId, syncedAt: targetSyncedAt - 1 });
+
+    // Updated meta propagates; the deleted meta disappears from synced_metas.
+    const targetSyncedMetas = await db
+      .select({ metaId: syncedMetas.metaId, name: syncedMetas.name })
+      .from(syncedMetas)
+      .where(eq(syncedMetas.mapGroupId, target.groupId))
+      .orderBy(asc(syncedMetas.metaId));
+    expect(targetSyncedMetas).toEqual([
+      { metaId: target.usMetaId, name: 'United States v2' },
+    ]);
+
+    // The updated location propagates; the deleted source location and the
+    // deleted meta's location are gone.
+    const targetSyncedLocations = await db
+      .select({
+        syncedMetaId: syncedLocations.syncedMetaId,
+        panoId: syncedLocations.panoId,
+        lat: syncedLocations.lat,
+      })
+      .from(syncedLocations)
+      .where(eq(syncedLocations.syncedMetaId, target.usMetaId))
+      .orderBy(asc(syncedLocations.panoId));
+    expect(targetSyncedLocations).toEqual([
+      { syncedMetaId: target.usMetaId, panoId: 'pano-us-1', lat: 51.5 },
+    ]);
+    const deletedMetaLocations = await db
+      .select()
+      .from(syncedLocations)
+      .where(eq(syncedLocations.syncedMetaId, target.jpMetaId));
+    expect(deletedMetaLocations).toEqual([]);
+
+    // Only the surviving meta keeps its map-meta association.
+    const targetAssociations = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, target.mapId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(targetAssociations).toEqual([
+      { mapId: target.mapId, syncedMetaId: target.usMetaId },
+    ]);
+
+    const otherSyncedMetas = await db
+      .select()
+      .from(syncedMetas)
+      .where(eq(syncedMetas.mapGroupId, other.groupId))
+      .orderBy(asc(syncedMetas.metaId));
+    expect(otherSyncedMetas).toEqual(otherMetasBefore);
+
+    const otherLocations = await db
+      .select()
+      .from(syncedLocations)
+      .where(
+        or(
+          eq(syncedLocations.syncedMetaId, other.usMetaId),
+          eq(syncedLocations.syncedMetaId, other.jpMetaId),
+        ),
+      )
+      .orderBy(asc(syncedLocations.syncedMetaId));
+    expect(otherLocations).toEqual(otherLocationsBefore);
+
+    const otherAssociations = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, other.mapId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(otherAssociations).toEqual(otherAssociationsBefore);
+  });
+});
+
+describe('syncMapGroup source tag/pano reassignment', () => {
+  test('reassignment above the boundary removes stale identities and inserts replacements without cross-group leakage', async () => {
+    const target = await seedNullSyncedAtFixture('reassign-target');
+    const other = await seedNullSyncedAtFixture('reassign-other');
+
+    const targetSyncedAt = await syncMapGroup({
+      id: target.groupId,
+      syncedAt: null,
+    });
+    await syncMapGroup({ id: other.groupId, syncedAt: null });
+
+    // Snapshot the other group's synced locations. It deliberately shares the
+    // same pano ids and tag names as the target group so any cross-group
+    // leakage in the target-group deletes would show up here.
+    const otherLocationsBefore = await db
+      .select()
+      .from(syncedLocations)
+      .where(
+        or(
+          eq(syncedLocations.syncedMetaId, other.usMetaId),
+          eq(syncedLocations.syncedMetaId, other.jpMetaId),
+        ),
+      )
+      .orderBy(asc(syncedLocations.syncedMetaId), asc(syncedLocations.panoId));
+
+    // Reassignments are written as delete + insert: the production BEFORE
+    // UPDATE trigger on map_group_locations overwrites any explicit
+    // modified_at with NOW(), so an UPDATE cannot carry a controlled
+    // timestamp. Delete first because (map_group_id, pano_id) is unique.
+    //
+    // Tag reassignment: pano-us-1 leaves the 'us' meta and joins 'Japan'.
+    await db
+      .delete(mapGroupLocations)
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, target.groupId),
+          eq(mapGroupLocations.panoId, 'pano-us-1'),
+        ),
+      );
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: target.groupId,
+      lat: 38.9,
+      lng: -77,
+      heading: 1,
+      pitch: 2,
+      zoom: 3,
+      panoId: 'pano-us-1',
+      extraTag: 'Japan',
+      modifiedAt: targetSyncedAt + 10,
+    });
+
+    // Pano reassignment: pano-jp-1 keeps its 'Japan' tag but gets a new pano
+    // id.
+    await db
+      .delete(mapGroupLocations)
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, target.groupId),
+          eq(mapGroupLocations.panoId, 'pano-jp-1'),
+        ),
+      );
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: target.groupId,
+      lat: 35.6,
+      lng: 139.7,
+      heading: 4,
+      pitch: 5,
+      zoom: 6,
+      panoId: 'pano-jp-2',
+      extraTag: 'Japan',
+      modifiedAt: targetSyncedAt + 10,
+    });
+
+    await syncMapGroup({ id: target.groupId, syncedAt: targetSyncedAt });
+
+    // Stale identities are gone, replacements exist, and each replacement
+    // carries the exact payload of its reassigned source row.
+    const targetLocations = await db
+      .select()
+      .from(syncedLocations)
+      .where(
+        or(
+          eq(syncedLocations.syncedMetaId, target.usMetaId),
+          eq(syncedLocations.syncedMetaId, target.jpMetaId),
+        ),
+      )
+      .orderBy(asc(syncedLocations.syncedMetaId), asc(syncedLocations.panoId));
+    expect(
+      targetLocations.map((row) => `${row.syncedMetaId}:${row.panoId}`),
+    ).toEqual([`${target.jpMetaId}:pano-jp-2`, `${target.jpMetaId}:pano-us-1`]);
+
+    const replacedPanoRow = targetLocations.find(
+      (row) => row.panoId === 'pano-jp-2',
+    );
+    expect(replacedPanoRow).toEqual({
+      syncedMetaId: target.jpMetaId,
+      lat: 35.6,
+      lng: 139.7,
+      heading: 4,
+      pitch: 5,
+      zoom: 6,
+      panoId: 'pano-jp-2',
+      extraTag: 'Japan',
+      extraPanoId: null,
+      extraPanoDate: null,
+      country: 'Japan',
+    });
+    const retaggedRow = targetLocations.find(
+      (row) => row.panoId === 'pano-us-1',
+    );
+    expect(retaggedRow).toEqual({
+      syncedMetaId: target.jpMetaId,
+      lat: 38.9,
+      lng: -77,
+      heading: 1,
+      pitch: 2,
+      zoom: 3,
+      panoId: 'pano-us-1',
+      extraTag: 'Japan',
+      extraPanoId: null,
+      extraPanoDate: null,
+      country: 'Japan',
+    });
+
+    // The other group shares pano ids and tag names with the target group;
+    // its synced locations must stay byte-identical.
+    const otherLocations = await db
+      .select()
+      .from(syncedLocations)
+      .where(
+        or(
+          eq(syncedLocations.syncedMetaId, other.usMetaId),
+          eq(syncedLocations.syncedMetaId, other.jpMetaId),
+        ),
+      )
+      .orderBy(asc(syncedLocations.syncedMetaId), asc(syncedLocations.panoId));
+    expect(otherLocations).toEqual(otherLocationsBefore);
+  });
+});
+
+describe('syncMapGroup incremental membership move', () => {
+  test('meta leaving map A for map B removes the stale association and inserts the new one', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Membership move group' })
+      .returning({ id: mapGroups.id, syncedAt: mapGroups.syncedAt });
+    const groupId = group!.id;
+    expect(group!.syncedAt).toBeNull();
+
+    const [levelA] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level A' })
+      .returning({ id: levels.id });
+    const [levelB] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level B' })
+      .returning({ id: levels.id });
+    const levelAId = levelA!.id;
+    const levelBId = levelB!.id;
+
+    async function insertMeta(
+      tagName: string,
+      levelId: number,
+      modifiedAt: number,
+    ) {
+      const [meta] = await db
+        .insert(metas)
+        .values({
+          mapGroupId: groupId,
+          tagName,
+          name: tagName,
+          note: '',
+          noteHtml: '',
+          footer: '',
+          footerHtml: '',
+          noteFromPlonkit: false,
+          modifiedAt,
+        })
+        .returning({ id: metas.id });
+      const metaId = meta!.id;
+      await db.insert(metaLevels).values({ metaId, levelId });
+      return metaId;
+    }
+
+    // x and y hold level A (map A); z holds level B (map B). x later moves
+    // from level A to level B, leaving map A while y keeps map A in the
+    // membership source so its stale association can be deleted.
+    const xMetaId = await insertMeta('x', levelAId, 100);
+    const yMetaId = await insertMeta('y', levelAId, 100);
+    const zMetaId = await insertMeta('z', levelBId, 100);
+
+    const [mapA] = await db
+      .insert(maps)
+      .values({
+        mapGroupId: groupId,
+        name: 'Map A',
+        geoguessrId: 'membership-move-a',
+      })
+      .returning({ id: maps.id });
+    const mapAId = mapA!.id;
+    await db.insert(mapLevels).values({ mapId: mapAId, levelId: levelAId });
+
+    const [mapB] = await db
+      .insert(maps)
+      .values({
+        mapGroupId: groupId,
+        name: 'Map B',
+        geoguessrId: 'membership-move-b',
+      })
+      .returning({ id: maps.id });
+    const mapBId = mapB!.id;
+    await db.insert(mapLevels).values({ mapId: mapBId, levelId: levelBId });
+
+    const syncedAt = await syncMapGroup({ id: groupId, syncedAt: null });
+
+    // Baseline: x belongs to map A.
+    const beforeMapA = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, mapAId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(beforeMapA).toEqual([
+      { mapId: mapAId, syncedMetaId: xMetaId },
+      { mapId: mapAId, syncedMetaId: yMetaId },
+    ]);
+
+    // Source membership change with a controlled timestamp strictly above the
+    // sync boundary: x leaves level A and joins level B.
+    await db
+      .update(metas)
+      .set({ modifiedAt: syncedAt + 10 })
+      .where(eq(metas.id, xMetaId));
+    await db
+      .delete(metaLevels)
+      .where(
+        and(eq(metaLevels.metaId, xMetaId), eq(metaLevels.levelId, levelAId)),
+      );
+    await db.insert(metaLevels).values({ metaId: xMetaId, levelId: levelBId });
+
+    await syncMapGroup({ id: groupId, syncedAt });
+
+    // x's stale map-A association is gone and the map-B association exists.
+    const after = await db
+      .select()
+      .from(syncedMapMetas)
+      .orderBy(asc(syncedMapMetas.mapId), asc(syncedMapMetas.syncedMetaId));
+    expect(after).toEqual([
+      { mapId: mapAId, syncedMetaId: yMetaId },
+      { mapId: mapBId, syncedMetaId: xMetaId },
+      { mapId: mapBId, syncedMetaId: zMetaId },
+    ]);
+  });
+});

--- a/apps/api/src/lib/internal/sync/index.db.test.ts
+++ b/apps/api/src/lib/internal/sync/index.db.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { and, asc, eq, or } from 'drizzle-orm';
+import { and, asc, eq, or, sql } from 'drizzle-orm';
 import {
   levels,
   mapFilters,
@@ -947,5 +947,221 @@ describe('syncMapGroup incremental membership move', () => {
       { mapId: mapBId, syncedMetaId: xMetaId },
       { mapId: mapBId, syncedMetaId: zMetaId },
     ]);
+  });
+});
+
+describe('syncMapGroup map-meta membership transition to zero', () => {
+  test.todo('map with associations dropping to zero removes all stale map-meta rows', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Zero membership group' })
+      .returning({ id: mapGroups.id, syncedAt: mapGroups.syncedAt });
+    const groupId = group!.id;
+    expect(group!.syncedAt).toBeNull();
+
+    const [levelA] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level A' })
+      .returning({ id: levels.id });
+    const [levelB] = await db
+      .insert(levels)
+      .values({ mapGroupId: groupId, name: 'Level B' })
+      .returning({ id: levels.id });
+    const levelAId = levelA!.id;
+    const levelBId = levelB!.id;
+
+    async function insertMeta(tagName: string, levelId: number) {
+      const [meta] = await db
+        .insert(metas)
+        .values({
+          mapGroupId: groupId,
+          tagName,
+          name: tagName,
+          note: '',
+          noteHtml: '',
+          footer: '',
+          footerHtml: '',
+          noteFromPlonkit: false,
+          modifiedAt: 100,
+        })
+        .returning({ id: metas.id });
+      const metaId = meta!.id;
+      await db.insert(metaLevels).values({ metaId, levelId });
+      return metaId;
+    }
+
+    // x and y hold level A (map A); z holds level B (map B). x and y later
+    // lose level A entirely, so map A's membership drops from two metas to
+    // zero while map B stays untouched.
+    const xMetaId = await insertMeta('x', levelAId);
+    const yMetaId = await insertMeta('y', levelAId);
+    const zMetaId = await insertMeta('z', levelBId);
+
+    const [mapA] = await db
+      .insert(maps)
+      .values({
+        mapGroupId: groupId,
+        name: 'Map A',
+        geoguessrId: 'zero-membership-a',
+      })
+      .returning({ id: maps.id });
+    const mapAId = mapA!.id;
+    await db.insert(mapLevels).values({ mapId: mapAId, levelId: levelAId });
+
+    const [mapB] = await db
+      .insert(maps)
+      .values({
+        mapGroupId: groupId,
+        name: 'Map B',
+        geoguessrId: 'zero-membership-b',
+      })
+      .returning({ id: maps.id });
+    const mapBId = mapB!.id;
+    await db.insert(mapLevels).values({ mapId: mapBId, levelId: levelBId });
+
+    const syncedAt = await syncMapGroup({ id: groupId, syncedAt: null });
+
+    // Baseline: map A holds x and y; unrelated map B holds z.
+    const beforeMapA = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, mapAId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(beforeMapA).toEqual([
+      { mapId: mapAId, syncedMetaId: xMetaId },
+      { mapId: mapAId, syncedMetaId: yMetaId },
+    ]);
+    const beforeMapB = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, mapBId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(beforeMapB).toEqual([{ mapId: mapBId, syncedMetaId: zMetaId }]);
+
+    // Source membership change with a controlled timestamp strictly above the
+    // sync boundary: x and y leave level A, leaving map A with no matching
+    // meta.
+    for (const metaId of [xMetaId, yMetaId]) {
+      await db
+        .update(metas)
+        .set({ modifiedAt: syncedAt + 10 })
+        .where(eq(metas.id, metaId));
+      await db
+        .delete(metaLevels)
+        .where(
+          and(eq(metaLevels.metaId, metaId), eq(metaLevels.levelId, levelAId)),
+        );
+    }
+
+    await syncMapGroup({ id: groupId, syncedAt });
+
+    // Desired contract: the transition to zero matching metas removes every
+    // stale map-A association...
+    const afterMapA = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, mapAId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(afterMapA).toEqual([]);
+
+    // ...while unrelated map B keeps its association untouched.
+    const afterMapB = await db
+      .select()
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, mapBId))
+      .orderBy(asc(syncedMapMetas.syncedMetaId));
+    expect(afterMapB).toEqual(beforeMapB);
+  });
+});
+
+describe('syncMapGroup late SQL failure rollback', () => {
+  test('rejection rolls back every synced table and the group timestamp', async () => {
+    const { groupId } = await seedNullSyncedAtFixture();
+
+    const baselineGroupSyncedAt = await db
+      .select({ syncedAt: mapGroups.syncedAt })
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    const baselineMetas = await db
+      .select()
+      .from(syncedMetas)
+      .orderBy(asc(syncedMetas.metaId));
+    const baselineLocations = await db
+      .select()
+      .from(syncedLocations)
+      .orderBy(asc(syncedLocations.syncedMetaId), asc(syncedLocations.panoId));
+    const baselineAssociations = await db
+      .select()
+      .from(syncedMapMetas)
+      .orderBy(asc(syncedMapMetas.mapId), asc(syncedMapMetas.syncedMetaId));
+    expect(baselineGroupSyncedAt[0]!.syncedAt).toBeNull();
+    expect(baselineMetas).toEqual([]);
+    expect(baselineLocations).toEqual([]);
+    expect(baselineAssociations).toEqual([]);
+
+    // Make the transaction's final statement (the map_groups synced_at
+    // update) fail deterministically, after the synced-metas,
+    // synced-locations, and map-meta writes already executed in-transaction.
+    await db.$primary.execute(sql`
+      CREATE OR REPLACE FUNCTION geometa_test_fail_sync()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'intentional test failure';
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await db.$primary.execute(sql`
+      CREATE TRIGGER geometa_test_fail_sync_trigger
+      BEFORE UPDATE ON map_groups
+      FOR EACH ROW EXECUTE FUNCTION geometa_test_fail_sync()
+    `);
+
+    try {
+      let rejection: unknown;
+      try {
+        await syncMapGroup({ id: groupId, syncedAt: null });
+        throw new Error('expected syncMapGroup to reject');
+      } catch (error) {
+        rejection = error;
+      }
+
+      // The failure lands on the transaction's final statement (the
+      // map_groups synced_at update), raised by the trigger.
+      expect(rejection).toMatchObject({
+        message: expect.stringContaining('synced_at'),
+        cause: expect.objectContaining({ code: 'P0001' }),
+      });
+    } finally {
+      await db.$primary.execute(sql`
+        DROP TRIGGER IF EXISTS geometa_test_fail_sync_trigger ON map_groups
+      `);
+      await db.$primary.execute(sql`
+        DROP FUNCTION IF EXISTS geometa_test_fail_sync()
+      `);
+    }
+
+    // Rejection rolled back all in-transaction writes: synced tables and the
+    // group timestamp stay exactly at baseline.
+    const afterGroupSyncedAt = await db
+      .select({ syncedAt: mapGroups.syncedAt })
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    const afterMetas = await db
+      .select()
+      .from(syncedMetas)
+      .orderBy(asc(syncedMetas.metaId));
+    const afterLocations = await db
+      .select()
+      .from(syncedLocations)
+      .orderBy(asc(syncedLocations.syncedMetaId), asc(syncedLocations.panoId));
+    const afterAssociations = await db
+      .select()
+      .from(syncedMapMetas)
+      .orderBy(asc(syncedMapMetas.mapId), asc(syncedMapMetas.syncedMetaId));
+
+    expect(afterGroupSyncedAt).toEqual(baselineGroupSyncedAt);
+    expect(afterMetas).toEqual(baselineMetas);
+    expect(afterLocations).toEqual(baselineLocations);
+    expect(afterAssociations).toEqual(baselineAssociations);
   });
 });

--- a/apps/api/src/lib/internal/sync/index.db.test.ts
+++ b/apps/api/src/lib/internal/sync/index.db.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from 'bun:test';
-import { and, asc, eq, or, sql } from 'drizzle-orm';
 import {
   levels,
   mapFilters,
@@ -13,8 +12,9 @@ import {
   syncedLocations,
   syncedMapMetas,
   syncedMetas,
-} from '../../db/schema';
-import { db } from '../../drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { and, asc, eq, or, sql } from 'drizzle-orm';
 import { syncMapGroup } from './index';
 
 async function seedNullSyncedAtFixture(geoguessrId = 'full-sync-map') {

--- a/apps/api/src/lib/userscript/locations.db.test.ts
+++ b/apps/api/src/lib/userscript/locations.db.test.ts
@@ -7,7 +7,7 @@ import {
   syncedMetas,
 } from '../db/schema';
 import { db } from '../drizzle';
-import { locationSelect } from './locations';
+import { locationSelect, mapLocationsExportSelect } from './locations';
 
 async function seedTwoMaps() {
   const [groupA] = await db
@@ -225,6 +225,57 @@ async function seedPersonalMapAttribution() {
   return { personalMapId: personalMap!.id, tieFirstId, tieSecondId };
 }
 
+// personal map borrowing a meta that no nonpersonal map includes: the lateral
+// original lookup finds nothing, so attribution fields stay null and the
+// personal map's own footer is used
+async function seedPersonalMapWithoutOriginal() {
+  const [personalMap] = await db
+    .insert(maps)
+    .values({
+      name: 'Orphan Personal Map',
+      geoguessrId: 'map-personal-orphan',
+      isPersonal: true,
+      mapGroupId: null,
+      authors: 'Orphan Author',
+      footerHtml: '<p>Orphan footer html</p>',
+    })
+    .returning({ id: maps.id });
+
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Borrowed Group' })
+    .returning({ id: mapGroups.id });
+
+  await db.insert(syncedMetas).values({
+    metaId: 5005,
+    mapGroupId: group!.id,
+    name: 'Borrowed Meta',
+    note: 'Borrowed note',
+    noteFromPlonkit: false,
+    footer: 'Borrowed footer',
+    images: ['borrowed.jpg'],
+  });
+
+  await db.insert(syncedMapMetas).values({
+    mapId: personalMap!.id,
+    syncedMetaId: 5005,
+  });
+
+  await db.insert(syncedLocations).values({
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+    syncedMetaId: 5005,
+    panoId: 'pano-orphan',
+    country: 'Austria',
+    extraTag: 'tag-orphan',
+  });
+
+  return { personalMapId: personalMap!.id };
+}
+
 describe('userscript location lookup', () => {
   test('exact map+pano lookup returns the selected public fields', async () => {
     await seedTwoMaps();
@@ -328,5 +379,59 @@ describe('userscript location lookup', () => {
         mapFooter: '<p>Tie First Map footer html</p>',
       }),
     );
+  });
+
+  test('personal map without nonpersonal original uses own footer and null attribution', async () => {
+    const { personalMapId } = await seedPersonalMapWithoutOriginal();
+
+    const [result] = await locationSelect.execute({
+      mapId: 'map-personal-orphan',
+      panoId: 'pano-orphan',
+    });
+
+    expect(result).toEqual({
+      name: 'Borrowed Meta',
+      note: 'Borrowed note',
+      footer: 'Borrowed footer',
+      images: ['borrowed.jpg'],
+      noteFromPlonkit: false,
+      country: 'Austria',
+      isPersonalMap: true,
+      // no eligible nonpersonal original: the personal map's own footer wins
+      mapFooter: '<p>Orphan footer html</p>',
+      mapName: null,
+      mapAuthors: null,
+      mapGeoguessrId: null,
+      mapId: personalMapId,
+      syncedMetaId: 5005,
+    });
+  });
+});
+
+describe('userscript map locations export', () => {
+  test('includes only synced locations of the requested map and omits other maps', async () => {
+    const { mapAId, mapBId } = await seedTwoMaps();
+
+    const alphaLocations = await mapLocationsExportSelect.execute({
+      mapId: mapAId,
+    });
+    // pano-shared also exists under map B's meta; only map A's own meta's
+    // locations may come back, and pano-b-only must stay invisible
+    expect(
+      alphaLocations.sort((a, b) => a.panoId.localeCompare(b.panoId)),
+    ).toEqual([
+      { lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5, panoId: 'pano-a-only' },
+      { lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5, panoId: 'pano-shared' },
+    ]);
+
+    const betaLocations = await mapLocationsExportSelect.execute({
+      mapId: mapBId,
+    });
+    expect(
+      betaLocations.sort((a, b) => a.panoId.localeCompare(b.panoId)),
+    ).toEqual([
+      { lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5, panoId: 'pano-b-only' },
+      { lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5, panoId: 'pano-shared' },
+    ]);
   });
 });

--- a/apps/api/src/lib/userscript/locations.db.test.ts
+++ b/apps/api/src/lib/userscript/locations.db.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mapGroups,
+  maps,
+  syncedLocations,
+  syncedMapMetas,
+  syncedMetas,
+} from '../db/schema';
+import { db } from '../drizzle';
+import { locationSelect } from './locations';
+
+async function seedTwoMaps() {
+  const [groupA] = await db
+    .insert(mapGroups)
+    .values({ name: 'Group A' })
+    .returning({ id: mapGroups.id });
+  const [groupB] = await db
+    .insert(mapGroups)
+    .values({ name: 'Group B' })
+    .returning({ id: mapGroups.id });
+
+  const [mapA] = await db
+    .insert(maps)
+    .values({
+      name: 'Alpha Map',
+      geoguessrId: 'map-a',
+      mapGroupId: groupA!.id,
+      authors: 'Author A',
+      footerHtml: '<p>Alpha footer html</p>',
+    })
+    .returning({ id: maps.id });
+  const [mapB] = await db
+    .insert(maps)
+    .values({
+      name: 'Beta Map',
+      geoguessrId: 'map-b',
+      mapGroupId: groupB!.id,
+      authors: 'Author B',
+      footerHtml: '<p>Beta footer html</p>',
+    })
+    .returning({ id: maps.id });
+
+  await db.insert(syncedMetas).values([
+    {
+      metaId: 1001,
+      mapGroupId: groupA!.id,
+      name: 'Alpha Meta',
+      note: 'Alpha note',
+      noteFromPlonkit: false,
+      footer: 'Alpha footer',
+      images: ['a1.jpg', 'a2.jpg'],
+    },
+    {
+      metaId: 2002,
+      mapGroupId: groupB!.id,
+      name: 'Beta Meta',
+      note: 'Beta note',
+      noteFromPlonkit: true,
+      footer: 'Beta footer',
+      images: ['b1.jpg'],
+    },
+  ]);
+
+  await db.insert(syncedMapMetas).values([
+    { mapId: mapA!.id, syncedMetaId: 1001 },
+    { mapId: mapB!.id, syncedMetaId: 2002 },
+  ]);
+
+  const sharedPano = {
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+  };
+  await db.insert(syncedLocations).values([
+    {
+      ...sharedPano,
+      syncedMetaId: 1001,
+      panoId: 'pano-shared',
+      country: 'Czechia',
+      extraTag: 'tag-a',
+    },
+    {
+      ...sharedPano,
+      syncedMetaId: 2002,
+      panoId: 'pano-shared',
+      country: 'France',
+      extraTag: 'tag-b',
+    },
+    {
+      ...sharedPano,
+      syncedMetaId: 1001,
+      panoId: 'pano-a-only',
+      country: 'Germany',
+      extraTag: 'tag-a',
+    },
+    {
+      ...sharedPano,
+      syncedMetaId: 2002,
+      panoId: 'pano-b-only',
+      country: 'Spain',
+      extraTag: 'tag-b',
+    },
+  ]);
+
+  return { mapAId: mapA!.id, mapBId: mapB!.id };
+}
+
+// personal map borrowing a meta from multiple nonpersonal maps: attribution
+// must come from the most-played nonpersonal original, with deterministic
+// tie-break (lower original map id) for equal play counts
+async function seedPersonalMapAttribution() {
+  const [personalMap] = await db
+    .insert(maps)
+    .values({
+      name: 'Personal Map',
+      geoguessrId: 'map-personal',
+      isPersonal: true,
+      mapGroupId: null,
+      authors: 'Personal Author',
+      footerHtml: '<p>Personal footer html</p>',
+    })
+    .returning({ id: maps.id });
+
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Shared Group' })
+    .returning({ id: mapGroups.id });
+
+  async function insertNonpersonalMap(
+    name: string,
+    geoguessrId: string,
+    numberOfGamesPlayed: number,
+  ) {
+    const [map] = await db
+      .insert(maps)
+      .values({
+        name,
+        geoguessrId,
+        mapGroupId: group!.id,
+        isPersonal: false,
+        authors: `${name} Author`,
+        footerHtml: `<p>${name} footer html</p>`,
+        numberOfGamesPlayed,
+      })
+      .returning({ id: maps.id });
+    return map!.id;
+  }
+
+  // insertion order fixes ids so the tie-break expectation is well-defined
+  const lowPlayId = await insertNonpersonalMap('Low Play Map', 'map-low', 10);
+  const highPlayId = await insertNonpersonalMap(
+    'High Play Map',
+    'map-high',
+    1000,
+  );
+  const tieFirstId = await insertNonpersonalMap(
+    'Tie First Map',
+    'map-tie-first',
+    500,
+  );
+  const tieSecondId = await insertNonpersonalMap(
+    'Tie Second Map',
+    'map-tie-second',
+    500,
+  );
+
+  await db.insert(syncedMetas).values([
+    {
+      metaId: 3003,
+      mapGroupId: group!.id,
+      name: 'Shared Meta',
+      note: 'Shared note',
+      noteFromPlonkit: false,
+      footer: 'Shared footer',
+      images: ['shared.jpg'],
+    },
+    {
+      metaId: 4004,
+      mapGroupId: group!.id,
+      name: 'Tie Meta',
+      note: 'Tie note',
+      noteFromPlonkit: false,
+      footer: 'Tie footer',
+      images: ['tie.jpg'],
+    },
+  ]);
+
+  await db.insert(syncedMapMetas).values([
+    // meta 3003 shared with a low-play and a high-play nonpersonal map
+    { mapId: personalMap!.id, syncedMetaId: 3003 },
+    { mapId: lowPlayId, syncedMetaId: 3003 },
+    { mapId: highPlayId, syncedMetaId: 3003 },
+    // meta 4004 shared with two nonpersonal maps of equal play count
+    { mapId: personalMap!.id, syncedMetaId: 4004 },
+    { mapId: tieFirstId, syncedMetaId: 4004 },
+    { mapId: tieSecondId, syncedMetaId: 4004 },
+  ]);
+
+  const sharedPano = {
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+  };
+  await db.insert(syncedLocations).values([
+    {
+      ...sharedPano,
+      syncedMetaId: 3003,
+      panoId: 'pano-personal-shared',
+      country: 'Italy',
+      extraTag: 'tag-shared',
+    },
+    {
+      ...sharedPano,
+      syncedMetaId: 4004,
+      panoId: 'pano-personal-tie',
+      country: 'Italy',
+      extraTag: 'tag-tie',
+    },
+  ]);
+
+  return { personalMapId: personalMap!.id, tieFirstId, tieSecondId };
+}
+
+describe('userscript location lookup', () => {
+  test('exact map+pano lookup returns the selected public fields', async () => {
+    await seedTwoMaps();
+
+    const [result] = await locationSelect.execute({
+      mapId: 'map-a',
+      panoId: 'pano-shared',
+    });
+
+    expect(result).toEqual({
+      name: 'Alpha Meta',
+      note: 'Alpha note',
+      footer: 'Alpha footer',
+      images: ['a1.jpg', 'a2.jpg'],
+      noteFromPlonkit: false,
+      country: 'Czechia',
+      isPersonalMap: false,
+      mapFooter: '<p>Alpha footer html</p>',
+      // original-map attribution only applies to personal maps, so these are null
+      mapName: null,
+      mapAuthors: null,
+      mapGeoguessrId: null,
+      mapId: expect.any(Number),
+      syncedMetaId: 1001,
+    });
+  });
+
+  test('same pano in another map/group does not leak across maps', async () => {
+    const { mapAId, mapBId } = await seedTwoMaps();
+
+    const [alphaLookup] = await locationSelect.execute({
+      mapId: 'map-a',
+      panoId: 'pano-shared',
+    });
+    expect(alphaLookup).toEqual(
+      expect.objectContaining({
+        name: 'Alpha Meta',
+        note: 'Alpha note',
+        country: 'Czechia',
+        mapId: mapAId,
+        syncedMetaId: 1001,
+      }),
+    );
+
+    const [betaLookup] = await locationSelect.execute({
+      mapId: 'map-b',
+      panoId: 'pano-shared',
+    });
+    expect(betaLookup).toEqual(
+      expect.objectContaining({
+        name: 'Beta Meta',
+        note: 'Beta note',
+        country: 'France',
+        noteFromPlonkit: true,
+        mapId: mapBId,
+        syncedMetaId: 2002,
+      }),
+    );
+
+    // a pano that exists only in the other map is invisible under this map
+    expect(
+      await locationSelect.execute({ mapId: 'map-a', panoId: 'pano-b-only' }),
+    ).toEqual([]);
+    expect(
+      await locationSelect.execute({ mapId: 'map-b', panoId: 'pano-a-only' }),
+    ).toEqual([]);
+  });
+
+  test('personal map selects highest-played nonpersonal original attribution with deterministic tie-break', async () => {
+    const { tieFirstId, tieSecondId } = await seedPersonalMapAttribution();
+
+    // highest-played nonpersonal map wins
+    const [highest] = await locationSelect.execute({
+      mapId: 'map-personal',
+      panoId: 'pano-personal-shared',
+    });
+    expect(highest).toEqual(
+      expect.objectContaining({
+        name: 'Shared Meta',
+        isPersonalMap: true,
+        mapName: 'High Play Map',
+        mapAuthors: 'High Play Map Author',
+        mapGeoguessrId: 'map-high',
+        mapFooter: '<p>High Play Map footer html</p>',
+      }),
+    );
+
+    // equal play counts resolve deterministically to the lower original id
+    expect(tieFirstId).toBeLessThan(tieSecondId);
+    const [tie] = await locationSelect.execute({
+      mapId: 'map-personal',
+      panoId: 'pano-personal-tie',
+    });
+    expect(tie).toEqual(
+      expect.objectContaining({
+        name: 'Tie Meta',
+        isPersonalMap: true,
+        mapName: 'Tie First Map',
+        mapAuthors: 'Tie First Map Author',
+        mapGeoguessrId: 'map-tie-first',
+        mapFooter: '<p>Tie First Map footer html</p>',
+      }),
+    );
+  });
+});

--- a/apps/api/src/routes/internal/map-groups-delete.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups-delete.db.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { app } from '../../api';
+import {
+  levels,
+  mapGroupChanges,
+  mapGroupLocations,
+  mapGroupPermissions,
+  mapGroups,
+  maps,
+  metas,
+  syncedMetas,
+  users,
+} from '../../lib/db/schema';
+import { db } from '../../lib/drizzle';
+
+function deleteGroupRequest(userId: string, groupId: number) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/map-groups/${groupId}`, {
+      method: 'DELETE',
+      headers: { 'x-api-user-id': userId },
+    }),
+  );
+}
+
+async function seedUser(id: string) {
+  await db.insert(users).values({ id, username: id });
+}
+
+async function seedGroup(name: string, ownerId: string) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name })
+    .returning({ id: mapGroups.id });
+  const groupId = group!.id;
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId: ownerId,
+    role: 'owner',
+  });
+  return groupId;
+}
+
+async function seedMember(groupId: number, userId: string) {
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId,
+    role: 'editor',
+  });
+}
+
+// Representative owned relations; deeper child-table cascades are covered by
+// the schema invariant suite.
+async function seedOwnedData(
+  groupId: number,
+  userId: string,
+  suffix: string,
+): Promise<void> {
+  const [level] = await db
+    .insert(levels)
+    .values({ mapGroupId: groupId, name: `Level ${suffix}` })
+    .returning({ id: levels.id });
+  const levelId = level!.id;
+
+  const [meta] = await db
+    .insert(metas)
+    .values({
+      mapGroupId: groupId,
+      tagName: `tag-${suffix}`,
+      name: `Meta ${suffix}`,
+      note: `note ${suffix}`,
+      modifiedAt: 100,
+    })
+    .returning({ id: metas.id });
+  const metaId = meta!.id;
+
+  await db.insert(maps).values({
+    mapGroupId: groupId,
+    name: `Map ${suffix}`,
+    geoguessrId: `geoguessr-${suffix}`,
+  });
+
+  await db.insert(mapGroupLocations).values({
+    mapGroupId: groupId,
+    panoId: `pano-${suffix}`,
+    extraTag: `tag-${suffix}`,
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+    updatedAt: 100,
+  });
+
+  await db.insert(syncedMetas).values({
+    metaId,
+    mapGroupId: groupId,
+    name: `Synced ${suffix}`,
+    note: `note ${suffix}`,
+    noteFromPlonkit: false,
+    footer: '',
+    images: [],
+  });
+  await db.insert(mapGroupChanges).values({
+    mapGroupId: groupId,
+    userId,
+    entityType: 'level',
+    entityId: levelId,
+    entityLabel: `Level ${suffix}`,
+    operation: 'create',
+    newValue: { name: `Level ${suffix}` },
+    createdAt: 100,
+  });
+  await db.insert(mapGroupChanges).values({
+    mapGroupId: groupId,
+    userId,
+    entityType: 'sync',
+    entityId: groupId,
+    entityLabel: 'changes published',
+    operation: 'update',
+    createdAt: 200,
+  });
+}
+
+async function ownedSnapshot(groupId: number) {
+  return {
+    group: await db.select().from(mapGroups).where(eq(mapGroups.id, groupId)),
+    levels: await db
+      .select()
+      .from(levels)
+      .where(eq(levels.mapGroupId, groupId)),
+    metas: await db.select().from(metas).where(eq(metas.mapGroupId, groupId)),
+    maps: await db.select().from(maps).where(eq(maps.mapGroupId, groupId)),
+    locations: await db
+      .select()
+      .from(mapGroupLocations)
+      .where(eq(mapGroupLocations.mapGroupId, groupId)),
+    permissions: await db
+      .select()
+      .from(mapGroupPermissions)
+      .where(eq(mapGroupPermissions.mapGroupId, groupId)),
+    syncedMetas: await db
+      .select()
+      .from(syncedMetas)
+      .where(eq(syncedMetas.mapGroupId, groupId)),
+    changes: await db
+      .select()
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId)),
+  };
+}
+
+describe('DELETE /api/internal/map-groups/:id', () => {
+  test('owner delete returns 200, cascades owned data, and preserves an unrelated group', async () => {
+    await seedUser('del-owner-1');
+    await seedUser('del-editor-1');
+    const groupId = await seedGroup('Doomed group', 'del-owner-1');
+    await seedMember(groupId, 'del-editor-1');
+    await seedOwnedData(groupId, 'del-owner-1', 'doomed');
+
+    const survivorGroupId = await seedGroup('Survivor group', 'del-owner-1');
+    await seedOwnedData(survivorGroupId, 'del-owner-1', 'survivor');
+    const survivorBefore = await ownedSnapshot(survivorGroupId);
+    expect(survivorBefore.group).toHaveLength(1);
+
+    const response = await deleteGroupRequest('del-owner-1', groupId);
+
+    expect(response.status).toBe(200);
+    // every owned relation is cascaded away, including permissions, synced
+    // rows, and audit entries
+    expect(await ownedSnapshot(groupId)).toEqual({
+      group: [],
+      levels: [],
+      metas: [],
+      maps: [],
+      locations: [],
+      permissions: [],
+      syncedMetas: [],
+      changes: [],
+    });
+    // the unrelated group and all of its data are untouched
+    expect(await ownedSnapshot(survivorGroupId)).toEqual(survivorBefore);
+  });
+
+  test('editor delete is denied and leaves every owned row unchanged', async () => {
+    await seedUser('del-owner-2');
+    await seedUser('del-editor-2');
+    const groupId = await seedGroup('Editor protected group', 'del-owner-2');
+    await seedMember(groupId, 'del-editor-2');
+    await seedOwnedData(groupId, 'del-owner-2', 'editor');
+
+    const before = await ownedSnapshot(groupId);
+    expect(before.group).toHaveLength(1);
+
+    const response = await deleteGroupRequest('del-editor-2', groupId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual([
+      "You don't have permissions for this",
+    ]);
+    expect(await ownedSnapshot(groupId)).toEqual(before);
+  });
+});

--- a/apps/api/src/routes/internal/map-groups-delete.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups-delete.db.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
-import { app } from '../../api';
+import { app } from '@api/api';
 import {
   levels,
   mapGroupChanges,
@@ -11,8 +10,9 @@ import {
   metas,
   syncedMetas,
   users,
-} from '../../lib/db/schema';
-import { db } from '../../lib/drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { eq } from 'drizzle-orm';
 
 function deleteGroupRequest(userId: string, groupId: number) {
   return app.handle(

--- a/apps/api/src/routes/internal/map-groups-errors.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups-errors.db.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { app } from '../../api';
-import { mapGroups, users } from '../../lib/db/schema';
-import { db } from '../../lib/drizzle';
+import { app } from '@api/api';
+import { mapGroups, users } from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
 
 const syncedAt = 1700000000;
 

--- a/apps/api/src/routes/internal/map-groups-errors.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups-errors.db.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { app } from '../../api';
+import { mapGroups, users } from '../../lib/db/schema';
+import { db } from '../../lib/drizzle';
+
+const syncedAt = 1700000000;
+
+// int32 max: tests resequence ids from 1 (TRUNCATE ... RESTART IDENTITY), so
+// no seeded group can ever reach this id - guaranteed missing within the file
+const MISSING_GROUP_ID = 2_147_483_647;
+
+async function seedUser(id: string, isSuperadmin = false) {
+  await db.insert(users).values({ id, username: id, isSuperadmin });
+}
+
+function groupRequest(userId: string, groupId: number) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/map-groups/${groupId}`, {
+      method: 'GET',
+      headers: { 'x-api-user-id': userId },
+    }),
+  );
+}
+
+describe('missing map-group response contract', () => {
+  // Current behavior on a nonexistent group id: the handler gates on
+  // ensurePermissions before any existence check. A plain user without a
+  // permission row is rejected by the permission error catcher - 403 with
+  // ["You don't have permissions for this"] - while a superadmin, treated as
+  // implicit owner by getGroupRole, passes the guard, hits the existence
+  // check, and gets the bare 404. The missing-group contract thus diverges by
+  // caller role (auth-before-existence).
+  // Desired contract: a missing group is role-independent - the canonical bare
+  // 404 for every caller. 403 keeps its meaning of "group exists but you have
+  // no access" (verified by the control group below).
+  test.todo('missing group yields the same bare 404 for ordinary user and superadmin', async () => {
+    await seedUser('missing-regular');
+    await seedUser('missing-admin', true);
+
+    const [regular, admin] = await Promise.all([
+      groupRequest('missing-regular', MISSING_GROUP_ID),
+      groupRequest('missing-admin', MISSING_GROUP_ID),
+    ]);
+
+    expect(regular.status).toBe(404);
+    expect(admin.status).toBe(404);
+    // both are the bare status(404): identical "Not Found" body
+    expect(await regular.text()).toBe('Not Found');
+    expect(await admin.text()).toBe('Not Found');
+
+    // control: with a real group, role semantics stay intact so 404 keeps
+    // meaning "missing" instead of masking authorization
+    const [group] = await db
+      .insert(mapGroups)
+      .values({
+        name: 'Contract control',
+        syncedAt,
+        syncIncludeLocationsNotOnStreetView: true,
+      })
+      .returning({ id: mapGroups.id });
+    const [denied, allowed] = await Promise.all([
+      groupRequest('missing-regular', group!.id),
+      groupRequest('missing-admin', group!.id),
+    ]);
+    expect(denied.status).toBe(403);
+    expect(allowed.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/internal/map-groups-upload-batches.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups-upload-batches.db.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
-import { app } from '../../api';
+import { app } from '@api/api';
 import {
   mapGroupChanges,
   mapGroupLocations,
@@ -8,8 +7,9 @@ import {
   mapGroups,
   metas,
   users,
-} from '../../lib/db/schema';
-import { db } from '../../lib/drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { eq } from 'drizzle-orm';
 
 // The upload handler chunks its upsert into BATCH_SIZE = 1000-row INSERT
 // statements. A duplicate split across statements never triggers PostgreSQL's

--- a/apps/api/src/routes/internal/map-groups-upload-batches.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups-upload-batches.db.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { app } from '../../api';
+import {
+  mapGroupChanges,
+  mapGroupLocations,
+  mapGroupPermissions,
+  mapGroups,
+  metas,
+  users,
+} from '../../lib/db/schema';
+import { db } from '../../lib/drizzle';
+
+// The upload handler chunks its upsert into BATCH_SIZE = 1000-row INSERT
+// statements. A duplicate split across statements never triggers PostgreSQL's
+// same-statement cardinality violation: the later batch silently updates the
+// row inserted by the earlier batch.
+const BATCH_SIZE = 1000;
+const DUPLICATE_MESSAGE =
+  'The uploaded file contains duplicate panoId values. Please remove duplicates and try again.';
+
+function uploadRequest(userId: string, groupId: number, body: unknown) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/map-groups/${groupId}/locations/upload`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-user-id': userId,
+        },
+        body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+async function seedOwnerGroup(userId: string, name: string) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name })
+    .returning({ id: mapGroups.id });
+  const groupId = group!.id;
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId,
+    role: 'owner',
+  });
+  return groupId;
+}
+
+// minimal body accepted by the upload schema
+function locationBody(panoId: string) {
+  return {
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+    panoId,
+    extraTag: 'tag-a',
+    extraPanoId: null,
+  };
+}
+
+function distinctLocations(count: number) {
+  return Array.from({ length: count }, (_, i) => locationBody(`pano-${i}`));
+}
+
+async function groupState(groupId: number) {
+  return {
+    locations: await db
+      .select({
+        panoId: mapGroupLocations.panoId,
+        extraTag: mapGroupLocations.extraTag,
+      })
+      .from(mapGroupLocations)
+      .where(eq(mapGroupLocations.mapGroupId, groupId))
+      .orderBy(mapGroupLocations.panoId),
+    metas: await db
+      .select({ tagName: metas.tagName })
+      .from(metas)
+      .where(eq(metas.mapGroupId, groupId))
+      .orderBy(metas.tagName),
+    changes: await db
+      .select({
+        entityType: mapGroupChanges.entityType,
+        entityId: mapGroupChanges.entityId,
+        entityLabel: mapGroupChanges.entityLabel,
+        operation: mapGroupChanges.operation,
+      })
+      .from(mapGroupChanges)
+      .where(eq(mapGroupChanges.mapGroupId, groupId))
+      .orderBy(mapGroupChanges.id),
+  };
+}
+
+describe('POST /api/internal/map-groups/:id/locations/upload duplicate panos across 1000-row batches', () => {
+  // todo: the handler runs each 1000-row chunk as its own INSERT statement, so
+  // a duplicate straddling the boundary (last row of batch 0, first row of
+  // batch 1) never collides inside one statement. Batch 1's ON CONFLICT DO
+  // UPDATE silently overwrites the row batch 0 inserted and the whole
+  // transaction commits. Observed instead of the 409: a 200 with count 1001 /
+  // conflictCount 0, a single merged pano-dup row, a created tag-a meta, and
+  // a location_batch change entry. Cross-batch duplicates should surface as
+  // the same 409 and roll back every batch atomically.
+  test.todo('rejects a duplicate pano split across the 1000-row batch boundary with 409 and leaves the group untouched', async () => {
+    const userId = 'batch-cross-owner';
+    await db.insert(users).values({ id: userId, username: userId });
+    const groupId = await seedOwnerGroup(userId, 'Cross-batch duplicate');
+
+    // batch 0 = indices 0..999, batch 1 = index 1000; pano-dup sits on both
+    // sides of the production chunk boundary
+    const locations = distinctLocations(BATCH_SIZE);
+    locations[BATCH_SIZE - 1] = locationBody('pano-dup');
+    locations.push(locationBody('pano-dup'));
+    expect(locations).toHaveLength(BATCH_SIZE + 1);
+
+    const response = await uploadRequest(userId, groupId, {
+      uploadMode: 'partial',
+      locations,
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ message: DUPLICATE_MESSAGE });
+    // atomic: no row, no meta, and no change-log entry survive the rollback
+    expect(await groupState(groupId)).toEqual({
+      locations: [],
+      metas: [],
+      changes: [],
+    });
+  });
+});

--- a/apps/api/src/routes/internal/map-groups.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups.db.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { and, eq, inArray } from 'drizzle-orm';
-import { app } from '../../api';
+import { app } from '@api/api';
 import {
   mapGroupChanges,
   mapGroupLocations,
@@ -12,8 +11,9 @@ import {
   syncedMapMetas,
   syncedMetas,
   users,
-} from '../../lib/db/schema';
-import { db } from '../../lib/drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { and, eq, inArray } from 'drizzle-orm';
 
 const syncedAt = 1700000000;
 

--- a/apps/api/src/routes/internal/map-groups.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups.db.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import { app } from '../../api';
+import {
+  mapGroupChanges,
+  mapGroupPermissions,
+  mapGroups,
+  users,
+} from '../../lib/db/schema';
+import { db } from '../../lib/drizzle';
+
+const syncedAt = 1700000000;
+
+async function seedUser(id: string) {
+  await db.insert(users).values({ id, username: id });
+}
+
+async function seedOwnerGroup(
+  userId: string,
+  name: string,
+  settings: {
+    syncedAt: number | null;
+    syncIncludeLocationsNotOnStreetView: boolean;
+  },
+) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name, ...settings })
+    .returning({ id: mapGroups.id });
+  const groupId = group!.id;
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId,
+    role: 'owner',
+  });
+  return groupId;
+}
+
+async function getGroup(groupId: number) {
+  const [row] = await db
+    .select({
+      syncedAt: mapGroups.syncedAt,
+      syncIncludeLocationsNotOnStreetView:
+        mapGroups.syncIncludeLocationsNotOnStreetView,
+    })
+    .from(mapGroups)
+    .where(eq(mapGroups.id, groupId));
+  return row!;
+}
+
+async function getSettingsLogs(groupId: number) {
+  return db
+    .select({
+      mapGroupId: mapGroupChanges.mapGroupId,
+      userId: mapGroupChanges.userId,
+      entityType: mapGroupChanges.entityType,
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      oldValue: mapGroupChanges.oldValue,
+      newValue: mapGroupChanges.newValue,
+      createdAt: mapGroupChanges.createdAt,
+    })
+    .from(mapGroupChanges)
+    .where(
+      and(
+        eq(mapGroupChanges.mapGroupId, groupId),
+        eq(mapGroupChanges.entityType, 'settings'),
+      ),
+    )
+    .orderBy(mapGroupChanges.id);
+}
+
+function settingsRequest(userId: string, groupId: number, body: unknown) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/map-groups/${groupId}/settings`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-user-id': userId,
+        },
+        body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+describe('POST /api/internal/map-groups/:id/settings', () => {
+  test('no-op save preserves syncedAt and adds no audit log', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedOwnerGroup('owner-1', 'No-op group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const response = await settingsRequest('owner-1', groupId, {
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    expect(response.status).toBe(200);
+    // identical value: row untouched, sync state intact
+    expect(await getGroup(groupId)).toEqual({
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    expect(await getSettingsLogs(groupId)).toEqual([]);
+  });
+
+  test('changed explicit false persists, resets syncedAt, and writes exact log', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedOwnerGroup('owner-1', 'False transition', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const response = await settingsRequest('owner-1', groupId, {
+      syncIncludeLocationsNotOnStreetView: false,
+    });
+
+    expect(response.status).toBe(200);
+    // explicit false is a real value, not an omission marker
+    expect(await getGroup(groupId)).toEqual({
+      syncedAt: null,
+      syncIncludeLocationsNotOnStreetView: false,
+    });
+    expect(await getSettingsLogs(groupId)).toEqual([
+      {
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'settings',
+        entityId: groupId,
+        entityLabel: null,
+        operation: 'update',
+        oldValue: { syncIncludeLocationsNotOnStreetView: true },
+        newValue: { syncIncludeLocationsNotOnStreetView: false },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  test('changed explicit true persists, resets syncedAt, and writes exact log', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedOwnerGroup('owner-1', 'True transition', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: false,
+    });
+
+    const response = await settingsRequest('owner-1', groupId, {
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await getGroup(groupId)).toEqual({
+      syncedAt: null,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    expect(await getSettingsLogs(groupId)).toEqual([
+      {
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'settings',
+        entityId: groupId,
+        entityLabel: null,
+        operation: 'update',
+        oldValue: { syncIncludeLocationsNotOnStreetView: false },
+        newValue: { syncIncludeLocationsNotOnStreetView: true },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+});

--- a/apps/api/src/routes/internal/map-groups.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups.db.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { app } from '../../api';
 import {
   mapGroupChanges,
@@ -181,6 +181,40 @@ function deletePermissionRequest(
       },
     ),
   );
+}
+
+// number of sessions blocked waiting on the group's permission-row FOR UPDATE
+// lock, i.e. transactions stuck in the last-owner guard
+async function blockedLockWaiterCount() {
+  const rows = await db.$primary.$client`
+    SELECT count(*)::int AS blocked
+    FROM pg_stat_activity
+    WHERE datname = current_database()
+      AND state = 'active'
+      AND wait_event_type = 'Lock'
+      AND query ILIKE '%map_group_permissions%'
+      AND query ILIKE '%for update%'
+      AND pid <> pg_backend_pid()
+  `;
+  return Number(rows[0]?.blocked ?? 0);
+}
+
+// condition polling (event-loop yields only, no fixed sleeps) until the given
+// number of transactions are blocked on the last-owner lock
+async function waitForBlockedLockWaiters(count: number, deadlineMs = 10_000) {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    const blocked = await blockedLockWaiterCount();
+    if (blocked >= count) {
+      return;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `timed out after ${deadlineMs}ms waiting for ${count} permission transactions to block on the last-owner lock (blocked=${blocked})`,
+      );
+    }
+    await Bun.sleep(0);
+  }
 }
 
 function locationUploadRequest(userId: string, groupId: number, body: unknown) {
@@ -546,6 +580,92 @@ describe('permission management', () => {
   });
 });
 
+describe('concurrent last-owner demotion and removal', () => {
+  test('racing DELETE and PATCH demote cannot leave a group ownerless', async () => {
+    await seedUser('race-admin', true);
+    await seedUser('race-owner-a');
+    await seedUser('race-owner-b');
+    const groupId = await seedOwnerGroup('race-owner-a', 'Race group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedMember(groupId, 'race-owner-b', 'owner');
+    const ownerA = (await getPermission(groupId, 'race-owner-a'))!;
+    const ownerB = (await getPermission(groupId, 'race-owner-b'))!;
+
+    // hold the group's permission-row locks so both requests' guard
+    // transactions are guaranteed to be in flight before either can commit
+    let lockAcquired!: () => void;
+    const lockAcquiredPromise = new Promise<void>((resolve) => {
+      lockAcquired = resolve;
+    });
+    let releaseLock!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const lockHolder = db.$primary.transaction(async (tx) => {
+      await tx
+        .select()
+        .from(mapGroupPermissions)
+        .where(eq(mapGroupPermissions.mapGroupId, groupId))
+        .for('update');
+      lockAcquired();
+      await gate;
+    });
+    await lockAcquiredPromise;
+
+    const requests = Promise.allSettled([
+      deletePermissionRequest('race-admin', groupId, ownerA.id),
+      updatePermissionRequest('race-admin', groupId, ownerB.id, {
+        role: 'editor',
+      }),
+    ]);
+
+    // deterministically wait until both requests are blocked on the row lock
+    await waitForBlockedLockWaiters(2);
+
+    releaseLock();
+    await lockHolder;
+
+    const results = await requests;
+    expect(results).toHaveLength(2);
+    const statuses = results
+      .map((result) =>
+        result.status === 'fulfilled' ? result.value.status : -1,
+      )
+      .sort();
+    // exactly one removal/demotion wins; the loser is rejected by the
+    // last-owner guard regardless of which request wins
+    expect(statuses).toEqual([200, 400]);
+    const deleteWon =
+      results[0].status === 'fulfilled' && results[0].value.status === 200;
+    const losers = results.filter(
+      (result) => result.status === 'fulfilled' && result.value.status === 400,
+    );
+    expect(losers).toHaveLength(1);
+    const loser = losers[0] as PromiseFulfilledResult<Response>;
+    expect(await loser.value.json()).toEqual({
+      field: 'permissionId',
+      message: 'A group must keep at least one owner',
+    });
+
+    // final invariant: exactly one owner survives, and the non-surviving
+    // owner is either removed (delete won) or demoted to editor (demote won)
+    const finalPermissions = await permissionSnapshot(groupId);
+    const owners = finalPermissions.filter((p) => p.role === 'owner');
+    expect(owners).toHaveLength(1);
+    if (deleteWon) {
+      expect(owners[0].userId).toBe('race-owner-b');
+      expect(await getPermission(groupId, 'race-owner-a')).toBeUndefined();
+    } else {
+      expect(owners[0].userId).toBe('race-owner-a');
+      expect(await getPermission(groupId, 'race-owner-b')).toEqual(
+        expect.objectContaining({ role: 'editor' }),
+      );
+    }
+  });
+});
+
 describe('location upload deletion semantics', () => {
   test('partial upload preserves omitted rows', async () => {
     await seedUser('upload-owner-1');
@@ -597,6 +717,59 @@ describe('location upload deletion semantics', () => {
     // every row not in the upload is deleted, regardless of tag
     expect(await locationSnapshot(groupId)).toEqual([
       { panoId: 'pano-a', extraTag: 'tag-a', extraPanoId: null },
+    ]);
+  });
+
+  test('empty full upload deletes all rows; empty partial upload is a no-op', async () => {
+    await seedUser('upload-owner-4');
+    const groupId = await seedOwnerGroup('upload-owner-4', 'Empty uploads', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedLocation(groupId, 'pano-a', 'tag-a');
+    await seedLocation(groupId, 'pano-b', 'tag-b');
+    // an unrelated group's row proves deletions stay scoped to this group
+    const otherGroupId = await seedOwnerGroup(
+      'upload-owner-4',
+      'Empty upload other',
+      {
+        syncedAt,
+        syncIncludeLocationsNotOnStreetView: true,
+      },
+    );
+    await seedLocation(otherGroupId, 'pano-c', 'tag-a');
+
+    const partial = await locationUploadRequest('upload-owner-4', groupId, {
+      uploadMode: 'partial',
+      locations: [],
+    });
+    expect(partial.status).toBe(200);
+    expect(await partial.json()).toEqual({
+      count: 0,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+    // empty partial upload is a no-op: every row survives untouched
+    expect(await locationSnapshot(groupId)).toEqual([
+      { panoId: 'pano-a', extraTag: 'tag-a', extraPanoId: null },
+      { panoId: 'pano-b', extraTag: 'tag-b', extraPanoId: null },
+    ]);
+
+    const full = await locationUploadRequest('upload-owner-4', groupId, {
+      uploadMode: 'full',
+      locations: [],
+    });
+    expect(full.status).toBe(200);
+    expect(await full.json()).toEqual({
+      count: 0,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+    // empty full upload replaces the group with nothing: all rows deleted
+    expect(await locationSnapshot(groupId)).toEqual([]);
+    // the unrelated group is untouched by both uploads
+    expect(await locationSnapshot(otherGroupId)).toEqual([
+      { panoId: 'pano-c', extraTag: 'tag-a', extraPanoId: null },
     ]);
   });
 
@@ -728,6 +901,197 @@ describe('location upload editor scope and scoped semantics', () => {
       { panoId: 'pano-a', extraTag: 'tag-b', extraPanoId: null },
       { panoId: 'pano-x', extraTag: 'tag-a', extraPanoId: null },
     ]);
+  });
+});
+
+describe('location upload duplicate pano rollback', () => {
+  test('same-batch duplicate pano returns 409 and rolls back earlier upsert and delete work', async () => {
+    await seedUser('dup-owner-1');
+    const groupId = await seedOwnerGroup('dup-owner-1', 'Duplicate rollback', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    // stale updatedAt marks these as victims of the full upload's delete step
+    await seedLocation(groupId, 'dup-seed-a', 'tag-seed-a');
+    await seedLocation(groupId, 'dup-seed-b', 'tag-seed-b');
+
+    // a full batch (BATCH_SIZE = 1000) of genuine new upserts first, then the
+    // duplicate pano pair in the following batch, so the 21000 cardinality
+    // error fires only after real work happened inside the transaction
+    const locations = Array.from({ length: 1000 }, (_, i) =>
+      locationBody(`pano-batch-${i}`, 'tag-upload'),
+    );
+    locations.push(locationBody('dup-pano', 'tag-upload'));
+    locations.push(locationBody('dup-pano', 'tag-upload'));
+
+    const response = await locationUploadRequest('dup-owner-1', groupId, {
+      uploadMode: 'full',
+      locations,
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      message:
+        'The uploaded file contains duplicate panoId values. Please remove duplicates and try again.',
+    });
+    // neither the batch-1 upserts nor the full-replacement delete survived:
+    // only the seeded rows remain, untouched
+    expect(await locationSnapshot(groupId)).toEqual([
+      { panoId: 'dup-seed-a', extraTag: 'tag-seed-a', extraPanoId: null },
+      { panoId: 'dup-seed-b', extraTag: 'tag-seed-b', extraPanoId: null },
+    ]);
+    // the rolled-back upsert did not even stamp the seeded rows' timestamps
+    const remaining = await db
+      .select({
+        panoId: mapGroupLocations.panoId,
+        updatedAt: mapGroupLocations.updatedAt,
+      })
+      .from(mapGroupLocations)
+      .where(eq(mapGroupLocations.mapGroupId, groupId))
+      .orderBy(mapGroupLocations.panoId);
+    expect(remaining).toEqual([
+      { panoId: 'dup-seed-a', updatedAt: syncedAt },
+      { panoId: 'dup-seed-b', updatedAt: syncedAt },
+    ]);
+    // the auto-created meta and the location_batch/meta audit logs are gone too
+    expect(
+      await db
+        .select({ id: metas.id })
+        .from(metas)
+        .where(eq(metas.mapGroupId, groupId)),
+    ).toEqual([]);
+    expect(
+      await db
+        .select({ id: mapGroupChanges.id })
+        .from(mapGroupChanges)
+        .where(eq(mapGroupChanges.mapGroupId, groupId)),
+    ).toEqual([]);
+  });
+});
+
+async function getUploadLogs(groupId: number) {
+  return db
+    .select({
+      mapGroupId: mapGroupChanges.mapGroupId,
+      userId: mapGroupChanges.userId,
+      entityType: mapGroupChanges.entityType,
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      oldValue: mapGroupChanges.oldValue,
+      newValue: mapGroupChanges.newValue,
+      createdAt: mapGroupChanges.createdAt,
+    })
+    .from(mapGroupChanges)
+    .where(
+      and(
+        eq(mapGroupChanges.mapGroupId, groupId),
+        inArray(mapGroupChanges.entityType, ['location_batch', 'meta']),
+      ),
+    )
+    .orderBy(mapGroupChanges.id);
+}
+
+describe('location upload unscoped meta auto-creation', () => {
+  test('new tag creates an empty meta and exact audit entries; re-uploading the existing tag adds no duplicate meta or create entry', async () => {
+    await seedUser('upload-owner-5');
+    const groupId = await seedOwnerGroup('upload-owner-5', 'Unscoped new tag', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const before = Math.floor(Date.now() / 1000);
+    const response = await locationUploadRequest('upload-owner-5', groupId, {
+      uploadMode: 'partial',
+      locations: [locationBody('pano-new', 'tag-new')],
+    });
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      count: 1,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+
+    // the unseen tag is auto-created as an empty meta row
+    const [meta] = await db
+      .select()
+      .from(metas)
+      .where(and(eq(metas.mapGroupId, groupId), eq(metas.tagName, 'tag-new')));
+    expect(meta).toEqual(
+      expect.objectContaining({
+        mapGroupId: groupId,
+        tagName: 'tag-new',
+        name: '',
+        note: '',
+        noteHtml: '',
+        footer: '',
+        footerHtml: '',
+        noteFromPlonkit: false,
+        hasImage: false,
+      }),
+    );
+    expect(meta!.modifiedAt).toBeGreaterThanOrEqual(before);
+    expect(meta!.modifiedAt).toBeLessThanOrEqual(after);
+
+    // exact audit snapshot: the batch marker plus the meta create entry
+    expect(await getUploadLogs(groupId)).toEqual([
+      {
+        mapGroupId: groupId,
+        userId: 'upload-owner-5',
+        entityType: 'location_batch',
+        entityId: null,
+        entityLabel: '1 tags',
+        operation: 'update',
+        oldValue: null,
+        newValue: {
+          uploadMode: 'partial',
+          count: 1,
+          deletedCount: 0,
+          ignoredCount: 0,
+          conflictCount: 0,
+          tags: ['tag-new'],
+        },
+        createdAt: expect.any(Number),
+      },
+      {
+        mapGroupId: groupId,
+        userId: 'upload-owner-5',
+        entityType: 'meta',
+        entityId: meta!.id,
+        entityLabel: 'tag-new',
+        operation: 'create',
+        oldValue: null,
+        newValue: { tagName: 'tag-new', createdByLocationUpload: true },
+        createdAt: expect.any(Number),
+      },
+    ]);
+
+    // existing-tag distinction: re-uploading the same tag only upserts
+    // locations; no second meta row and no second meta create entry
+    const second = await locationUploadRequest('upload-owner-5', groupId, {
+      uploadMode: 'partial',
+      locations: [locationBody('pano-new-2', 'tag-new')],
+    });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({
+      count: 1,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+
+    expect(
+      await db
+        .select({ id: metas.id })
+        .from(metas)
+        .where(eq(metas.mapGroupId, groupId)),
+    ).toHaveLength(1);
+    // the create entry stays the only meta entry; the second upload only
+    // appends its own location_batch marker
+    const logs = await getUploadLogs(groupId);
+    expect(logs.filter((log) => log.entityType === 'meta')).toHaveLength(1);
+    expect(logs).toHaveLength(3);
   });
 });
 

--- a/apps/api/src/routes/internal/map-groups.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups.db.test.ts
@@ -3,16 +3,59 @@ import { and, eq } from 'drizzle-orm';
 import { app } from '../../api';
 import {
   mapGroupChanges,
+  mapGroupLocations,
   mapGroupPermissions,
   mapGroups,
+  maps,
+  metas,
+  syncedLocations,
+  syncedMapMetas,
+  syncedMetas,
   users,
 } from '../../lib/db/schema';
 import { db } from '../../lib/drizzle';
 
 const syncedAt = 1700000000;
 
-async function seedUser(id: string) {
-  await db.insert(users).values({ id, username: id });
+async function seedUser(id: string, isSuperadmin = false) {
+  await db.insert(users).values({ id, username: id, isSuperadmin });
+}
+
+async function seedMember(
+  groupId: number,
+  userId: string,
+  role: 'owner' | 'editor' = 'editor',
+) {
+  const [permission] = await db
+    .insert(mapGroupPermissions)
+    .values({ mapGroupId: groupId, userId, role })
+    .returning({ id: mapGroupPermissions.id });
+  return permission!.id;
+}
+
+async function getPermission(groupId: number, userId: string) {
+  const [row] = await db
+    .select()
+    .from(mapGroupPermissions)
+    .where(
+      and(
+        eq(mapGroupPermissions.mapGroupId, groupId),
+        eq(mapGroupPermissions.userId, userId),
+      ),
+    );
+  return row;
+}
+
+async function permissionSnapshot(groupId: number) {
+  return db
+    .select({
+      id: mapGroupPermissions.id,
+      userId: mapGroupPermissions.userId,
+      role: mapGroupPermissions.role,
+    })
+    .from(mapGroupPermissions)
+    .where(eq(mapGroupPermissions.mapGroupId, groupId))
+    .orderBy(mapGroupPermissions.id);
 }
 
 async function seedOwnerGroup(
@@ -85,6 +128,116 @@ function settingsRequest(userId: string, groupId: number, body: unknown) {
       },
     ),
   );
+}
+
+function addPermissionRequest(userId: string, groupId: number, body: unknown) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/map-groups/${groupId}/permissions`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-user-id': userId,
+        },
+        body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+function updatePermissionRequest(
+  userId: string,
+  groupId: number,
+  permissionId: number,
+  body: unknown,
+) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/map-groups/${groupId}/permissions/${permissionId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-user-id': userId,
+        },
+        body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+function deletePermissionRequest(
+  userId: string,
+  groupId: number,
+  permissionId: number,
+) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/map-groups/${groupId}/permissions/${permissionId}`,
+      {
+        method: 'DELETE',
+        headers: { 'x-api-user-id': userId },
+      },
+    ),
+  );
+}
+
+function locationUploadRequest(userId: string, groupId: number, body: unknown) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/map-groups/${groupId}/locations/upload`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-user-id': userId,
+        },
+        body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+// seeded before an upload so the row is not part of the current batch and its
+// stale updatedAt exposes it to full/tagReplace deletion
+async function seedLocation(groupId: number, panoId: string, extraTag: string) {
+  await db.insert(mapGroupLocations).values({
+    mapGroupId: groupId,
+    panoId,
+    extraTag,
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+    updatedAt: syncedAt,
+  });
+}
+
+function locationBody(panoId: string, extraTag: string) {
+  return {
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+    panoId,
+    extraTag,
+    extraPanoId: null,
+  };
+}
+
+async function locationSnapshot(groupId: number) {
+  return db
+    .select({
+      panoId: mapGroupLocations.panoId,
+      extraTag: mapGroupLocations.extraTag,
+      extraPanoId: mapGroupLocations.extraPanoId,
+    })
+    .from(mapGroupLocations)
+    .where(eq(mapGroupLocations.mapGroupId, groupId))
+    .orderBy(mapGroupLocations.panoId);
 }
 
 describe('POST /api/internal/map-groups/:id/settings', () => {
@@ -169,5 +322,575 @@ describe('POST /api/internal/map-groups/:id/settings', () => {
         createdAt: expect.any(Number),
       },
     ]);
+  });
+});
+
+describe('permission management', () => {
+  test('POST adds a member with the default editor role', async () => {
+    await seedUser('perm-owner-1');
+    await seedUser('perm-member-1');
+    const groupId = await seedOwnerGroup('perm-owner-1', 'Add default group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const response = await addPermissionRequest('perm-owner-1', groupId, {
+      username: 'perm-member-1',
+    });
+
+    expect(response.status).toBe(200);
+    // role is optional on the request and defaults to editor
+    expect(await getPermission(groupId, 'perm-member-1')).toEqual(
+      expect.objectContaining({ userId: 'perm-member-1', role: 'editor' }),
+    );
+  });
+
+  test('PATCH promotes an editor to owner', async () => {
+    await seedUser('perm-owner-6');
+    await seedUser('perm-editor-6');
+    const groupId = await seedOwnerGroup('perm-owner-6', 'Promote group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedMember(groupId, 'perm-editor-6');
+
+    const response = await updatePermissionRequest(
+      'perm-owner-6',
+      groupId,
+      (await getPermission(groupId, 'perm-editor-6'))!.id,
+      { role: 'owner' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await getPermission(groupId, 'perm-editor-6')).toEqual(
+      expect.objectContaining({ userId: 'perm-editor-6', role: 'owner' }),
+    );
+  });
+
+  test('PATCH rejects changing your own role', async () => {
+    await seedUser('perm-owner-7');
+    const groupId = await seedOwnerGroup('perm-owner-7', 'Self-change group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const before = await permissionSnapshot(groupId);
+    const response = await updatePermissionRequest(
+      'perm-owner-7',
+      groupId,
+      (await getPermission(groupId, 'perm-owner-7'))!.id,
+      { role: 'editor' },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      field: 'permissionId',
+      message: "Can't change your own role",
+    });
+    expect(await permissionSnapshot(groupId)).toEqual(before);
+  });
+
+  test('PATCH rejects demoting the last owner', async () => {
+    await seedUser('perm-owner-8');
+    await seedUser('perm-admin-8', true);
+    const groupId = await seedOwnerGroup('perm-owner-8', 'Last-owner group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const before = await permissionSnapshot(groupId);
+    // superadmin acts as owner without holding a permission row, so the sole
+    // owner row is the last owner and cannot be demoted
+    const response = await updatePermissionRequest(
+      'perm-admin-8',
+      groupId,
+      (await getPermission(groupId, 'perm-owner-8'))!.id,
+      { role: 'editor' },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      field: 'permissionId',
+      message: 'A group must keep at least one owner',
+    });
+    expect(await permissionSnapshot(groupId)).toEqual(before);
+  });
+
+  test('PATCH rejects a permission id belonging to another group', async () => {
+    await seedUser('perm-owner-9');
+    await seedUser('perm-foreign-9');
+    const groupId = await seedOwnerGroup('perm-owner-9', 'Own group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    const otherGroupId = await seedOwnerGroup('perm-owner-9', 'Other group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedMember(otherGroupId, 'perm-foreign-9');
+
+    const before = await permissionSnapshot(groupId);
+    const response = await updatePermissionRequest(
+      'perm-owner-9',
+      groupId,
+      (await getPermission(otherGroupId, 'perm-foreign-9'))!.id,
+      { role: 'owner' },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      field: 'permissionId',
+      message: 'Permission not found',
+    });
+    expect(await permissionSnapshot(groupId)).toEqual(before);
+    // the foreign group's permission is untouched as well
+    expect(await getPermission(otherGroupId, 'perm-foreign-9')).toEqual(
+      expect.objectContaining({ role: 'editor' }),
+    );
+  });
+
+  test('DELETE removes a member from the group', async () => {
+    await seedUser('perm-owner-11');
+    await seedUser('perm-member-11');
+    const groupId = await seedOwnerGroup('perm-owner-11', 'Delete member', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    const memberPermissionId = await seedMember(groupId, 'perm-member-11');
+
+    const response = await deletePermissionRequest(
+      'perm-owner-11',
+      groupId,
+      memberPermissionId,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await getPermission(groupId, 'perm-member-11')).toBeUndefined();
+  });
+
+  test('DELETE rejects stripping your own permissions', async () => {
+    await seedUser('perm-owner-12');
+    const groupId = await seedOwnerGroup('perm-owner-12', 'Self-strip group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const before = await permissionSnapshot(groupId);
+    const response = await deletePermissionRequest(
+      'perm-owner-12',
+      groupId,
+      (await getPermission(groupId, 'perm-owner-12'))!.id,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      field: 'permissionId',
+      message: "Can't strip your own permissions",
+    });
+    expect(await permissionSnapshot(groupId)).toEqual(before);
+  });
+
+  test('DELETE rejects removing the last owner', async () => {
+    await seedUser('perm-owner-13');
+    await seedUser('perm-admin-13', true);
+    const groupId = await seedOwnerGroup('perm-owner-13', 'Last-owner delete', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+
+    const before = await permissionSnapshot(groupId);
+    const response = await deletePermissionRequest(
+      'perm-admin-13',
+      groupId,
+      (await getPermission(groupId, 'perm-owner-13'))!.id,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      field: 'permissionId',
+      message: 'A group must keep at least one owner',
+    });
+    expect(await permissionSnapshot(groupId)).toEqual(before);
+  });
+
+  test('DELETE rejects a permission id belonging to another group', async () => {
+    await seedUser('perm-owner-14');
+    await seedUser('perm-foreign-14');
+    const groupId = await seedOwnerGroup('perm-owner-14', 'Own delete group', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    const otherGroupId = await seedOwnerGroup('perm-owner-14', 'Other delete', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    const foreignPermissionId = await seedMember(
+      otherGroupId,
+      'perm-foreign-14',
+    );
+
+    const before = await permissionSnapshot(groupId);
+    const response = await deletePermissionRequest(
+      'perm-owner-14',
+      groupId,
+      foreignPermissionId,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      field: 'permissionId',
+      message: 'Permission not found',
+    });
+    expect(await permissionSnapshot(groupId)).toEqual(before);
+    expect(await getPermission(otherGroupId, 'perm-foreign-14')).toBeDefined();
+  });
+});
+
+describe('location upload deletion semantics', () => {
+  test('partial upload preserves omitted rows', async () => {
+    await seedUser('upload-owner-1');
+    const groupId = await seedOwnerGroup('upload-owner-1', 'Partial upload', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedLocation(groupId, 'pano-a', 'tag-a');
+    await seedLocation(groupId, 'pano-b', 'tag-b');
+
+    const response = await locationUploadRequest('upload-owner-1', groupId, {
+      uploadMode: 'partial',
+      locations: [locationBody('pano-a', 'tag-a')],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      count: 1,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+    // only pano-a is upserted; the omitted pano-b row survives untouched
+    expect(await locationSnapshot(groupId)).toEqual([
+      { panoId: 'pano-a', extraTag: 'tag-a', extraPanoId: null },
+      { panoId: 'pano-b', extraTag: 'tag-b', extraPanoId: null },
+    ]);
+  });
+
+  test('full upload removes all omitted rows', async () => {
+    await seedUser('upload-owner-2');
+    const groupId = await seedOwnerGroup('upload-owner-2', 'Full upload', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedLocation(groupId, 'pano-a', 'tag-a');
+    await seedLocation(groupId, 'pano-b', 'tag-b');
+
+    const response = await locationUploadRequest('upload-owner-2', groupId, {
+      uploadMode: 'full',
+      locations: [locationBody('pano-a', 'tag-a')],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      count: 1,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+    // every row not in the upload is deleted, regardless of tag
+    expect(await locationSnapshot(groupId)).toEqual([
+      { panoId: 'pano-a', extraTag: 'tag-a', extraPanoId: null },
+    ]);
+  });
+
+  test('tagReplace upload removes only omitted rows in replaced tags', async () => {
+    await seedUser('upload-owner-3');
+    const groupId = await seedOwnerGroup('upload-owner-3', 'Tag replace', {
+      syncedAt,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    await seedLocation(groupId, 'pano-a', 'tag-a');
+    await seedLocation(groupId, 'pano-b', 'tag-b');
+    // same-tag row in another group proves deletion stays in this group
+    const otherGroupId = await seedOwnerGroup(
+      'upload-owner-3',
+      'Other upload',
+      {
+        syncedAt,
+        syncIncludeLocationsNotOnStreetView: true,
+      },
+    );
+    await seedLocation(otherGroupId, 'pano-c', 'tag-a');
+
+    const response = await locationUploadRequest('upload-owner-3', groupId, {
+      uploadMode: 'tagReplace',
+      locations: [locationBody('pano-x', 'tag-a')],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      count: 1,
+      ignoredCount: 0,
+      conflictCount: 0,
+    });
+    // omitted tag-a row is deleted, omitted tag-b row is preserved, and the
+    // newly uploaded pano-x survives
+    expect(await locationSnapshot(groupId)).toEqual([
+      { panoId: 'pano-b', extraTag: 'tag-b', extraPanoId: null },
+      { panoId: 'pano-x', extraTag: 'tag-a', extraPanoId: null },
+    ]);
+    // the other group's same-tag row is untouched
+    expect(await locationSnapshot(otherGroupId)).toEqual([
+      { panoId: 'pano-c', extraTag: 'tag-a', extraPanoId: null },
+    ]);
+  });
+});
+
+describe('location upload editor scope and scoped semantics', () => {
+  test('editor must scope to a meta and cannot use full mode', async () => {
+    await seedUser('scope-editor-owner-1');
+    await seedUser('scope-editor-1');
+    const groupId = await seedOwnerGroup(
+      'scope-editor-owner-1',
+      'Editor scope',
+      {
+        syncedAt,
+        syncIncludeLocationsNotOnStreetView: true,
+      },
+    );
+    await seedMember(groupId, 'scope-editor-1');
+
+    const before = await locationSnapshot(groupId);
+
+    const unscoped = await locationUploadRequest('scope-editor-1', groupId, {
+      uploadMode: 'partial',
+      locations: [locationBody('pano-e', 'tag-a')],
+    });
+    expect(unscoped.status).toBe(403);
+    expect(await unscoped.json()).toEqual({
+      message: 'Editors can only upload locations for a specific meta',
+    });
+
+    const fullScoped = await locationUploadRequest('scope-editor-1', groupId, {
+      uploadMode: 'full',
+      scopeTag: 'tag-a',
+      locations: [locationBody('pano-e', 'tag-a')],
+    });
+    expect(fullScoped.status).toBe(403);
+    expect(await fullScoped.json()).toEqual({
+      message: 'Editors cannot replace all locations in a group',
+    });
+
+    // neither denial touched the group's locations
+    expect(await locationSnapshot(groupId)).toEqual(before);
+  });
+
+  test('scoped tagReplace ignores out-of-scope rows and conflicts on panos owned by another tag', async () => {
+    await seedUser('scope-editor-owner-2');
+    await seedUser('scope-editor-2');
+    const groupId = await seedOwnerGroup(
+      'scope-editor-owner-2',
+      'Scoped upload',
+      {
+        syncedAt,
+        syncIncludeLocationsNotOnStreetView: true,
+      },
+    );
+    await seedMember(groupId, 'scope-editor-2');
+    // the scoped tag must already exist as a meta in the group
+    await db.insert(metas).values({
+      mapGroupId: groupId,
+      tagName: 'tag-a',
+      name: 'Tag A',
+      note: '',
+      modifiedAt: syncedAt,
+    });
+    // pano-a already belongs to tag-b; re-uploading it under tag-a must
+    // conflict and leave the existing row untouched
+    await seedLocation(groupId, 'pano-a', 'tag-b');
+
+    const response = await locationUploadRequest('scope-editor-2', groupId, {
+      uploadMode: 'tagReplace',
+      scopeTag: 'tag-a',
+      locations: [
+        locationBody('pano-a', 'tag-a'),
+        locationBody('pano-x', 'tag-a'),
+        locationBody('pano-z', 'tag-b'),
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      count: 1,
+      ignoredCount: 1,
+      conflictCount: 1,
+    });
+    // pano-a stays on tag-b, pano-x is inserted, and the out-of-scope pano-z
+    // is neither inserted nor deleted (tag-b rows are untouched)
+    expect(await locationSnapshot(groupId)).toEqual([
+      { panoId: 'pano-a', extraTag: 'tag-b', extraPanoId: null },
+      { panoId: 'pano-x', extraTag: 'tag-a', extraPanoId: null },
+    ]);
+  });
+});
+
+function syncRequest(userId: string, groupId: number) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/map-groups/${groupId}/sync`, {
+      method: 'POST',
+      headers: { 'x-api-user-id': userId },
+    }),
+  );
+}
+
+async function getSyncMarkers(groupId: number) {
+  return db
+    .select({
+      mapGroupId: mapGroupChanges.mapGroupId,
+      userId: mapGroupChanges.userId,
+      entityType: mapGroupChanges.entityType,
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      oldValue: mapGroupChanges.oldValue,
+      newValue: mapGroupChanges.newValue,
+      createdAt: mapGroupChanges.createdAt,
+    })
+    .from(mapGroupChanges)
+    .where(
+      and(
+        eq(mapGroupChanges.mapGroupId, groupId),
+        eq(mapGroupChanges.entityType, 'sync'),
+      ),
+    )
+    .orderBy(mapGroupChanges.id);
+}
+
+async function seedSyncFixture(
+  userId: string,
+  groupName: string,
+  geoguessrId: string,
+) {
+  const groupId = await seedOwnerGroup(userId, groupName, {
+    syncedAt: null,
+    syncIncludeLocationsNotOnStreetView: true,
+  });
+  const [meta] = await db
+    .insert(metas)
+    .values({
+      mapGroupId: groupId,
+      tagName: 'us',
+      name: 'United States',
+      note: '**Capital:** Washington',
+      noteHtml: '<p><strong>Capital:</strong> Washington</p>',
+      footer: '',
+      footerHtml: '',
+      noteFromPlonkit: true,
+      modifiedAt: 100,
+    })
+    .returning({ id: metas.id });
+  await seedLocation(groupId, 'pano-sync', 'us');
+  const [map] = await db
+    .insert(maps)
+    .values({ mapGroupId: groupId, name: 'Sync map', geoguessrId })
+    .returning({ id: maps.id });
+  return { groupId, metaId: meta!.id, mapId: map!.id };
+}
+
+describe('POST /api/internal/map-groups/:id/sync', () => {
+  test('owner sync persists synced rows, advances the group timestamp, and writes the exact sync marker', async () => {
+    await seedUser('sync-owner-1');
+    const { groupId, metaId, mapId } = await seedSyncFixture(
+      'sync-owner-1',
+      'Sync owner group',
+      'sync-owner-map',
+    );
+
+    const before = Math.floor(Date.now() / 1000);
+    const response = await syncRequest('sync-owner-1', groupId);
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(response.status).toBe(200);
+
+    // the source meta is mirrored into the synced tables with its exact
+    // rendered payload
+    expect(await db.select().from(syncedMetas)).toEqual([
+      {
+        metaId,
+        mapGroupId: groupId,
+        name: 'United States',
+        note: '<p><strong>Capital:</strong> Washington</p>',
+        noteFromPlonkit: true,
+        footer: '',
+        images: [],
+      },
+    ]);
+    expect(await db.select().from(syncedLocations)).toEqual([
+      {
+        syncedMetaId: metaId,
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        panoId: 'pano-sync',
+        extraTag: 'us',
+        extraPanoId: null,
+        extraPanoDate: null,
+        country: 'us',
+      },
+    ]);
+    expect(await db.select().from(syncedMapMetas)).toEqual([
+      { mapId, syncedMetaId: metaId },
+    ]);
+
+    // the group timestamp advanced to the sync's own second
+    const [group] = await db
+      .select({ syncedAt: mapGroups.syncedAt })
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    const syncedTimestamp = group!.syncedAt!;
+    expect(syncedTimestamp).toBeGreaterThanOrEqual(before);
+    expect(syncedTimestamp).toBeLessThanOrEqual(after);
+
+    // the value-less sync marker is stamped with the same timestamp so it sits
+    // exactly on the synced/unsynced boundary instead of classifying itself
+    // unsynced
+    expect(await getSyncMarkers(groupId)).toEqual([
+      {
+        mapGroupId: groupId,
+        userId: 'sync-owner-1',
+        entityType: 'sync',
+        entityId: groupId,
+        entityLabel: 'changes published',
+        operation: 'update',
+        oldValue: null,
+        newValue: null,
+        createdAt: syncedTimestamp,
+      },
+    ]);
+  });
+
+  test('editor is denied with source and synced state unchanged', async () => {
+    await seedUser('sync-owner-2');
+    await seedUser('sync-editor-2');
+    const { groupId } = await seedSyncFixture(
+      'sync-owner-2',
+      'Sync editor group',
+      'sync-editor-map',
+    );
+    await seedMember(groupId, 'sync-editor-2');
+
+    const response = await syncRequest('sync-editor-2', groupId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual([
+      "You don't have permissions for this",
+    ]);
+    expect(await getGroup(groupId)).toEqual({
+      syncedAt: null,
+      syncIncludeLocationsNotOnStreetView: true,
+    });
+    expect(await db.select().from(syncedMetas)).toEqual([]);
+    expect(await db.select().from(syncedLocations)).toEqual([]);
+    expect(await db.select().from(syncedMapMetas)).toEqual([]);
+    expect(await getSyncMarkers(groupId)).toEqual([]);
   });
 });

--- a/apps/api/src/routes/internal/maps/group.db.test.ts
+++ b/apps/api/src/routes/internal/maps/group.db.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { and, asc, eq } from 'drizzle-orm';
-import { app } from '../../../api';
+import { app } from '@api/api';
 import {
   levels,
   mapData,
@@ -18,9 +17,10 @@ import {
   syncedMapMetas,
   syncedMetas,
   users,
-} from '../../../lib/db/schema';
-import { db } from '../../../lib/drizzle';
-import { popularMapMessage } from '../../../lib/internal/utils';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { popularMapMessage } from '@api/lib/internal/utils';
+import { and, asc, eq } from 'drizzle-orm';
 
 const originalFetch = globalThis.fetch;
 const originalNfcaToken = process.env.NFCA_TOKEN;

--- a/apps/api/src/routes/internal/maps/group.db.test.ts
+++ b/apps/api/src/routes/internal/maps/group.db.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import { app } from '../../../api';
 import {
   levels,
+  mapData,
   mapFilters,
+  mapGroupChanges,
+  mapGroupLocations,
   mapGroupPermissions,
   mapGroups,
   mapLevels,
+  mapLocations,
   mapRegions,
   maps,
+  metas,
   regions,
+  syncedMapMetas,
+  syncedMetas,
   users,
 } from '../../../lib/db/schema';
 import { db } from '../../../lib/drizzle';
@@ -130,6 +137,46 @@ function groupMapPutRequest(userId: string, body: unknown) {
       body: JSON.stringify(body),
     }),
   );
+}
+
+function groupMapDeleteRequest(userId: string, mapId: number) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/maps/group/${mapId}`, {
+      method: 'DELETE',
+      headers: { 'x-api-user-id': userId },
+    }),
+  );
+}
+
+function groupMapDownloadRequest(
+  userId: string,
+  mapId: number,
+  groupId: number,
+) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/internal/maps/group/${mapId}/download?groupId=${groupId}`,
+      { headers: { 'x-api-user-id': userId } },
+    ),
+  );
+}
+
+async function getMapLogs() {
+  return db
+    .select({
+      mapGroupId: mapGroupChanges.mapGroupId,
+      userId: mapGroupChanges.userId,
+      entityType: mapGroupChanges.entityType,
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      oldValue: mapGroupChanges.oldValue,
+      newValue: mapGroupChanges.newValue,
+      createdAt: mapGroupChanges.createdAt,
+    })
+    .from(mapGroupChanges)
+    .where(eq(mapGroupChanges.entityType, 'map'))
+    .orderBy(asc(mapGroupChanges.id));
 }
 
 describe('PUT /api/internal/maps/group', () => {
@@ -769,5 +816,687 @@ describe('PUT /api/internal/maps/group', () => {
       // unchanged GeoGuessr ID and superadmin caller: no external lookup
       expect(geoguessrFetches).toEqual([]);
     });
+  });
+
+  describe('moving between groups', () => {
+    test('owner of source and target moves the map and logs exact source delete / target create', async () => {
+      await seedUser('owner-1');
+      const sourceId = await seedGroup('Source group');
+      const targetId = await seedGroup('Target group');
+      await seedGroupOwner('owner-1', sourceId);
+      await seedGroupOwner('owner-1', targetId);
+      const sourceLevelId = await seedLevel(sourceId, 'Beginner');
+      const targetLevelId = await seedLevel(targetId, 'Beginner');
+      const regionId = await seedRegion('Europe');
+
+      const created = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          mapGroupId: sourceId,
+          geoguessrId: 'moved-map',
+          levels: [sourceLevelId],
+          regions: [regionId],
+          includeFilters: ['us'],
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      geoguessrFetches = [];
+      const moved = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          id,
+          mapGroupId: targetId,
+          geoguessrId: 'moved-map',
+          levels: [targetLevelId],
+          regions: [regionId],
+          includeFilters: ['us'],
+        }),
+      );
+      expect(moved.status).toBe(200);
+      expect(await moved.json()).toEqual({ id });
+      // unchanged GeoGuessr ID: the move never reaches the external boundary
+      expect(geoguessrFetches).toEqual([]);
+
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row!.mapGroupId).toBe(targetId);
+      expect(row!.geoguessrId).toBe('moved-map');
+
+      // plain owner: gated fields fall back to the source map's values
+      const mapDetails = {
+        name: 'Map Name',
+        geoguessrId: 'moved-map',
+        description: 'Map description',
+        isPublished: false,
+        isShared: true,
+        authors: 'Author',
+        footer: '**Footer**',
+        difficulty: 2,
+        ordering: 0,
+        autoUpdate: false,
+        isVerified: false,
+        regions: ['Europe'],
+        levels: ['Beginner'],
+        includeFilters: ['us'],
+        excludeFilters: [],
+      };
+
+      expect(await getMapLogs()).toEqual([
+        // the original create still sits in the source group
+        {
+          mapGroupId: sourceId,
+          userId: 'owner-1',
+          entityType: 'map',
+          entityId: id,
+          entityLabel: 'Map Name',
+          operation: 'create',
+          oldValue: null,
+          newValue: { mapGroupId: sourceId, ...mapDetails },
+          createdAt: expect.any(Number),
+        },
+        // the move deletes the map from the source group...
+        {
+          mapGroupId: sourceId,
+          userId: 'owner-1',
+          entityType: 'map',
+          entityId: id,
+          entityLabel: 'Map Name',
+          operation: 'delete',
+          oldValue: { mapGroupId: sourceId, ...mapDetails },
+          newValue: { movedToGroupId: targetId },
+          createdAt: expect.any(Number),
+        },
+        // ...and creates it in the target group
+        {
+          mapGroupId: targetId,
+          userId: 'owner-1',
+          entityType: 'map',
+          entityId: id,
+          entityLabel: 'Map Name',
+          operation: 'create',
+          oldValue: null,
+          newValue: {
+            mapGroupId: targetId,
+            ...mapDetails,
+            movedFromGroupId: sourceId,
+          },
+          createdAt: expect.any(Number),
+        },
+      ]);
+    });
+
+    test('move is denied without owner access to the source group, with no mutation or log leakage', async () => {
+      await seedUser('source-owner');
+      await seedUser('target-owner');
+      const sourceId = await seedGroup('Source group');
+      const targetId = await seedGroup('Target group');
+      await seedGroupOwner('source-owner', sourceId);
+      await seedGroupOwner('target-owner', targetId);
+
+      const created = await groupMapPutRequest(
+        'source-owner',
+        groupMapBody({ mapGroupId: sourceId, geoguessrId: 'locked-map' }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      // caller owns the target group but not the source: both are required
+      geoguessrFetches = [];
+      const moved = await groupMapPutRequest(
+        'target-owner',
+        groupMapBody({ id, mapGroupId: targetId, geoguessrId: 'locked-map' }),
+      );
+      expect(moved.status).toBe(403);
+      expect(geoguessrFetches).toEqual([]);
+
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row!.mapGroupId).toBe(sourceId);
+
+      // only the original create log exists: no delete/create pair leaked
+      expect(await getMapLogs()).toEqual([
+        expect.objectContaining({
+          mapGroupId: sourceId,
+          userId: 'source-owner',
+          operation: 'create',
+        }),
+      ]);
+      expect(
+        await db
+          .select()
+          .from(mapGroupChanges)
+          .where(eq(mapGroupChanges.mapGroupId, targetId)),
+      ).toEqual([]);
+    });
+  });
+
+  describe('cross-group level rejection', () => {
+    test.todo('rejects level IDs from another group before any persistence', async () => {
+      // The level FK does not enforce that map and level belong to one group.
+      await seedUser('admin-1', true);
+      const groupId = await seedGroup('Target group');
+      const otherGroupId = await seedGroup('Other group');
+      const levelId = await seedLevel(groupId, 'Beginner');
+      const foreignLevelId = await seedLevel(otherGroupId, 'Foreign level');
+
+      const created = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'own-level-map',
+          levels: [levelId],
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      const rejected = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          id,
+          mapGroupId: groupId,
+          geoguessrId: 'own-level-map',
+          name: 'Should Not Persist',
+          levels: [foreignLevelId],
+        }),
+      );
+      expect(rejected.status).toBeGreaterThanOrEqual(400);
+      expect(rejected.status).toBeLessThan(500);
+      expect(geoguessrFetches).toEqual([]);
+
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row).toEqual(
+        expect.objectContaining({
+          id,
+          name: 'Map Name',
+          geoguessrId: 'own-level-map',
+        }),
+      );
+
+      expect(
+        await db
+          .select({ levelId: mapLevels.levelId })
+          .from(mapLevels)
+          .where(eq(mapLevels.mapId, id)),
+      ).toEqual([{ levelId }]);
+
+      expect(
+        await db
+          .select()
+          .from(mapGroupChanges)
+          .where(eq(mapGroupChanges.entityId, id)),
+      ).toEqual([
+        expect.objectContaining({
+          mapGroupId: groupId,
+          userId: 'admin-1',
+          entityType: 'map',
+          operation: 'create',
+        }),
+      ]);
+    });
+  });
+});
+
+describe('DELETE /api/internal/maps/group/:id', () => {
+  beforeEach(() => {
+    // map creates inside these tests hit the GeoGuessr popularity check
+    process.env.NFCA_TOKEN = 'test-token';
+    geoguessrFetches = [];
+    geoguessrMapResults = {};
+    mockFetchFailClosed();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    restoreNfcaToken();
+  });
+
+  test('owner delete cascades map level/filter/region/data/meta associations and leaves unrelated rows', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Test group');
+    await seedGroupOwner('owner-1', groupId);
+    const levelId = await seedLevel(groupId, 'Beginner');
+    const regionId = await seedRegion('Europe');
+
+    const created = await groupMapPutRequest(
+      'owner-1',
+      groupMapBody({
+        mapGroupId: groupId,
+        geoguessrId: 'doomed-map',
+        levels: [levelId],
+        regions: [regionId],
+        includeFilters: ['us'],
+        excludeFilters: ['dangerous'],
+      }),
+    );
+    expect(created.status).toBe(200);
+    const { id } = (await created.json()) as { id: number };
+
+    // a second map in the same group shares the level, region, and synced meta
+    const survivor = await groupMapPutRequest(
+      'owner-1',
+      groupMapBody({
+        mapGroupId: groupId,
+        geoguessrId: 'survivor-map',
+        levels: [levelId],
+        regions: [regionId],
+        includeFilters: ['ca'],
+      }),
+    );
+    expect(survivor.status).toBe(200);
+    const { id: survivorId } = (await survivor.json()) as { id: number };
+
+    // data and meta associations are not settable through the PUT route: seed directly
+    const [syncedMeta] = await db
+      .insert(syncedMetas)
+      .values({
+        metaId: 7001,
+        mapGroupId: groupId,
+        name: 'Synced meta',
+        note: 'note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      })
+      .returning({ metaId: syncedMetas.metaId });
+    await db.insert(mapData).values([{ mapId: id }, { mapId: survivorId }]);
+    await db.insert(syncedMapMetas).values([
+      { mapId: id, syncedMetaId: syncedMeta!.metaId },
+      { mapId: survivorId, syncedMetaId: syncedMeta!.metaId },
+    ]);
+
+    const response = await groupMapDeleteRequest('owner-1', id);
+    expect(response.status).toBe(200);
+
+    // the deleted map row is gone and every association row followed via cascade
+    expect(await db.select().from(maps).where(eq(maps.id, id))).toEqual([]);
+    expect(
+      await db.select().from(mapLevels).where(eq(mapLevels.mapId, id)),
+    ).toEqual([]);
+    expect(
+      await db.select().from(mapFilters).where(eq(mapFilters.mapId, id)),
+    ).toEqual([]);
+    expect(
+      await db.select().from(mapRegions).where(eq(mapRegions.mapId, id)),
+    ).toEqual([]);
+    expect(
+      await db.select().from(mapData).where(eq(mapData.mapId, id)),
+    ).toEqual([]);
+    expect(
+      await db
+        .select()
+        .from(syncedMapMetas)
+        .where(eq(syncedMapMetas.mapId, id)),
+    ).toEqual([]);
+
+    // the unrelated map keeps its row and every shared association
+    expect(
+      await db.select().from(maps).where(eq(maps.id, survivorId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select({ levelId: mapLevels.levelId })
+        .from(mapLevels)
+        .where(eq(mapLevels.mapId, survivorId)),
+    ).toEqual([{ levelId }]);
+    expect(
+      await db
+        .select({ tagLike: mapFilters.tagLike })
+        .from(mapFilters)
+        .where(eq(mapFilters.mapId, survivorId)),
+    ).toEqual([{ tagLike: 'ca' }]);
+    expect(
+      await db
+        .select({ regionId: mapRegions.regionId })
+        .from(mapRegions)
+        .where(eq(mapRegions.mapId, survivorId)),
+    ).toEqual([{ regionId }]);
+    expect(
+      await db.select().from(mapData).where(eq(mapData.mapId, survivorId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+        .from(syncedMapMetas)
+        .where(eq(syncedMapMetas.mapId, survivorId)),
+    ).toEqual([{ syncedMetaId: syncedMeta!.metaId }]);
+
+    // master rows referenced by the deleted map survive: only join rows cascade
+    expect(
+      await db.select().from(levels).where(eq(levels.id, levelId)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(regions).where(eq(regions.id, regionId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(syncedMetas)
+        .where(eq(syncedMetas.metaId, syncedMeta!.metaId)),
+    ).toHaveLength(1);
+
+    // exactly one delete log entry, owned by the caller, for the deleted map
+    expect(
+      await db
+        .select()
+        .from(mapGroupChanges)
+        .where(
+          and(
+            eq(mapGroupChanges.entityType, 'map'),
+            eq(mapGroupChanges.entityId, id),
+            eq(mapGroupChanges.operation, 'delete'),
+          ),
+        ),
+    ).toEqual([
+      expect.objectContaining({
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'map',
+        entityId: id,
+        entityLabel: 'Map Name',
+        operation: 'delete',
+        oldValue: expect.objectContaining({
+          name: 'Map Name',
+          geoguessrId: 'doomed-map',
+        }),
+      }),
+    ]);
+  });
+
+  test('editor and unrelated callers are denied with row and associations unchanged', async () => {
+    await seedUser('owner-1');
+    await seedUser('editor-1');
+    await seedUser('outsider-1');
+    const groupId = await seedGroup('Test group');
+    await seedGroupOwner('owner-1', groupId);
+    await db.insert(mapGroupPermissions).values({
+      mapGroupId: groupId,
+      userId: 'editor-1',
+      role: 'editor',
+    });
+    const levelId = await seedLevel(groupId, 'Beginner');
+    const regionId = await seedRegion('Europe');
+
+    const created = await groupMapPutRequest(
+      'owner-1',
+      groupMapBody({
+        mapGroupId: groupId,
+        geoguessrId: 'protected-map',
+        levels: [levelId],
+        regions: [regionId],
+        includeFilters: ['us'],
+      }),
+    );
+    expect(created.status).toBe(200);
+    const { id } = (await created.json()) as { id: number };
+
+    const [syncedMeta] = await db
+      .insert(syncedMetas)
+      .values({
+        metaId: 7001,
+        mapGroupId: groupId,
+        name: 'Synced meta',
+        note: 'note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      })
+      .returning({ metaId: syncedMetas.metaId });
+    await db.insert(mapData).values([{ mapId: id }]);
+    await db
+      .insert(syncedMapMetas)
+      .values([{ mapId: id, syncedMetaId: syncedMeta!.metaId }]);
+
+    // editor owns the group as editor, outsider has no relation to it
+    expect((await groupMapDeleteRequest('editor-1', id)).status).toBe(403);
+    expect((await groupMapDeleteRequest('outsider-1', id)).status).toBe(403);
+
+    // the map row and every association survive both denied attempts
+    expect(await db.select().from(maps).where(eq(maps.id, id))).toHaveLength(1);
+    expect(
+      await db
+        .select({ levelId: mapLevels.levelId })
+        .from(mapLevels)
+        .where(eq(mapLevels.mapId, id)),
+    ).toEqual([{ levelId }]);
+    expect(
+      await db
+        .select({ tagLike: mapFilters.tagLike })
+        .from(mapFilters)
+        .where(eq(mapFilters.mapId, id)),
+    ).toEqual([{ tagLike: 'us' }]);
+    expect(
+      await db
+        .select({ regionId: mapRegions.regionId })
+        .from(mapRegions)
+        .where(eq(mapRegions.mapId, id)),
+    ).toEqual([{ regionId }]);
+    expect(
+      await db.select().from(mapData).where(eq(mapData.mapId, id)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+        .from(syncedMapMetas)
+        .where(eq(syncedMapMetas.mapId, id)),
+    ).toEqual([{ syncedMetaId: syncedMeta!.metaId }]);
+
+    // no delete log leaked from the denied attempts
+    expect(
+      await db
+        .select()
+        .from(mapGroupChanges)
+        .where(
+          and(
+            eq(mapGroupChanges.entityType, 'map'),
+            eq(mapGroupChanges.entityId, id),
+            eq(mapGroupChanges.operation, 'delete'),
+          ),
+        ),
+    ).toEqual([]);
+  });
+});
+
+describe('GET /api/internal/maps/group/:id/download', () => {
+  beforeEach(() => {
+    // fail closed: this read-only route must never reach an external boundary
+    process.env.NFCA_TOKEN = 'test-token';
+    geoguessrFetches = [];
+    geoguessrMapResults = {};
+    mockFetchFailClosed();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    restoreNfcaToken();
+  });
+
+  // minimal group/meta/map/location fixture visible through the mapLocations view
+  async function seedDownloadFixture() {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Download group' })
+      .returning({ id: mapGroups.id });
+    const groupId = group!.id;
+
+    await db.insert(metas).values({
+      mapGroupId: groupId,
+      tagName: 'alpha',
+      name: 'Alpha meta',
+      note: 'Meta note',
+    });
+
+    const [map] = await db
+      .insert(maps)
+      .values({
+        mapGroupId: groupId,
+        name: 'Download Map',
+        geoguessrId: 'download-map',
+        isPersonal: false,
+      })
+      .returning({ id: maps.id });
+
+    await db.insert(mapGroupLocations).values([
+      {
+        mapGroupId: groupId,
+        extraTag: 'alpha',
+        panoId: 'pano-a',
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        extraPanoId: 'extra-a',
+        extraPanoDate: '2020-01-01',
+      },
+      {
+        mapGroupId: groupId,
+        extraTag: 'alpha',
+        panoId: 'pano-b',
+        lat: 1.5,
+        lng: 2.5,
+        heading: 3.5,
+        pitch: 4.5,
+        zoom: 5.5,
+        extraPanoId: null,
+        extraPanoDate: null,
+      },
+    ]);
+
+    return { groupId, mapId: map!.id };
+  }
+
+  test('owner and editor download the exact public JSON and omit internal view fields', async () => {
+    await seedUser('owner-1');
+    await seedUser('editor-1');
+    const { groupId, mapId } = await seedDownloadFixture();
+    await seedGroupOwner('owner-1', groupId);
+    await db.insert(mapGroupPermissions).values({
+      mapGroupId: groupId,
+      userId: 'editor-1',
+      role: 'editor',
+    });
+
+    for (const userId of ['owner-1', 'editor-1']) {
+      const response = await groupMapDownloadRequest(userId, mapId, groupId);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toMatch(
+        /^application\/json/,
+      );
+      expect(response.headers.get('content-disposition')).toBe(
+        'attachment; filename="Download Map.json"',
+      );
+
+      const body = (await response.json()) as {
+        name: string;
+        customCoordinates: Array<{
+          lat: number;
+          lng: number;
+          heading: number;
+          pitch: number;
+          zoom: number;
+          panoId: string;
+          countryCode: null;
+          stateCode: null;
+          extra: {
+            tags: string[];
+            panoDate: string | null;
+            panoId: string | null;
+          };
+        }>;
+        extra: { tags: Record<string, never>; infoCoordinates: never[] };
+      };
+      body.customCoordinates.sort((a, b) => a.panoId.localeCompare(b.panoId));
+      expect(body).toEqual({
+        name: 'Download Map',
+        customCoordinates: [
+          {
+            lat: 1,
+            lng: 2,
+            heading: 3,
+            pitch: 4,
+            zoom: 5,
+            panoId: 'pano-a',
+            countryCode: null,
+            stateCode: null,
+            extra: {
+              // the group-map export intentionally leaves tags empty
+              tags: [],
+              panoDate: '2020-01-01',
+              panoId: 'extra-a',
+            },
+          },
+          {
+            lat: 1.5,
+            lng: 2.5,
+            heading: 3.5,
+            pitch: 4.5,
+            zoom: 5.5,
+            panoId: 'pano-b',
+            countryCode: null,
+            stateCode: null,
+            extra: {
+              tags: [],
+              panoDate: null,
+              panoId: null,
+            },
+          },
+        ],
+        extra: {
+          tags: {},
+          infoCoordinates: [],
+        },
+      });
+    }
+
+    // the view exposes internal columns for every downloaded location; none leak
+    const viewRows = await db
+      .select()
+      .from(mapLocations)
+      .where(eq(mapLocations.mapId, mapId));
+    expect(viewRows).toHaveLength(2);
+    for (const row of viewRows) {
+      expect(row).toEqual(
+        expect.objectContaining({
+          mapId,
+          tagName: 'alpha',
+          metaName: 'Alpha meta',
+          metaNote: 'Meta note',
+          metaNoteFromPlonkit: false,
+        }),
+      );
+    }
+  });
+
+  test('unrelated caller is denied without leaking the map or its locations', async () => {
+    await seedUser('outsider-1');
+    const { groupId, mapId } = await seedDownloadFixture();
+
+    const response = await groupMapDownloadRequest(
+      'outsider-1',
+      mapId,
+      groupId,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  test('map id with a mismatched group id is 404 even for a member of the real group', async () => {
+    await seedUser('owner-1');
+    const { groupId, mapId } = await seedDownloadFixture();
+    await seedGroupOwner('owner-1', groupId);
+    const [otherGroup] = await db
+      .insert(mapGroups)
+      .values({ name: 'Other group' })
+      .returning({ id: mapGroups.id });
+
+    const response = await groupMapDownloadRequest(
+      'owner-1',
+      mapId,
+      otherGroup!.id,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Map not found' });
   });
 });

--- a/apps/api/src/routes/internal/maps/group.db.test.ts
+++ b/apps/api/src/routes/internal/maps/group.db.test.ts
@@ -1035,6 +1035,39 @@ describe('PUT /api/internal/maps/group', () => {
       ]);
     });
   });
+
+  describe('id=0 validation', () => {
+    test.todo('rejects id 0 by validation instead of mixing create and update behavior', async () => {
+      await seedUser('owner-1');
+      const groupId = await seedGroup('Test group');
+      await seedGroupOwner('owner-1', groupId);
+
+      // id=0 passes the Integer schema, so the route mixes paths: the
+      // popularity check treats it as a create (`if (id)` is falsy) while the
+      // transaction treats it as an update of map 0 (`id === undefined` is
+      // false). No map row is touched, association inserts target a
+      // nonexistent map_id, and the response is 200 { id: 0 } or 500
+      // depending on the association arrays.
+      const response = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          id: 0,
+          mapGroupId: groupId,
+          geoguessrId: 'id-zero-map',
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(await response.json()).toEqual(
+        expect.objectContaining({ type: 'validation', on: 'body' }),
+      );
+      // validation must reject before the handler: no external lookup
+      expect(geoguessrFetches).toEqual([]);
+      // and nothing may be persisted
+      expect(
+        await db.select().from(maps).where(eq(maps.geoguessrId, 'id-zero-map')),
+      ).toEqual([]);
+    });
+  });
 });
 
 describe('DELETE /api/internal/maps/group/:id', () => {

--- a/apps/api/src/routes/internal/maps/group.db.test.ts
+++ b/apps/api/src/routes/internal/maps/group.db.test.ts
@@ -1,0 +1,773 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { asc, eq } from 'drizzle-orm';
+import { app } from '../../../api';
+import {
+  levels,
+  mapFilters,
+  mapGroupPermissions,
+  mapGroups,
+  mapLevels,
+  mapRegions,
+  maps,
+  regions,
+  users,
+} from '../../../lib/db/schema';
+import { db } from '../../../lib/drizzle';
+import { popularMapMessage } from '../../../lib/internal/utils';
+
+const originalFetch = globalThis.fetch;
+const originalNfcaToken = process.env.NFCA_TOKEN;
+
+let geoguessrFetches: string[] = [];
+// geoguessrId -> numberOfGamesPlayed for the popularity search mock; an
+// unlisted ID resolves to no search result (not popular)
+let geoguessrMapResults: Record<string, number> = {};
+
+// Fail closed: superadmins skip the popularity lookup, so a geoguessr call here
+// means the route reached an external boundary and the test must surface it.
+function mockFetchFailClosed() {
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.startsWith('https://www.geoguessr.com/api/v3/search/map')) {
+      const q = new URL(url).searchParams.get('q') ?? '';
+      geoguessrFetches.push(q);
+      const numberOfGamesPlayed = geoguessrMapResults[q];
+      const body =
+        numberOfGamesPlayed === undefined
+          ? []
+          : [{ id: q, numberOfGamesPlayed }];
+      return new Response(JSON.stringify(body), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`Unexpected external request: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+function restoreNfcaToken() {
+  if (originalNfcaToken === undefined) {
+    delete process.env.NFCA_TOKEN;
+  } else {
+    process.env.NFCA_TOKEN = originalNfcaToken;
+  }
+}
+
+async function seedUser(id: string, isSuperadmin = false, isTrusted = false) {
+  await db.insert(users).values({
+    id,
+    username: id,
+    isSuperadmin,
+    isTrusted,
+  });
+}
+
+async function seedGroupOwner(userId: string, groupId: number) {
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId,
+    role: 'owner',
+  });
+}
+
+async function seedGroup(name: string) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name })
+    .returning({ id: mapGroups.id });
+  return group!.id;
+}
+
+async function seedLevel(groupId: number, name: string) {
+  const [level] = await db
+    .insert(levels)
+    .values({ mapGroupId: groupId, name })
+    .returning({ id: levels.id });
+  return level!.id;
+}
+
+async function seedRegion(name: string) {
+  const [region] = await db
+    .insert(regions)
+    .values({ name })
+    .returning({ id: regions.id });
+  return region!.id;
+}
+
+function groupMapBody(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Map Name',
+    description: 'Map description',
+    geoguessrId: 'group-map-1',
+    mapGroupId: 1,
+    footer: '**Footer**',
+    isPublished: true,
+    isShared: true,
+    authors: 'Author',
+    ordering: 3,
+    autoUpdate: true,
+    difficulty: 2,
+    isVerified: true,
+    levels: [],
+    regions: [],
+    includeFilters: [],
+    excludeFilters: [],
+    ...overrides,
+  };
+}
+
+function groupMapPutRequest(userId: string, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/api/internal/maps/group', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe('PUT /api/internal/maps/group', () => {
+  beforeEach(() => {
+    // geoguessrAPIFetch throws before any network call without this token
+    process.env.NFCA_TOKEN = 'test-token';
+    geoguessrFetches = [];
+    geoguessrMapResults = {};
+    mockFetchFailClosed();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    restoreNfcaToken();
+  });
+
+  test('create persists base fields and the level/filter/region associations', async () => {
+    await seedUser('admin-1', true);
+    const groupId = await seedGroup('Test group');
+    const levelA = await seedLevel(groupId, 'Beginner');
+    const levelB = await seedLevel(groupId, 'Advanced');
+    const regionA = await seedRegion('Europe');
+    const regionB = await seedRegion('Asia');
+    const before = Math.floor(Date.now() / 1000);
+
+    const response = await groupMapPutRequest(
+      'admin-1',
+      groupMapBody({
+        mapGroupId: groupId,
+        levels: [levelA, levelB],
+        regions: [regionA, regionB],
+        includeFilters: ['us', 'ca'],
+        excludeFilters: ['dangerous'],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const { id } = (await response.json()) as { id: number };
+    expect(id).toEqual(expect.any(Number));
+    // superadmin bypasses the GeoGuessr popularity lookup
+    expect(geoguessrFetches).toEqual([]);
+
+    const [row] = await db.select().from(maps).where(eq(maps.id, id));
+    const after = Math.floor(Date.now() / 1000);
+    expect(row).toEqual(
+      expect.objectContaining({
+        id,
+        mapGroupId: groupId,
+        name: 'Map Name',
+        geoguessrId: 'group-map-1',
+        description: 'Map description',
+        isPublished: true,
+        isShared: true,
+        isPersonal: false,
+        userId: null,
+        authors: 'Author',
+        ordering: 3,
+        autoUpdate: true,
+        footer: '**Footer**',
+        footerHtml: '<p><strong>Footer</strong></p>',
+        modifiedAt: expect.any(Number),
+        difficulty: 2,
+        isVerified: true,
+      }),
+    );
+    expect(row!.modifiedAt).toBeGreaterThanOrEqual(before);
+    expect(row!.modifiedAt).toBeLessThanOrEqual(after);
+
+    const levelRows = await db
+      .select({ mapId: mapLevels.mapId, levelId: mapLevels.levelId })
+      .from(mapLevels)
+      .where(eq(mapLevels.mapId, id))
+      .orderBy(asc(mapLevels.levelId));
+    expect(levelRows).toEqual([
+      { mapId: id, levelId: levelA },
+      { mapId: id, levelId: levelB },
+    ]);
+
+    const filterRows = await db
+      .select({ tagLike: mapFilters.tagLike, isExclude: mapFilters.isExclude })
+      .from(mapFilters)
+      .where(eq(mapFilters.mapId, id))
+      .orderBy(asc(mapFilters.tagLike));
+    expect(filterRows).toEqual([
+      { tagLike: 'ca', isExclude: false },
+      { tagLike: 'dangerous', isExclude: true },
+      { tagLike: 'us', isExclude: false },
+    ]);
+
+    const regionRows = await db
+      .select({ regionId: mapRegions.regionId })
+      .from(mapRegions)
+      .where(eq(mapRegions.mapId, id))
+      .orderBy(asc(mapRegions.regionId));
+    expect(regionRows).toEqual([{ regionId: regionA }, { regionId: regionB }]);
+  });
+
+  test('update replaces base fields and all associations without stale or duplicate rows', async () => {
+    await seedUser('admin-1', true);
+    const groupId = await seedGroup('Test group');
+    const levelA = await seedLevel(groupId, 'Beginner');
+    const levelB = await seedLevel(groupId, 'Advanced');
+    const levelC = await seedLevel(groupId, 'Expert');
+    const regionA = await seedRegion('Europe');
+    const regionB = await seedRegion('Asia');
+
+    const created = await groupMapPutRequest(
+      'admin-1',
+      groupMapBody({
+        mapGroupId: groupId,
+        levels: [levelA, levelB],
+        regions: [regionA, regionB],
+        includeFilters: ['us', 'ca'],
+        excludeFilters: ['dangerous'],
+      }),
+    );
+    expect(created.status).toBe(200);
+    const { id } = (await created.json()) as { id: number };
+
+    const updated = await groupMapPutRequest(
+      'admin-1',
+      groupMapBody({
+        id,
+        mapGroupId: groupId,
+        name: 'Renamed Map',
+        geoguessrId: 'group-map-1',
+        description: null,
+        footer: 'New footer',
+        isPublished: false,
+        isShared: false,
+        authors: null,
+        ordering: 0,
+        autoUpdate: false,
+        difficulty: 5,
+        isVerified: false,
+        levels: [levelB, levelC],
+        regions: [],
+        includeFilters: ['ca'],
+        excludeFilters: [],
+      }),
+    );
+
+    expect(updated.status).toBe(200);
+    expect(await updated.json()).toEqual({ id });
+    // unchanged GeoGuessr ID, so no external lookup on update either
+    expect(geoguessrFetches).toEqual([]);
+
+    const [row] = await db.select().from(maps).where(eq(maps.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({
+        id,
+        mapGroupId: groupId,
+        name: 'Renamed Map',
+        geoguessrId: 'group-map-1',
+        description: null,
+        isPublished: false,
+        isShared: false,
+        authors: null,
+        ordering: 0,
+        autoUpdate: false,
+        footer: 'New footer',
+        footerHtml: '<p>New footer</p>',
+        difficulty: 5,
+        isVerified: false,
+      }),
+    );
+
+    // level A removed, level C added, level B retained exactly once
+    const levelRows = await db
+      .select({ mapId: mapLevels.mapId, levelId: mapLevels.levelId })
+      .from(mapLevels)
+      .where(eq(mapLevels.mapId, id))
+      .orderBy(asc(mapLevels.levelId));
+    expect(levelRows).toEqual([
+      { mapId: id, levelId: levelB },
+      { mapId: id, levelId: levelC },
+    ]);
+
+    // include 'us' and exclude 'dangerous' removed, include 'ca' retained once
+    const filterRows = await db
+      .select({ tagLike: mapFilters.tagLike, isExclude: mapFilters.isExclude })
+      .from(mapFilters)
+      .where(eq(mapFilters.mapId, id))
+      .orderBy(asc(mapFilters.tagLike));
+    expect(filterRows).toEqual([{ tagLike: 'ca', isExclude: false }]);
+
+    // both regions removed
+    const regionRows = await db
+      .select({ regionId: mapRegions.regionId })
+      .from(mapRegions)
+      .where(eq(mapRegions.mapId, id))
+      .orderBy(asc(mapRegions.regionId));
+    expect(regionRows).toEqual([]);
+  });
+
+  describe('field gating by caller role', () => {
+    test('create: gated fields fall back to defaults unless the role unlocks them', async () => {
+      await seedUser('owner-1');
+      await seedUser('trusted-1', false, true);
+      await seedUser('admin-1', true);
+      const groupId = await seedGroup('Test group');
+      await seedGroupOwner('owner-1', groupId);
+      await seedGroupOwner('trusted-1', groupId);
+
+      // every caller requests full privileges; only the role grants them
+      const requested = {
+        isPublished: true,
+        ordering: 7,
+        autoUpdate: true,
+        isVerified: true,
+      };
+
+      const ownerResponse = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'owner-map',
+          ...requested,
+        }),
+      );
+      const trustedResponse = await groupMapPutRequest(
+        'trusted-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'trusted-map',
+          ...requested,
+        }),
+      );
+      const adminResponse = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'admin-map',
+          ...requested,
+        }),
+      );
+
+      expect(ownerResponse.status).toBe(200);
+      expect(trustedResponse.status).toBe(200);
+      expect(adminResponse.status).toBe(200);
+      const { id: ownerId } = (await ownerResponse.json()) as { id: number };
+      const { id: trustedId } = (await trustedResponse.json()) as {
+        id: number;
+      };
+      const { id: adminId } = (await adminResponse.json()) as { id: number };
+
+      // Plain owner: publication needs trusted status; remaining fields need superadmin.
+      const [ownerRow] = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.id, ownerId));
+      expect(ownerRow).toEqual(
+        expect.objectContaining({
+          isPublished: false,
+          ordering: 0,
+          autoUpdate: false,
+          isVerified: false,
+          // ungated fields are honored for every role
+          name: 'Map Name',
+          description: 'Map description',
+          isShared: true,
+          authors: 'Author',
+          difficulty: 2,
+        }),
+      );
+
+      // trusted owner: isPublished honored, superadmin-only fields default
+      const [trustedRow] = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.id, trustedId));
+      expect(trustedRow).toEqual(
+        expect.objectContaining({
+          isPublished: true,
+          ordering: 0,
+          autoUpdate: false,
+          isVerified: false,
+        }),
+      );
+
+      // superadmin: every requested value honored
+      const [adminRow] = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.id, adminId));
+      expect(adminRow).toEqual(
+        expect.objectContaining({
+          isPublished: true,
+          ordering: 7,
+          autoUpdate: true,
+          isVerified: true,
+        }),
+      );
+
+      // owner and trusted creates hit the GeoGuessr popularity check;
+      // the superadmin create bypasses it
+      expect(geoguessrFetches).toEqual(['owner-map', 'trusted-map']);
+    });
+
+    test('superadmin create honors explicit false and ordering 0', async () => {
+      await seedUser('admin-1', true);
+      const groupId = await seedGroup('Test group');
+
+      const response = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'admin-zero-map',
+          isPublished: false,
+          ordering: 0,
+          autoUpdate: false,
+          isVerified: false,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const { id } = (await response.json()) as { id: number };
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row).toEqual(
+        expect.objectContaining({
+          isPublished: false,
+          ordering: 0,
+          autoUpdate: false,
+          isVerified: false,
+        }),
+      );
+      // falsy values are real values, not omission markers
+      expect(geoguessrFetches).toEqual([]);
+    });
+
+    test('update retains gated fields unless the caller role unlocks them', async () => {
+      await seedUser('owner-1');
+      await seedUser('trusted-1', false, true);
+      await seedUser('admin-1', true);
+      const groupId = await seedGroup('Test group');
+      await seedGroupOwner('owner-1', groupId);
+      await seedGroupOwner('trusted-1', groupId);
+
+      const created = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'retained-map',
+          isPublished: true,
+          ordering: 7,
+          autoUpdate: true,
+          isVerified: true,
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      const clearRequest = groupMapBody({
+        id,
+        mapGroupId: groupId,
+        geoguessrId: 'retained-map',
+        isPublished: false,
+        ordering: 0,
+        autoUpdate: false,
+        isVerified: false,
+      });
+
+      // plain owner asks to clear every gated field; nothing may change
+      const ownerUpdate = await groupMapPutRequest('owner-1', clearRequest);
+      expect(ownerUpdate.status).toBe(200);
+      const [afterOwner] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(afterOwner).toEqual(
+        expect.objectContaining({
+          isPublished: true,
+          ordering: 7,
+          autoUpdate: true,
+          isVerified: true,
+        }),
+      );
+
+      // trusted owner unlocks isPublished but not the superadmin-only fields
+      const trustedUpdate = await groupMapPutRequest('trusted-1', clearRequest);
+      expect(trustedUpdate.status).toBe(200);
+      const [afterTrusted] = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.id, id));
+      expect(afterTrusted).toEqual(
+        expect.objectContaining({
+          isPublished: false,
+          ordering: 7,
+          autoUpdate: true,
+          isVerified: true,
+        }),
+      );
+
+      // superadmin unlocks everything, including explicit false and ordering 0
+      const adminUpdate = await groupMapPutRequest('admin-1', clearRequest);
+      expect(adminUpdate.status).toBe(200);
+      const [afterAdmin] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(afterAdmin).toEqual(
+        expect.objectContaining({
+          isPublished: false,
+          ordering: 0,
+          autoUpdate: false,
+          isVerified: false,
+        }),
+      );
+
+      // unchanged GeoGuessr ID means no external lookup on any update
+      expect(geoguessrFetches).toEqual([]);
+    });
+  });
+
+  describe('GeoGuessr popularity check', () => {
+    test('update with a changed GeoGuessr ID looks up the new ID externally', async () => {
+      await seedUser('owner-1');
+      const groupId = await seedGroup('Test group');
+      await seedGroupOwner('owner-1', groupId);
+
+      const created = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({ mapGroupId: groupId, geoguessrId: 'original-id' }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      geoguessrFetches = [];
+      const updated = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          id,
+          mapGroupId: groupId,
+          geoguessrId: 'changed-id',
+        }),
+      );
+      expect(updated.status).toBe(200);
+      // only the new ID is queried, never the unchanged one
+      expect(geoguessrFetches).toEqual(['changed-id']);
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row!.geoguessrId).toBe('changed-id');
+    });
+
+    test('rejects exactly above the popularity threshold and allows exactly at it', async () => {
+      await seedUser('owner-1');
+      const groupId = await seedGroup('Test group');
+      await seedGroupOwner('owner-1', groupId);
+
+      geoguessrMapResults = { 'boundary-map': 10001 };
+      const rejected = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({ mapGroupId: groupId, geoguessrId: 'boundary-map' }),
+      );
+      expect(rejected.status).toBe(403);
+      expect(await rejected.json()).toEqual({ message: popularMapMessage });
+      expect(geoguessrFetches).toEqual(['boundary-map']);
+      // rejection happens before the insert transaction: nothing persisted
+      const rejectedRows = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.geoguessrId, 'boundary-map'));
+      expect(rejectedRows).toEqual([]);
+
+      geoguessrMapResults = { 'boundary-map': 10000 };
+      const allowed = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({ mapGroupId: groupId, geoguessrId: 'boundary-map' }),
+      );
+      expect(allowed.status).toBe(200);
+      const { id } = (await allowed.json()) as { id: number };
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row!.geoguessrId).toBe('boundary-map');
+    });
+
+    test('rejected update to a popular GeoGuessr ID keeps the old map intact', async () => {
+      await seedUser('owner-1');
+      const groupId = await seedGroup('Test group');
+      await seedGroupOwner('owner-1', groupId);
+      const oldLevelId = await seedLevel(groupId, 'Old level');
+      const newLevelId = await seedLevel(groupId, 'New level');
+
+      const created = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'stable-id',
+          levels: [oldLevelId],
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      geoguessrFetches = [];
+      geoguessrMapResults = { 'popular-id': 20000 };
+      const updated = await groupMapPutRequest(
+        'owner-1',
+        groupMapBody({
+          id,
+          mapGroupId: groupId,
+          geoguessrId: 'popular-id',
+          name: 'Should Not Persist',
+          levels: [newLevelId],
+        }),
+      );
+      expect(updated.status).toBe(403);
+      expect(await updated.json()).toEqual({ message: popularMapMessage });
+      expect(geoguessrFetches).toEqual(['popular-id']);
+
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row).toEqual(
+        expect.objectContaining({
+          id,
+          geoguessrId: 'stable-id',
+          name: 'Map Name',
+        }),
+      );
+      expect(
+        await db
+          .select({ levelId: mapLevels.levelId })
+          .from(mapLevels)
+          .where(eq(mapLevels.mapId, id)),
+      ).toEqual([{ levelId: oldLevelId }]);
+    });
+
+    test('superadmin update with a changed GeoGuessr ID bypasses the lookup', async () => {
+      await seedUser('admin-1', true);
+      const groupId = await seedGroup('Test group');
+
+      const created = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({ mapGroupId: groupId, geoguessrId: 'original-id' }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+      expect(geoguessrFetches).toEqual([]);
+
+      const updated = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          id,
+          mapGroupId: groupId,
+          geoguessrId: 'changed-id',
+          name: 'Superadmin Rename',
+        }),
+      );
+      expect(updated.status).toBe(200);
+      // even a changed ID never reaches the GeoGuessr API for superadmins
+      expect(geoguessrFetches).toEqual([]);
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row).toEqual(
+        expect.objectContaining({
+          id,
+          geoguessrId: 'changed-id',
+          name: 'Superadmin Rename',
+        }),
+      );
+    });
+  });
+
+  describe('transactional rollback', () => {
+    test('invalid association rolls back the base map row and every association set', async () => {
+      await seedUser('admin-1', true);
+      const groupId = await seedGroup('Test group');
+      const levelA = await seedLevel(groupId, 'Beginner');
+      const levelB = await seedLevel(groupId, 'Advanced');
+      const regionA = await seedRegion('Europe');
+      const regionB = await seedRegion('Asia');
+
+      const created = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          mapGroupId: groupId,
+          geoguessrId: 'stable-id',
+          levels: [levelA],
+          regions: [regionA],
+          includeFilters: ['us'],
+          excludeFilters: ['dangerous'],
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      // Nonexistent region id 999999: the region insert is the last data
+      // mutation in the transaction, so a rollback must restore the base row
+      // and the level/filter/region mutations that already ran.
+      const failed = await groupMapPutRequest(
+        'admin-1',
+        groupMapBody({
+          id,
+          mapGroupId: groupId,
+          geoguessrId: 'stable-id',
+          name: 'Should Not Persist',
+          levels: [levelB],
+          regions: [regionB, 999999],
+          includeFilters: ['ca'],
+          excludeFilters: [],
+        }),
+      );
+      // FK violation is not a GeoGuessr-ID conflict: it propagates as 500
+      expect(failed.status).toBe(500);
+
+      const [row] = await db.select().from(maps).where(eq(maps.id, id));
+      expect(row).toEqual(
+        expect.objectContaining({
+          id,
+          geoguessrId: 'stable-id',
+          name: 'Map Name',
+          description: 'Map description',
+        }),
+      );
+
+      // level A was not deleted, level B was not inserted
+      expect(
+        await db
+          .select({ levelId: mapLevels.levelId })
+          .from(mapLevels)
+          .where(eq(mapLevels.mapId, id)),
+      ).toEqual([{ levelId: levelA }]);
+
+      // 'us' and 'dangerous' were not deleted, 'ca' was not inserted
+      const filterRows = await db
+        .select({
+          tagLike: mapFilters.tagLike,
+          isExclude: mapFilters.isExclude,
+        })
+        .from(mapFilters)
+        .where(eq(mapFilters.mapId, id))
+        .orderBy(asc(mapFilters.tagLike));
+      expect(filterRows).toEqual([
+        { tagLike: 'dangerous', isExclude: true },
+        { tagLike: 'us', isExclude: false },
+      ]);
+
+      // region A remains, region B and the invalid id were not inserted
+      expect(
+        await db
+          .select({ regionId: mapRegions.regionId })
+          .from(mapRegions)
+          .where(eq(mapRegions.mapId, id)),
+      ).toEqual([{ regionId: regionA }]);
+
+      // unchanged GeoGuessr ID and superadmin caller: no external lookup
+      expect(geoguessrFetches).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/routes/internal/maps/index.db.test.ts
+++ b/apps/api/src/routes/internal/maps/index.db.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { app } from '../../../api';
+import { app } from '@api/api';
 import {
   mapGroupPermissions,
   mapGroups,
   maps,
   users,
-} from '../../../lib/db/schema';
-import { db } from '../../../lib/drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
 
 async function seedUser(id: string, isSuperadmin = false, apiToken?: string) {
   await db.insert(users).values({

--- a/apps/api/src/routes/internal/maps/index.db.test.ts
+++ b/apps/api/src/routes/internal/maps/index.db.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test';
+import { app } from '../../../api';
+import {
+  mapGroupPermissions,
+  mapGroups,
+  maps,
+  users,
+} from '../../../lib/db/schema';
+import { db } from '../../../lib/drizzle';
+
+async function seedUser(id: string, isSuperadmin = false, apiToken?: string) {
+  await db.insert(users).values({
+    id,
+    username: id,
+    isSuperadmin,
+    apiToken: apiToken ?? null,
+  });
+}
+
+async function seedGroup(name: string) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name })
+    .returning({ id: mapGroups.id });
+  return group!.id;
+}
+
+async function seedGroupMap(
+  name: string,
+  geoguessrId: string,
+  groupId: number,
+) {
+  const [map] = await db
+    .insert(maps)
+    .values({ mapGroupId: groupId, name, geoguessrId, isPersonal: false })
+    .returning({ id: maps.id });
+  return map!.id;
+}
+
+async function seedPersonalMap(
+  ownerId: string,
+  name: string,
+  geoguessrId: string,
+) {
+  const [map] = await db
+    .insert(maps)
+    .values({ userId: ownerId, name, geoguessrId, isPersonal: true })
+    .returning({ id: maps.id });
+  return map!.id;
+}
+
+async function seedPermission(
+  groupId: number,
+  userId: string,
+  role: 'owner' | 'editor',
+) {
+  await db
+    .insert(mapGroupPermissions)
+    .values({ mapGroupId: groupId, userId, role });
+}
+
+function mapGroupRequest(geoguessrId: string, userId: string) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/maps/mapgroup/${geoguessrId}`, {
+      headers: { 'x-api-user-id': userId },
+    }),
+  );
+}
+
+interface PermissionUser {
+  id: string;
+  username: string;
+  isTrusted: boolean;
+  isSuperadmin: boolean;
+  apiToken: string | null;
+}
+
+interface Permission {
+  id: number;
+  mapGroupId: number;
+  userId: string;
+  role: 'owner' | 'editor';
+  user: PermissionUser;
+}
+
+interface GroupResponse {
+  isPersonal: boolean;
+  id: number;
+  name: string;
+  syncedAt: number | null;
+  syncIncludeLocationsNotOnStreetView: boolean;
+  owners: string;
+  permissions: Permission[];
+}
+
+describe('GET /api/internal/maps/mapgroup/:geoguessrId', () => {
+  test('denies non-superadmin callers with 403', async () => {
+    await seedUser('user-1');
+    await seedUser('admin-1', true);
+    const groupId = await seedGroup('Test group');
+    await seedGroupMap('Group Map', 'group-map', groupId);
+
+    const response = await mapGroupRequest('group-map', 'user-1');
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('Forbidden: Admin access required');
+  });
+
+  test('superadmin gets 404 for a missing map', async () => {
+    await seedUser('admin-1', true);
+
+    const response = await mapGroupRequest('no-such-map', 'admin-1');
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Map not found');
+  });
+
+  test('superadmin gets the personal map branch', async () => {
+    await seedUser('admin-1', true);
+    await seedUser('owner-1');
+    const id = await seedPersonalMap('owner-1', 'My Map', 'personal-map');
+
+    const response = await mapGroupRequest('personal-map', 'admin-1');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      isPersonal: true,
+      id,
+      name: 'My Map',
+      owner: 'owner-1',
+      userId: 'owner-1',
+    });
+  });
+
+  describe('group map branch', () => {
+    test('superadmin gets the group with an owners summary', async () => {
+      await seedUser('admin-1', true);
+      await seedUser('owner-1', false, 'owner-secret-token');
+      await seedUser('editor-1', false, 'editor-secret-token');
+      const groupId = await seedGroup('Test group');
+      await seedGroupMap('Group Map', 'group-map', groupId);
+      await seedPermission(groupId, 'owner-1', 'owner');
+      await seedPermission(groupId, 'editor-1', 'editor');
+
+      const response = await mapGroupRequest('group-map', 'admin-1');
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as GroupResponse;
+
+      // security-relevant public shape only: the nested permission users are
+      // intentionally not asserted to include or exclude apiToken here (see
+      // the omission todo below)
+      expect(body).toMatchObject({
+        isPersonal: false,
+        id: groupId,
+        name: 'Test group',
+        syncedAt: null,
+        syncIncludeLocationsNotOnStreetView: true,
+      });
+      expect(body.owners.split(', ').sort()).toEqual(['editor-1', 'owner-1']);
+      expect(
+        body.permissions
+          .map(({ mapGroupId, userId, role, user }) => ({
+            mapGroupId,
+            userId,
+            role,
+            user: {
+              id: user.id,
+              username: user.username,
+              isTrusted: user.isTrusted,
+              isSuperadmin: user.isSuperadmin,
+            },
+          }))
+          .sort((a, b) => a.userId.localeCompare(b.userId)),
+      ).toEqual([
+        {
+          mapGroupId: groupId,
+          userId: 'editor-1',
+          role: 'editor',
+          user: {
+            id: 'editor-1',
+            username: 'editor-1',
+            isTrusted: false,
+            isSuperadmin: false,
+          },
+        },
+        {
+          mapGroupId: groupId,
+          userId: 'owner-1',
+          role: 'owner',
+          user: {
+            id: 'owner-1',
+            username: 'owner-1',
+            isTrusted: false,
+            isSuperadmin: false,
+          },
+        },
+      ]);
+      expect(body).not.toHaveProperty('owner');
+      expect(body).not.toHaveProperty('userId');
+    });
+
+    test.todo('omits apiToken from nested permission users', async () => {
+      // Defect: the handler loads mapGroup.permissions with `with: { user: true }`
+      // (src/routes/internal/maps/index.ts), so each nested user carries its
+      // apiToken. The group response must not expose secrets to the internal API.
+      await seedUser('admin-1', true);
+      await seedUser('owner-1', false, 'owner-secret-token');
+      const groupId = await seedGroup('Test group');
+      await seedGroupMap('Group Map', 'group-map', groupId);
+      await seedPermission(groupId, 'owner-1', 'owner');
+
+      const response = await mapGroupRequest('group-map', 'admin-1');
+      const body = (await response.json()) as GroupResponse;
+
+      for (const permission of body.permissions) {
+        expect(permission.user).not.toHaveProperty('apiToken');
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/internal/maps/personal.db.test.ts
+++ b/apps/api/src/routes/internal/maps/personal.db.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
-import { app } from '../../../api';
+import { app } from '@api/api';
 import {
   mapGroups,
   maps,
   syncedMapMetas,
   syncedMetas,
   users,
-} from '../../../lib/db/schema';
-import { db } from '../../../lib/drizzle';
-import { popularMapMessage } from '../../../lib/internal/utils';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { popularMapMessage } from '@api/lib/internal/utils';
+import { eq } from 'drizzle-orm';
 
 const originalFetch = globalThis.fetch;
 const originalNfcaToken = process.env.NFCA_TOKEN;

--- a/apps/api/src/routes/internal/maps/personal.db.test.ts
+++ b/apps/api/src/routes/internal/maps/personal.db.test.ts
@@ -1,0 +1,618 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { app } from '../../../api';
+import {
+  mapGroups,
+  maps,
+  syncedMapMetas,
+  syncedMetas,
+  users,
+} from '../../../lib/db/schema';
+import { db } from '../../../lib/drizzle';
+import { popularMapMessage } from '../../../lib/internal/utils';
+
+const originalFetch = globalThis.fetch;
+const originalNfcaToken = process.env.NFCA_TOKEN;
+
+let geoguessrFetches: string[] = [];
+
+function mockGeoguessrSearch(gamesPlayedByMap: Record<string, number>) {
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.startsWith('https://www.geoguessr.com/api/v3/search/map')) {
+      const q = new URL(url).searchParams.get('q') ?? '';
+      geoguessrFetches.push(q);
+      const numberOfGamesPlayed = gamesPlayedByMap[q];
+      const body =
+        numberOfGamesPlayed === undefined
+          ? []
+          : [{ id: q, numberOfGamesPlayed }];
+      return new Response(JSON.stringify(body), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`Unexpected external request: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+function restoreFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+function restoreNfcaToken() {
+  if (originalNfcaToken === undefined) {
+    delete process.env.NFCA_TOKEN;
+  } else {
+    process.env.NFCA_TOKEN = originalNfcaToken;
+  }
+}
+
+async function createPersonalMap({
+  userId,
+  name,
+  geoguessrId,
+}: {
+  userId: string;
+  name: string;
+  geoguessrId: string;
+}) {
+  return app.handle(
+    new Request('http://localhost/api/internal/maps/personal', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify({ name, geoguessrId }),
+    }),
+  );
+}
+
+async function seedUser(id: string, isSuperadmin = false) {
+  await db.insert(users).values({
+    id,
+    username: id,
+    isSuperadmin,
+  });
+}
+
+async function seedPersonalMap({
+  userId,
+  name,
+  geoguessrId,
+}: {
+  userId: string;
+  name: string;
+  geoguessrId: string;
+}) {
+  const [map] = await db
+    .insert(maps)
+    .values({ userId, name, geoguessrId, isPersonal: true })
+    .returning({ id: maps.id });
+  return map!;
+}
+
+async function seedGroupMap({
+  name,
+  geoguessrId,
+}: {
+  name: string;
+  geoguessrId: string;
+}) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Test group' })
+    .returning({ id: mapGroups.id });
+  const [map] = await db
+    .insert(maps)
+    .values({ mapGroupId: group!.id, name, geoguessrId, isPersonal: false })
+    .returning({ id: maps.id });
+  return map!;
+}
+
+function personalMapRequest(
+  mapId: number,
+  userId: string,
+  init: RequestInit = {},
+) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/maps/personal/${mapId}`, {
+      ...init,
+      headers: { 'x-api-user-id': userId, ...init.headers },
+    }),
+  );
+}
+
+function personalMapMetasRequest(
+  mapId: number,
+  userId: string,
+  init: RequestInit = {},
+) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/maps/personal/${mapId}/metas`, {
+      ...init,
+      headers: { 'x-api-user-id': userId, ...init.headers },
+    }),
+  );
+}
+
+describe('POST /api/internal/maps/personal', () => {
+  beforeEach(() => {
+    // geoguessrAPIFetch throws before any network call without this token
+    process.env.NFCA_TOKEN = 'test-token';
+    geoguessrFetches = [];
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    restoreNfcaToken();
+  });
+
+  describe('normal user', () => {
+    beforeEach(async () => {
+      await seedUser('user-1');
+    });
+
+    test('creates a personal map when the GeoGuessr ID is not popular', async () => {
+      mockGeoguessrSearch({ 'my-map': 100 });
+
+      const response = await createPersonalMap({
+        userId: 'user-1',
+        name: 'My Map',
+        geoguessrId: 'my-map',
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ id: expect.any(Number) });
+
+      const [row] = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.userId, 'user-1'));
+      expect(row).toEqual(
+        expect.objectContaining({
+          userId: 'user-1',
+          name: 'My Map',
+          geoguessrId: 'my-map',
+          isPersonal: true,
+          mapGroupId: null,
+        }),
+      );
+      expect(geoguessrFetches).toEqual(['my-map']);
+    });
+
+    test('rejects a popular map with 403 and stores nothing', async () => {
+      mockGeoguessrSearch({ famous: 50000 });
+
+      const response = await createPersonalMap({
+        userId: 'user-1',
+        name: 'Famous Map',
+        geoguessrId: 'famous',
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toBe(popularMapMessage);
+      expect(await db.select().from(maps)).toEqual([]);
+    });
+
+    test('returns 409 when the GeoGuessr ID is already taken', async () => {
+      mockGeoguessrSearch({ 'my-map': 100 });
+
+      const first = await createPersonalMap({
+        userId: 'user-1',
+        name: 'My Map',
+        geoguessrId: 'my-map',
+      });
+      expect(first.status).toBe(200);
+
+      const second = await createPersonalMap({
+        userId: 'user-1',
+        name: 'My Map Again',
+        geoguessrId: 'my-map',
+      });
+      expect(second.status).toBe(409);
+      expect(await second.text()).toBe(
+        'Map with this GeoGuessr ID already exists.',
+      );
+      expect(await db.select().from(maps)).toHaveLength(1);
+    });
+  });
+
+  describe('superadmin user', () => {
+    beforeEach(async () => {
+      await seedUser('admin-1', true);
+    });
+
+    test('bypasses the popularity check without calling the GeoGuessr API', async () => {
+      mockGeoguessrSearch({ famous: 50000 });
+
+      const response = await createPersonalMap({
+        userId: 'admin-1',
+        name: 'Famous Map',
+        geoguessrId: 'famous',
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ id: expect.any(Number) });
+      expect(geoguessrFetches).toEqual([]);
+
+      const [row] = await db
+        .select()
+        .from(maps)
+        .where(eq(maps.userId, 'admin-1'));
+      expect(row).toEqual(
+        expect.objectContaining({
+          userId: 'admin-1',
+          geoguessrId: 'famous',
+          isPersonal: true,
+        }),
+      );
+    });
+  });
+});
+
+describe('GET /api/internal/maps/personal/:id', () => {
+  test('owner can read their personal map', async () => {
+    await seedUser('user-1');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-1');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      geoguessrId: 'my-map',
+      name: 'My Map',
+      metas: [],
+    });
+  });
+
+  test('unrelated user cannot read another user personal map', async () => {
+    await seedUser('user-1');
+    await seedUser('user-2');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-2');
+
+    expect(response.status).toBe(403);
+  });
+
+  test('rejects group maps', async () => {
+    await seedUser('admin-1', true);
+    const { id } = await seedGroupMap({
+      name: 'Group Map',
+      geoguessrId: 'group-map',
+    });
+
+    const response = await personalMapRequest(id, 'admin-1');
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('PATCH /api/internal/maps/personal/:id', () => {
+  beforeEach(() => {
+    // geoguessrAPIFetch throws before any network call without this token
+    process.env.NFCA_TOKEN = 'test-token';
+    geoguessrFetches = [];
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    restoreNfcaToken();
+  });
+
+  test('partial update preserves omitted fields', async () => {
+    await seedUser('user-1');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id });
+    const [row] = await db.select().from(maps).where(eq(maps.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({
+        name: 'Renamed',
+        geoguessrId: 'my-map',
+        isPersonal: true,
+        userId: 'user-1',
+      }),
+    );
+  });
+
+  test('duplicate GeoGuessr ID conflict leaves the row unchanged', async () => {
+    mockGeoguessrSearch({ 'my-map': 100 });
+    await seedUser('user-1');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+    const { id: otherId } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'Other Map',
+      geoguessrId: 'other-map',
+    });
+
+    const response = await personalMapRequest(otherId, 'user-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed', geoguessrId: 'my-map' }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.text()).toBe(
+      'Map with this GeoGuessr ID already exists.',
+    );
+    // The whole update rolled back: neither the name nor the geoguessrId changed.
+    const [row] = await db.select().from(maps).where(eq(maps.id, otherId));
+    expect(row).toEqual(
+      expect.objectContaining({ name: 'Other Map', geoguessrId: 'other-map' }),
+    );
+    const [original] = await db.select().from(maps).where(eq(maps.id, id));
+    expect(original).toEqual(
+      expect.objectContaining({ name: 'My Map', geoguessrId: 'my-map' }),
+    );
+  });
+
+  test('unrelated user cannot update another user personal map', async () => {
+    await seedUser('user-1');
+    await seedUser('user-2');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-2', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(response.status).toBe(403);
+    const [row] = await db.select().from(maps).where(eq(maps.id, id));
+    expect(row).toEqual(expect.objectContaining({ name: 'My Map' }));
+  });
+
+  test('rejects group maps', async () => {
+    await seedUser('admin-1', true);
+    const { id } = await seedGroupMap({
+      name: 'Group Map',
+      geoguessrId: 'group-map',
+    });
+
+    const response = await personalMapRequest(id, 'admin-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed' }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/internal/maps/personal/:id', () => {
+  test('owner can delete their personal map', async () => {
+    await seedUser('user-1');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-1', {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await db.select().from(maps).where(eq(maps.id, id))).toEqual([]);
+  });
+
+  test('unrelated user cannot delete another user personal map', async () => {
+    await seedUser('user-1');
+    await seedUser('user-2');
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-2', {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(403);
+    expect(await db.select().from(maps).where(eq(maps.id, id))).toHaveLength(1);
+  });
+
+  test('rejects group maps', async () => {
+    await seedUser('user-1');
+    const { id } = await seedGroupMap({
+      name: 'Group Map',
+      geoguessrId: 'group-map',
+    });
+
+    const response = await personalMapRequest(id, 'user-1', {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(403);
+    expect(await db.select().from(maps).where(eq(maps.id, id))).toHaveLength(1);
+  });
+
+  test.todo('rejects deleting a group map when the caller passes the ownership check', async () => {
+    // Defect: the DELETE handler runs ensureMapAccess but then deletes by
+    // map id without an isPersonal guard, so any map the caller can access
+    // (e.g. a group map as superadmin, or a non-personal map with a userId)
+    // is deleted by the personal-maps endpoint.
+    await seedUser('admin-1', true);
+    const { id } = await seedGroupMap({
+      name: 'Group Map',
+      geoguessrId: 'group-map',
+    });
+
+    const response = await personalMapRequest(id, 'admin-1', {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(404);
+    expect(await db.select().from(maps).where(eq(maps.id, id))).toHaveLength(1);
+  });
+});
+
+describe('POST/DELETE /api/internal/maps/personal/:id/metas', () => {
+  test('owner adds only metas synced from shared maps; removal stays scoped to the target personal map', async () => {
+    await seedUser('owner-1');
+    await seedUser('other-1');
+
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Source group' })
+      .returning({ id: mapGroups.id });
+    const groupId = group!.id;
+
+    // Source metas: one synced from a shared map, one only from a nonshared map.
+    const sharedMetaId = 7001;
+    const nonsharedMetaId = 7002;
+    await db.insert(syncedMetas).values([
+      {
+        metaId: sharedMetaId,
+        mapGroupId: groupId,
+        name: 'Shared meta',
+        note: 'note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      },
+      {
+        metaId: nonsharedMetaId,
+        mapGroupId: groupId,
+        name: 'Nonshared meta',
+        note: 'note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      },
+    ]);
+
+    const [sharedSourceMap] = await db
+      .insert(maps)
+      .values({
+        name: 'Shared source map',
+        geoguessrId: 'shared-source-map',
+        mapGroupId: groupId,
+        isShared: true,
+        isPersonal: false,
+      })
+      .returning({ id: maps.id });
+    const [nonsharedSourceMap] = await db
+      .insert(maps)
+      .values({
+        name: 'Nonshared source map',
+        geoguessrId: 'nonshared-source-map',
+        mapGroupId: groupId,
+        isShared: false,
+        isPersonal: false,
+      })
+      .returning({ id: maps.id });
+
+    await db.insert(syncedMapMetas).values([
+      { mapId: sharedSourceMap!.id, syncedMetaId: sharedMetaId },
+      { mapId: nonsharedSourceMap!.id, syncedMetaId: nonsharedMetaId },
+    ]);
+
+    const { id: targetMapId } = await seedPersonalMap({
+      userId: 'owner-1',
+      name: 'Target map',
+      geoguessrId: 'target-map',
+    });
+    const { id: unrelatedMapId } = await seedPersonalMap({
+      userId: 'other-1',
+      name: 'Unrelated map',
+      geoguessrId: 'unrelated-map',
+    });
+    // The unrelated map already uses the shared meta; removal must not touch it.
+    await db.insert(syncedMapMetas).values({
+      mapId: unrelatedMapId,
+      syncedMetaId: sharedMetaId,
+    });
+
+    // POST: only the meta synced from a shared map may be added; the
+    // nonshared-source meta and an unknown id must stay unassociated.
+    const postResponse = await personalMapMetasRequest(targetMapId, 'owner-1', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        metaIds: [sharedMetaId, sharedMetaId, nonsharedMetaId, 9999],
+      }),
+    });
+    expect(postResponse.status).toBe(200);
+    expect(await postResponse.json()).toEqual({ success: true, inserted: 1 });
+
+    const targetMetasAfterPost = await db
+      .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, targetMapId));
+    expect(targetMetasAfterPost.map((row) => row.syncedMetaId)).toEqual([
+      sharedMetaId,
+    ]);
+
+    // DELETE: scoped to the target map; the same meta stays on the unrelated
+    // personal map and on the shared source map.
+    const deleteResponse = await personalMapMetasRequest(
+      targetMapId,
+      'owner-1',
+      {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ metaIds: [sharedMetaId] }),
+      },
+    );
+    expect(deleteResponse.status).toBe(200);
+
+    const targetMetasAfterDelete = await db
+      .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, targetMapId));
+    expect(targetMetasAfterDelete).toHaveLength(0);
+
+    const unrelatedAfterDelete = await db
+      .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, unrelatedMapId));
+    expect(unrelatedAfterDelete.map((row) => row.syncedMetaId)).toEqual([
+      sharedMetaId,
+    ]);
+    const sharedSourceAfterDelete = await db
+      .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, sharedSourceMap!.id));
+    expect(sharedSourceAfterDelete.map((row) => row.syncedMetaId)).toEqual([
+      sharedMetaId,
+    ]);
+    const nonsharedSourceAfterDelete = await db
+      .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, nonsharedSourceMap!.id));
+    expect(nonsharedSourceAfterDelete.map((row) => row.syncedMetaId)).toEqual([
+      nonsharedMetaId,
+    ]);
+  });
+});

--- a/apps/api/src/routes/internal/maps/personal.db.test.ts
+++ b/apps/api/src/routes/internal/maps/personal.db.test.ts
@@ -406,6 +406,30 @@ describe('PATCH /api/internal/maps/personal/:id', () => {
 
     expect(response.status).toBe(404);
   });
+
+  test.todo('superadmin can update any personal map through the personal route, matching ensureMapAccess', async () => {
+    // PATCH adds an owner predicate after ensureMapAccess grants superadmin access.
+    await seedUser('user-1');
+    await seedUser('admin-1', true);
+    const { id } = await seedPersonalMap({
+      userId: 'user-1',
+      name: 'My Map',
+      geoguessrId: 'my-map',
+    });
+
+    const response = await personalMapRequest(id, 'admin-1', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed by admin' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id });
+    const [row] = await db.select().from(maps).where(eq(maps.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({ name: 'Renamed by admin', userId: 'user-1' }),
+    );
+  });
 });
 
 describe('DELETE /api/internal/maps/personal/:id', () => {
@@ -614,5 +638,96 @@ describe('POST/DELETE /api/internal/maps/personal/:id/metas', () => {
     expect(nonsharedSourceAfterDelete.map((row) => row.syncedMetaId)).toEqual([
       nonsharedMetaId,
     ]);
+  });
+
+  test.todo('superadmin cannot mutate group map meta associations through personal routes', async () => {
+    // Defect: both the metas POST and DELETE handlers run ensureMapAccess
+    // (which superadmins pass for any map) but then mutate syncedMapMetas by
+    // map id without an isPersonal guard, so a group map is reachable through
+    // the personal-maps endpoint. GET and PATCH reject group maps with 404.
+    await seedUser('admin-1', true);
+    const { id: groupMapId } = await seedGroupMap({
+      name: 'Group Map',
+      geoguessrId: 'group-map',
+    });
+
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Source group' })
+      .returning({ id: mapGroups.id });
+    const groupId = group!.id;
+
+    // Both metas are synced from a shared map, so the handlers would accept
+    // them if the group-map route-type guard were missing.
+    const sharedMetaId = 7101;
+    const sharedMeta2Id = 7102;
+    await db.insert(syncedMetas).values([
+      {
+        metaId: sharedMetaId,
+        mapGroupId: groupId,
+        name: 'Shared meta',
+        note: 'note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      },
+      {
+        metaId: sharedMeta2Id,
+        mapGroupId: groupId,
+        name: 'Shared meta 2',
+        note: 'note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      },
+    ]);
+    const [sourceMap] = await db
+      .insert(maps)
+      .values({
+        name: 'Shared source map',
+        geoguessrId: 'shared-source-map',
+        mapGroupId: groupId,
+        isShared: true,
+        isPersonal: false,
+      })
+      .returning({ id: maps.id });
+    await db.insert(syncedMapMetas).values([
+      { mapId: sourceMap!.id, syncedMetaId: sharedMetaId },
+      { mapId: sourceMap!.id, syncedMetaId: sharedMeta2Id },
+    ]);
+    // Pre-existing association on the group map that DELETE must not remove.
+    await db.insert(syncedMapMetas).values({
+      mapId: groupMapId,
+      syncedMetaId: sharedMetaId,
+    });
+
+    const postResponse = await personalMapMetasRequest(groupMapId, 'admin-1', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ metaIds: [sharedMetaId, sharedMeta2Id] }),
+    });
+    expect(postResponse.status).toBe(404);
+
+    const deleteResponse = await personalMapMetasRequest(
+      groupMapId,
+      'admin-1',
+      {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ metaIds: [sharedMetaId] }),
+      },
+    );
+    expect(deleteResponse.status).toBe(404);
+
+    // Association preservation: neither POST added metas nor DELETE removed any,
+    // and the group map itself is untouched.
+    const associations = await db
+      .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
+      .from(syncedMapMetas)
+      .where(eq(syncedMapMetas.mapId, groupMapId));
+    expect(associations.map((row) => row.syncedMetaId)).toEqual([sharedMetaId]);
+    expect(
+      await db.select().from(maps).where(eq(maps.id, groupMapId)),
+    ).toHaveLength(1);
   });
 });

--- a/apps/api/src/routes/internal/metas-images.db.test.ts
+++ b/apps/api/src/routes/internal/metas-images.db.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { and, asc, eq } from 'drizzle-orm';
-import { app } from '../../api';
+import { app } from '@api/api';
 import {
   mapGroupChanges,
   mapGroupPermissions,
@@ -8,8 +7,9 @@ import {
   metaImages,
   metas,
   users,
-} from '../../lib/db/schema';
-import { db } from '../../lib/drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { and, asc, eq } from 'drizzle-orm';
 
 // distinctive value that a successful reorder overwrites
 const SEED_MODIFIED_AT = 1_000_000;

--- a/apps/api/src/routes/internal/metas-images.db.test.ts
+++ b/apps/api/src/routes/internal/metas-images.db.test.ts
@@ -1,0 +1,471 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { and, asc, eq } from 'drizzle-orm';
+import { app } from '../../api';
+import {
+  mapGroupChanges,
+  mapGroupPermissions,
+  mapGroups,
+  metaImages,
+  metas,
+  users,
+} from '../../lib/db/schema';
+import { db } from '../../lib/drizzle';
+
+// distinctive value that a successful reorder overwrites
+const SEED_MODIFIED_AT = 1_000_000;
+
+// S3 is the only true external boundary of the upload flow. Stub it before the
+// app module graph loads so the real Elysia handler, sharp conversion, and
+// PostgreSQL transaction run end to end.
+let uploadImageMock: (file: ArrayBuffer, name: string) => Promise<string>;
+mock.module('@api/lib/utils/s3', () => ({
+  uploadImage: (file: ArrayBuffer, name: string) => uploadImageMock(file, name),
+}));
+
+beforeEach(() => {
+  uploadImageMock = async () => {
+    throw new Error('uploadImage should not be called');
+  };
+});
+
+// 1x1 png: valid input for sharp, compact enough to keep inline
+const PNG_FIXTURE = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+async function seedUser(id: string) {
+  await db.insert(users).values({ id, username: id });
+}
+
+async function seedGroup(name: string) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name })
+    .returning({ id: mapGroups.id });
+  return group!.id;
+}
+
+async function seedPermission(userId: string, groupId: number) {
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId,
+    role: 'owner',
+  });
+}
+
+async function seedMeta(groupId: number, tagName: string) {
+  const [meta] = await db
+    .insert(metas)
+    .values({
+      mapGroupId: groupId,
+      tagName,
+      name: tagName,
+      note: `note for ${tagName}`,
+      modifiedAt: SEED_MODIFIED_AT,
+    })
+    .returning({ id: metas.id });
+  return meta!.id;
+}
+
+async function seedImage(metaId: number, imageUrl: string, order = 0) {
+  const [image] = await db
+    .insert(metaImages)
+    .values({ metaId, image_url: imageUrl, order })
+    .returning({ id: metaImages.id });
+  return image!;
+}
+
+function reorderImagesRequest(userId: string, metaId: number, body: unknown) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/metas/${metaId}/images/order`, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function uploadImageRequest(userId: string, metaId: number, file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  return app.handle(
+    new Request(`http://localhost/api/internal/metas/${metaId}/images`, {
+      method: 'POST',
+      headers: {
+        'x-api-user-id': userId,
+      },
+      body: form,
+    }),
+  );
+}
+
+function deleteImageRequest(userId: string, imageId: number) {
+  return app.handle(
+    new Request(`http://localhost/api/internal/metas/images/${imageId}`, {
+      method: 'DELETE',
+      headers: {
+        'x-api-user-id': userId,
+      },
+    }),
+  );
+}
+
+async function getImageOrders(metaId: number) {
+  return db
+    .select({ id: metaImages.id, order: metaImages.order })
+    .from(metaImages)
+    .where(eq(metaImages.metaId, metaId))
+    .orderBy(asc(metaImages.id));
+}
+
+async function getMetaModifiedAt(metaId: number) {
+  const [meta] = await db
+    .select({ modifiedAt: metas.modifiedAt })
+    .from(metas)
+    .where(eq(metas.id, metaId));
+  return meta!.modifiedAt;
+}
+
+async function getReorderLogs(groupId: number) {
+  return db
+    .select({
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      newValue: mapGroupChanges.newValue,
+    })
+    .from(mapGroupChanges)
+    .where(
+      and(
+        eq(mapGroupChanges.mapGroupId, groupId),
+        eq(mapGroupChanges.entityType, 'meta_image'),
+        eq(mapGroupChanges.operation, 'update'),
+      ),
+    );
+}
+
+async function getImageUrls(metaId: number) {
+  return db
+    .select({ imageUrl: metaImages.image_url })
+    .from(metaImages)
+    .where(eq(metaImages.metaId, metaId));
+}
+
+async function getImageCreateLogs(groupId: number) {
+  return db
+    .select({
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      newValue: mapGroupChanges.newValue,
+    })
+    .from(mapGroupChanges)
+    .where(
+      and(
+        eq(mapGroupChanges.mapGroupId, groupId),
+        eq(mapGroupChanges.entityType, 'meta_image'),
+        eq(mapGroupChanges.operation, 'create'),
+      ),
+    );
+}
+
+async function getImageDeleteLogs(groupId: number) {
+  return db
+    .select({
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      oldValue: mapGroupChanges.oldValue,
+    })
+    .from(mapGroupChanges)
+    .where(
+      and(
+        eq(mapGroupChanges.mapGroupId, groupId),
+        eq(mapGroupChanges.entityType, 'meta_image'),
+        eq(mapGroupChanges.operation, 'delete'),
+      ),
+    );
+}
+
+describe('PUT /api/internal/metas/:id/images/order', () => {
+  test('reorders images, bumps the meta modifiedAt, and logs the reorder', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+    const first = await seedImage(
+      metaId,
+      'https://img.example/france-1.jpg',
+      1,
+    );
+    const second = await seedImage(
+      metaId,
+      'https://img.example/france-2.jpg',
+      2,
+    );
+
+    const response = await reorderImagesRequest('owner-1', metaId, {
+      updates: [
+        { imageId: first.id, order: 2 },
+        { imageId: second.id, order: 1 },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      message: 'Image order updated successfully.',
+    });
+    expect(await getImageOrders(metaId)).toEqual([
+      { id: first.id, order: 2 },
+      { id: second.id, order: 1 },
+    ]);
+    expect(await getMetaModifiedAt(metaId)).not.toBe(SEED_MODIFIED_AT);
+    const logs = await getReorderLogs(groupId);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toEqual(
+      expect.objectContaining({
+        entityId: metaId,
+        entityLabel: 'france',
+        operation: 'update',
+        newValue: { reorderedImages: 2 },
+      }),
+    );
+  });
+
+  test('rejects a missing image id with 404 and rolls back every earlier update', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+    const first = await seedImage(
+      metaId,
+      'https://img.example/france-1.jpg',
+      1,
+    );
+    const second = await seedImage(
+      metaId,
+      'https://img.example/france-2.jpg',
+      2,
+    );
+    const missingImageId = second.id + 1000;
+
+    // the valid update comes first: only an atomic rollback keeps it from
+    // persisting when the missing image id fails later in the same batch
+    const response = await reorderImagesRequest('owner-1', metaId, {
+      updates: [
+        { imageId: first.id, order: 9 },
+        { imageId: missingImageId, order: 1 },
+      ],
+    });
+
+    expect(response.status).toBe(404);
+    // no partial write survived: orders, meta modifiedAt, and the log are
+    // all exactly as they were before the request
+    expect(await getImageOrders(metaId)).toEqual([
+      { id: first.id, order: 1 },
+      { id: second.id, order: 2 },
+    ]);
+    expect(await getMetaModifiedAt(metaId)).toBe(SEED_MODIFIED_AT);
+    expect(await getReorderLogs(groupId)).toEqual([]);
+  });
+
+  test('rejects an image belonging to another meta with 404 and leaves both metas untouched', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const franceId = await seedMeta(groupId, 'france');
+    const germanyId = await seedMeta(groupId, 'germany');
+    const franceImage = await seedImage(
+      franceId,
+      'https://img.example/france.jpg',
+      1,
+    );
+    const germanyImage = await seedImage(
+      germanyId,
+      'https://img.example/germany.jpg',
+      2,
+    );
+
+    // germany's image id is foreign to france's meta, so the scoped update
+    // matches no row and the whole batch must roll back
+    const response = await reorderImagesRequest('owner-1', franceId, {
+      updates: [
+        { imageId: franceImage.id, order: 5 },
+        { imageId: germanyImage.id, order: 6 },
+      ],
+    });
+
+    expect(response.status).toBe(404);
+    expect(await getImageOrders(franceId)).toEqual([
+      { id: franceImage.id, order: 1 },
+    ]);
+    expect(await getImageOrders(germanyId)).toEqual([
+      { id: germanyImage.id, order: 2 },
+    ]);
+    expect(await getMetaModifiedAt(franceId)).toBe(SEED_MODIFIED_AT);
+    expect(await getMetaModifiedAt(germanyId)).toBe(SEED_MODIFIED_AT);
+    expect(await getReorderLogs(groupId)).toEqual([]);
+  });
+
+  // todo: the handler returns status(404, undefined), which Elysia turns into a
+  // "Not Found" body; the declared 404: t.Void() response schema then rejects it
+  // as a 422 validation error. Missing metas should surface as 404.
+  test.todo('rejects a missing meta with 404', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+
+    const response = await reorderImagesRequest('owner-1', metaId + 1000, {
+      updates: [{ imageId: 1, order: 1 }],
+    });
+
+    expect(response.status).toBe(404);
+    expect(await getReorderLogs(groupId)).toEqual([]);
+  });
+});
+
+describe('DELETE /api/internal/metas/images/:imageId', () => {
+  test('deletes only the target image, bumps the meta modifiedAt, and logs the delete', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+    const target = await seedImage(
+      metaId,
+      'https://img.example/france-1.jpg',
+      1,
+    );
+    await seedImage(metaId, 'https://img.example/france-2.jpg', 2);
+
+    const response = await deleteImageRequest('owner-1', target.id);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ imageId: target.id });
+    // only the exact target row is gone; unrelated images of the same meta
+    // survive untouched
+    expect(await getImageUrls(metaId)).toEqual([
+      { imageUrl: 'https://img.example/france-2.jpg' },
+    ]);
+    expect(await getMetaModifiedAt(metaId)).not.toBe(SEED_MODIFIED_AT);
+    expect(await getImageDeleteLogs(groupId)).toEqual([
+      expect.objectContaining({
+        entityId: metaId,
+        entityLabel: 'france',
+        operation: 'delete',
+        oldValue: { imageUrl: 'https://img.example/france-1.jpg' },
+      }),
+    ]);
+  });
+
+  test('rejects a missing image with 404 and leaves the meta untouched', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+    const image = await seedImage(
+      metaId,
+      'https://img.example/france-1.jpg',
+      1,
+    );
+    const missingImageId = image.id + 1000;
+
+    const response = await deleteImageRequest('owner-1', missingImageId);
+
+    expect(response.status).toBe(404);
+    expect(await getImageUrls(metaId)).toEqual([
+      { imageUrl: 'https://img.example/france-1.jpg' },
+    ]);
+    expect(await getMetaModifiedAt(metaId)).toBe(SEED_MODIFIED_AT);
+    expect(await getImageDeleteLogs(groupId)).toEqual([]);
+  });
+});
+
+describe('POST /api/internal/metas/:id/images', () => {
+  test('converts a valid image, stores the uploaded URL, and logs the create', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+    const uploadedUrl = 'https://learnablemeta.com/images/123456789-abc.avif';
+    const calls: { file: ArrayBuffer; name: string }[] = [];
+    uploadImageMock = async (file, name) => {
+      calls.push({ file, name });
+      return uploadedUrl;
+    };
+
+    const response = await uploadImageRequest(
+      'owner-1',
+      metaId,
+      new File([PNG_FIXTURE], 'photo.png', { type: 'image/png' }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ imageUrl: uploadedUrl });
+    expect(calls).toHaveLength(1);
+    // the file was converted before upload: avif container magic bytes
+    expect(Buffer.from(calls[0].file).subarray(4, 12).toString()).toBe(
+      'ftypavif',
+    );
+    expect(calls[0].name).toMatch(
+      new RegExp(`^${groupId}/\\d+-\\w{3}\\.avif$`),
+    );
+    expect(await getImageUrls(metaId)).toEqual([{ imageUrl: uploadedUrl }]);
+    expect(await getMetaModifiedAt(metaId)).not.toBe(SEED_MODIFIED_AT);
+    expect(await getImageCreateLogs(groupId)).toEqual([
+      expect.objectContaining({
+        entityId: metaId,
+        entityLabel: 'france',
+        operation: 'create',
+        newValue: { imageUrl: uploadedUrl },
+      }),
+    ]);
+  });
+
+  // todo: the handler returns status(400, undefined), which Elysia turns into a
+  // "Bad Request" body; the declared 400: t.Void() response schema then rejects
+  // it as a 422 validation error. Non-image uploads should surface as 400, and
+  // the meta must stay untouched either way.
+  test.todo('rejects a non-image upload with 400 and leaves the meta untouched', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+
+    const response = await uploadImageRequest(
+      'owner-1',
+      metaId,
+      new File(['not actually an image'], 'broken.png', { type: 'image/png' }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await getImageUrls(metaId)).toEqual([]);
+    expect(await getMetaModifiedAt(metaId)).toBe(SEED_MODIFIED_AT);
+    expect(await getImageCreateLogs(groupId)).toEqual([]);
+  });
+
+  test('leaves the meta untouched when the S3 upload fails', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const metaId = await seedMeta(groupId, 'france');
+    uploadImageMock = async () => {
+      throw new Error('s3 upload failed');
+    };
+
+    const response = await uploadImageRequest(
+      'owner-1',
+      metaId,
+      new File([PNG_FIXTURE], 'photo.png', { type: 'image/png' }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await getImageUrls(metaId)).toEqual([]);
+    expect(await getMetaModifiedAt(metaId)).toBe(SEED_MODIFIED_AT);
+    expect(await getImageCreateLogs(groupId)).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/internal/metas.db.test.ts
+++ b/apps/api/src/routes/internal/metas.db.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { and, asc, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
 import { app } from '../../api';
 import {
   levels,
@@ -101,6 +101,19 @@ function bulkLevelAssignRequest(userId: string, body: unknown) {
 function metaCopyRequest(userId: string, body: unknown) {
   return app.handle(
     new Request('http://localhost/api/internal/metas/copy', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function metaShareRequest(userId: string, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/api/internal/metas/share', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -397,6 +410,70 @@ describe('PUT /api/internal/metas/', () => {
     expect(await getMetaLevelIds(id)).toEqual([{ levelId: beginner }]);
     // the aborted update wrote no log
     expect(await getMetaLogs(groupId)).toHaveLength(1);
+  });
+
+  test.todo('update rejects cross-group level IDs before persisting anything', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    const foreignGroupId = await seedGroup('Foreign group');
+    await seedPermission('owner-1', groupId);
+    const beginner = await seedLevel(groupId, 'Beginner');
+    const foreignLevel = await seedLevel(foreignGroupId, 'Foreign level');
+
+    const created = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'France',
+        note: 'old note',
+        levels: [beginner],
+      }),
+    );
+    expect(created.status).toBe(200);
+    const { id } = (await created.json()) as { id: number };
+
+    // the foreign level exists, so its FK succeeds: missing group alignment is
+    // the only thing that should reject the update
+    const rejected = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        id,
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'Should Not Persist',
+        note: 'should not persist',
+        levels: [beginner, foreignLevel],
+      }),
+    );
+    expect(rejected.status).toBeGreaterThanOrEqual(400);
+    expect(rejected.status).toBeLessThan(500);
+
+    // scalar fields untouched
+    const [row] = await db.select().from(metas).where(eq(metas.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({
+        id,
+        mapGroupId: groupId,
+        name: 'France',
+        note: 'old note',
+      }),
+    );
+    // level association untouched: no cross-group row was inserted
+    expect(await getMetaLevelIds(id)).toEqual([{ levelId: beginner }]);
+    expect(
+      await db
+        .select()
+        .from(metaLevels)
+        .where(eq(metaLevels.levelId, foreignLevel)),
+    ).toEqual([]);
+    // only the original create log; no update log and nothing in the foreign group
+    expect(await getMetaLogs(groupId)).toHaveLength(1);
+    expect(await getMetaLogs(foreignGroupId)).toEqual([]);
+    // the foreign group's level itself survives untouched
+    expect(
+      await db.select().from(levels).where(eq(levels.id, foreignLevel)),
+    ).toHaveLength(1);
   });
 
   describe('move between groups', () => {
@@ -1139,5 +1216,460 @@ describe('POST /api/internal/metas/copy', () => {
     expect(targetLogs[0]!.entityId).toBe(targetId);
     expect(targetLogs[0]!.operation).toBe('create');
     expect(await getMetaLevelIds(sourceId)).toEqual([{ levelId: beginner }]);
+  });
+});
+
+describe('POST /api/internal/metas/share', () => {
+  test('shares metas with images and tag locations and reports the committed count', async () => {
+    await seedUser('owner-1');
+    const sourceGroup = await seedGroup('Source group');
+    const targetGroup = await seedGroup('Target group');
+    await seedPermission('owner-1', sourceGroup);
+    await seedPermission('owner-1', targetGroup);
+    const note = '**bold** share';
+    const footer = 'shared footer';
+
+    const franceId = await seedMeta('owner-1', sourceGroup, 'france', {
+      name: 'France',
+      note,
+      footer,
+      noteFromPlonkit: true,
+    });
+    const germanyId = await seedMeta('owner-1', sourceGroup, 'germany', {
+      note: 'germany note',
+    });
+    // image and tag locations are seeded directly: image upload hits S3 and the
+    // locations upload path is out of scope for this endpoint
+    await db.insert(metaImages).values([
+      { metaId: franceId, image_url: 'https://img.example/france.jpg' },
+      { metaId: germanyId, image_url: 'https://img.example/germany.jpg' },
+    ]);
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: sourceGroup,
+      lat: 48.85,
+      lng: 2.35,
+      heading: 1,
+      pitch: 2,
+      zoom: 3,
+      panoId: 'pano-france-1',
+      extraTag: 'france',
+      extraPanoId: 'extra-1',
+      extraPanoDate: '2024-01-01',
+    });
+
+    const response = await metaShareRequest('owner-1', {
+      metaIds: [franceId, germanyId],
+      targetGroupId: targetGroup,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      copiedCount: 2,
+      totalRequested: 2,
+      message: 'Successfully shared 2 of 2 metas',
+    });
+
+    // both copies land in the target group under fresh ids
+    const [franceCopy] = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'france')),
+      );
+    const [germanyCopy] = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'germany')),
+      );
+    expect(franceCopy).toBeDefined();
+    expect(germanyCopy).toBeDefined();
+    expect(franceCopy!.id).not.toBe(franceId);
+    expect(germanyCopy!.id).not.toBe(germanyId);
+    expect(franceCopy).toEqual(
+      expect.objectContaining({
+        mapGroupId: targetGroup,
+        tagName: 'france',
+        name: 'France',
+        note,
+        footer,
+        noteFromPlonkit: true,
+      }),
+    );
+
+    // images follow each copy
+    const copiedImages = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, franceCopy!.id));
+    expect(copiedImages.map((image) => image.image_url)).toEqual([
+      'https://img.example/france.jpg',
+    ]);
+    // france's tag locations follow into the target group
+    const copiedLocations = await db
+      .select()
+      .from(mapGroupLocations)
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, targetGroup),
+          eq(mapGroupLocations.extraTag, 'france'),
+        ),
+      );
+    expect(copiedLocations).toHaveLength(1);
+    expect(copiedLocations[0]).toEqual(
+      expect.objectContaining({
+        mapGroupId: targetGroup,
+        lat: 48.85,
+        lng: 2.35,
+        heading: 1,
+        pitch: 2,
+        zoom: 3,
+        panoId: 'pano-france-1',
+        extraTag: 'france',
+        extraPanoId: 'extra-1',
+        extraPanoDate: '2024-01-01',
+      }),
+    );
+
+    // one create log per copy against the target group marking the shared origin
+    const targetLogs = await getMetaLogs(targetGroup);
+    expect(targetLogs).toHaveLength(2);
+    expect(targetLogs.map((log) => log.entityLabel).sort()).toEqual([
+      'france',
+      'germany',
+    ]);
+    expect(
+      targetLogs.every(
+        (log) => log.operation === 'create' && log.userId === 'owner-1',
+      ),
+    ).toBe(true);
+    expect(targetLogs.map((log) => log.newValue)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tagName: 'france',
+          name: 'France',
+          note,
+          footer,
+          noteFromPlonkit: true,
+          sharedFromGroupId: sourceGroup,
+        }),
+        expect.objectContaining({
+          tagName: 'germany',
+          note: 'germany note',
+          sharedFromGroupId: sourceGroup,
+        }),
+      ]),
+    );
+    // nothing new was logged against the source group (only its two creates)
+    expect(await getMetaLogs(sourceGroup)).toHaveLength(2);
+  });
+
+  test('existing target tag is skipped: the committed count excludes it and the target meta stays untouched', async () => {
+    await seedUser('owner-1');
+    const sourceGroup = await seedGroup('Source group');
+    const targetGroup = await seedGroup('Target group');
+    await seedPermission('owner-1', sourceGroup);
+    await seedPermission('owner-1', targetGroup);
+    const targetLevel = await seedLevel(targetGroup, 'Target level');
+
+    const sourceId = await seedMeta('owner-1', sourceGroup, 'france', {
+      name: 'France Source',
+      note: 'source note',
+    });
+    await db.insert(metaImages).values({
+      metaId: sourceId,
+      image_url: 'https://img.example/source.jpg',
+    });
+    const targetId = await seedMeta('owner-1', targetGroup, 'france', {
+      name: 'France Target',
+      note: 'target note',
+      levels: [targetLevel],
+    });
+    const germanyId = await seedMeta('owner-1', sourceGroup, 'germany', {
+      note: 'germany note',
+    });
+
+    const response = await metaShareRequest('owner-1', {
+      metaIds: [sourceId, germanyId],
+      targetGroupId: targetGroup,
+    });
+    expect(response.status).toBe(200);
+    // the existing-tag no-op is excluded from the committed count
+    expect(await response.json()).toEqual({
+      copiedCount: 1,
+      totalRequested: 2,
+      message: 'Successfully shared 1 of 2 metas',
+    });
+
+    // still exactly one 'france' in the target group: the pre-existing one
+    const targetFrance = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'france')),
+      );
+    expect(targetFrance).toHaveLength(1);
+    expect(targetFrance[0]!.id).toBe(targetId);
+    expect(targetFrance[0]).toEqual(
+      expect.objectContaining({ name: 'France Target', note: 'target note' }),
+    );
+
+    // nothing leaked from the skipped source meta: no image, no tag locations,
+    // and the pre-existing level assignment survives
+    expect(
+      await db.select().from(metaImages).where(eq(metaImages.metaId, targetId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(mapGroupLocations)
+        .where(
+          and(
+            eq(mapGroupLocations.mapGroupId, targetGroup),
+            eq(mapGroupLocations.extraTag, 'france'),
+          ),
+        ),
+    ).toHaveLength(0);
+    expect(await getMetaLevelIds(targetId)).toEqual([{ levelId: targetLevel }]);
+
+    // the germany meta copies normally with its own create log; the skipped
+    // france writes no log against the target group
+    const [germanyCopy] = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'germany')),
+      );
+    expect(germanyCopy).toBeDefined();
+    const targetLogs = await getMetaLogs(targetGroup);
+    expect(targetLogs).toHaveLength(2);
+    expect(targetLogs.map((log) => log.entityLabel).sort()).toEqual([
+      'france',
+      'germany',
+    ]);
+    const germanyLog = targetLogs.find((log) => log.entityLabel === 'germany')!;
+    expect(germanyLog.operation).toBe('create');
+    expect(germanyLog.newValue).toEqual(
+      expect.objectContaining({
+        tagName: 'germany',
+        sharedFromGroupId: sourceGroup,
+      }),
+    );
+  });
+
+  test('continues after a per-meta failure and counts only committed copies', async () => {
+    await seedUser('owner-1');
+    const sourceGroup = await seedGroup('Source group');
+    const targetGroup = await seedGroup('Target group');
+    await seedPermission('owner-1', sourceGroup);
+    await seedPermission('owner-1', targetGroup);
+    // the failing meta and its image are seeded before the trigger exists, so
+    // only the copy's image insert raises
+    const failingId = await seedMeta('owner-1', sourceGroup, 'fail-meta', {
+      note: 'will fail',
+    });
+    await db.insert(metaImages).values({
+      metaId: failingId,
+      image_url: 'https://img.example/fail.jpg',
+    });
+    const okId = await seedMeta('owner-1', sourceGroup, 'germany', {
+      note: 'germany note',
+    });
+    await db.insert(metaImages).values({
+      metaId: okId,
+      image_url: 'https://img.example/ok.jpg',
+    });
+
+    // make the failing meta's copy abort mid-transaction: the copy has already
+    // inserted its metas row by the time the image insert raises
+    await db.$primary.execute(sql`
+      CREATE OR REPLACE FUNCTION geometa_test_fail_share()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'intentional share test failure';
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await db.$primary.execute(sql`
+      CREATE TRIGGER geometa_test_fail_share_trigger
+      BEFORE INSERT ON meta_images
+      FOR EACH ROW WHEN (NEW.image_url = 'https://img.example/fail.jpg')
+      EXECUTE FUNCTION geometa_test_fail_share()
+    `);
+
+    try {
+      const response = await metaShareRequest('owner-1', {
+        metaIds: [failingId, okId],
+        targetGroupId: targetGroup,
+      });
+      // the per-meta failure is contained: the request succeeds with the other
+      // copy, and the count reflects only the committed copy
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        copiedCount: 1,
+        totalRequested: 2,
+        message: 'Successfully shared 1 of 2 metas',
+      });
+    } finally {
+      await db.$primary.execute(sql`
+        DROP TRIGGER IF EXISTS geometa_test_fail_share_trigger ON meta_images
+      `);
+      await db.$primary.execute(sql`
+        DROP FUNCTION IF EXISTS geometa_test_fail_share()
+      `);
+    }
+
+    // the failed copy left nothing behind: its whole per-meta transaction
+    // rolled back the meta and any tag-location writes
+    expect(
+      await db
+        .select()
+        .from(metas)
+        .where(
+          and(
+            eq(metas.mapGroupId, targetGroup),
+            eq(metas.tagName, 'fail-meta'),
+          ),
+        ),
+    ).toEqual([]);
+    expect(
+      await db
+        .select()
+        .from(mapGroupLocations)
+        .where(
+          and(
+            eq(mapGroupLocations.mapGroupId, targetGroup),
+            eq(mapGroupLocations.extraTag, 'fail-meta'),
+          ),
+        ),
+    ).toEqual([]);
+
+    // the healthy meta was copied in full: meta, image, and log
+    const [germanyCopy] = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'germany')),
+      );
+    expect(germanyCopy).toBeDefined();
+    expect(germanyCopy!.id).not.toBe(okId);
+    const copiedImages = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, germanyCopy!.id));
+    expect(copiedImages.map((image) => image.image_url)).toEqual([
+      'https://img.example/ok.jpg',
+    ]);
+    const targetLogs = await getMetaLogs(targetGroup);
+    expect(targetLogs).toHaveLength(1);
+    expect(targetLogs[0]!.entityLabel).toBe('germany');
+    expect(targetLogs[0]!.operation).toBe('create');
+    expect(targetLogs[0]!.newValue).toEqual(
+      expect.objectContaining({
+        tagName: 'germany',
+        sharedFromGroupId: sourceGroup,
+      }),
+    );
+
+    // the source meta keeps its own image
+    expect(
+      await db
+        .select()
+        .from(metaImages)
+        .where(eq(metaImages.metaId, failingId)),
+    ).toHaveLength(1);
+  });
+
+  test.todo('share remaps levels to same-named target-group levels and omits source-only levels', async () => {
+    await seedUser('owner-1');
+    const sourceGroup = await seedGroup('Source group');
+    const targetGroup = await seedGroup('Target group');
+    await seedPermission('owner-1', sourceGroup);
+    await seedPermission('owner-1', targetGroup);
+    // the same level name exists in both groups under distinct ids, plus one
+    // level that only the source group has
+    const sourceBeginner = await seedLevel(sourceGroup, 'Beginner');
+    const targetBeginner = await seedLevel(targetGroup, 'Beginner');
+    const sourceOnly = await seedLevel(sourceGroup, 'Source Only');
+
+    const sourceId = await seedMeta('owner-1', sourceGroup, 'france', {
+      name: 'France',
+      note: 'share remap note',
+      levels: [sourceBeginner, sourceOnly],
+    });
+
+    const response = await metaShareRequest('owner-1', {
+      metaIds: [sourceId],
+      targetGroupId: targetGroup,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      copiedCount: 1,
+      totalRequested: 1,
+      message: 'Successfully shared 1 of 1 metas',
+    });
+
+    const [copyRow] = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'france')),
+      );
+    expect(copyRow).toBeDefined();
+
+    // desired: the matching level name maps to the target group's own level id
+    // and the source-only level is safely omitted from the copy
+    expect(await getMetaLevelIds(copyRow!.id)).toEqual([
+      { levelId: targetBeginner },
+    ]);
+
+    // desired: no cross-group meta_levels row links a target meta to a
+    // source-group level
+    const targetLevelIds = new Set(
+      (
+        await db
+          .select({ id: levels.id })
+          .from(levels)
+          .where(eq(levels.mapGroupId, targetGroup))
+      ).map((level) => level.id),
+    );
+    const copyAssignments = await db
+      .select({ levelId: metaLevels.levelId })
+      .from(metaLevels)
+      .where(eq(metaLevels.metaId, copyRow!.id));
+    expect(
+      copyAssignments.every((assignment) =>
+        targetLevelIds.has(assignment.levelId),
+      ),
+    ).toBe(true);
+
+    // the source meta keeps its own level assignments untouched
+    expect(await getMetaLevelIds(sourceId)).toEqual([
+      { levelId: sourceBeginner },
+      { levelId: sourceOnly },
+    ]);
+
+    // the target copy is audited as a create sharing the source origin; the
+    // source group logs nothing new
+    expect(await getMetaLogs(targetGroup)).toEqual([
+      {
+        mapGroupId: targetGroup,
+        userId: 'owner-1',
+        entityType: 'meta',
+        entityId: copyRow!.id,
+        entityLabel: 'france',
+        operation: 'create',
+        oldValue: null,
+        newValue: {
+          tagName: 'france',
+          name: 'France',
+          note: 'share remap note',
+          footer: '',
+          noteFromPlonkit: false,
+          sharedFromGroupId: sourceGroup,
+        },
+        createdAt: expect.any(Number),
+      },
+    ]);
+    expect(await getMetaLogs(sourceGroup)).toHaveLength(1);
   });
 });

--- a/apps/api/src/routes/internal/metas.db.test.ts
+++ b/apps/api/src/routes/internal/metas.db.test.ts
@@ -1,0 +1,1143 @@
+import { describe, expect, test } from 'bun:test';
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { app } from '../../api';
+import {
+  levels,
+  mapGroupChanges,
+  mapGroupLocations,
+  mapGroupPermissions,
+  mapGroups,
+  metaImages,
+  metaLevels,
+  metas,
+  users,
+} from '../../lib/db/schema';
+import { db } from '../../lib/drizzle';
+
+async function seedUser(id: string) {
+  await db.insert(users).values({ id, username: id });
+}
+
+async function seedGroup(name: string) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name })
+    .returning({ id: mapGroups.id });
+  return group!.id;
+}
+
+async function seedPermission(
+  userId: string,
+  groupId: number,
+  role: 'owner' | 'editor' = 'owner',
+) {
+  await db.insert(mapGroupPermissions).values({
+    mapGroupId: groupId,
+    userId,
+    role,
+  });
+}
+
+async function seedLevel(groupId: number, name: string) {
+  const [level] = await db
+    .insert(levels)
+    .values({ mapGroupId: groupId, name })
+    .returning({ id: levels.id });
+  return level!.id;
+}
+
+function metaBody(overrides: Record<string, unknown> = {}) {
+  return {
+    mapGroupId: 1,
+    tagName: 'test-tag',
+    name: 'Test Meta',
+    note: 'plain note',
+    noteFromPlonkit: false,
+    levels: [],
+    footer: '',
+    ...overrides,
+  };
+}
+
+function metaPutRequest(userId: string, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/api/internal/metas/', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function metaDeleteRequest(userId: string, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/api/internal/metas/', {
+      method: 'DELETE',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function bulkLevelAssignRequest(userId: string, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/api/internal/metas/levels', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function metaCopyRequest(userId: string, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/api/internal/metas/copy', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-user-id': userId,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+// Creates a meta via the PUT endpoint and returns its id.
+async function seedMeta(
+  userId: string,
+  groupId: number,
+  tagName: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const response = await metaPutRequest(
+    userId,
+    metaBody({ mapGroupId: groupId, tagName, name: tagName, ...overrides }),
+  );
+  expect(response.status).toBe(200);
+  const { id } = (await response.json()) as { id: number };
+  return id;
+}
+
+async function getDeleteLogs(groupId: number) {
+  const logs = await getMetaLogs(groupId);
+  return logs.filter((log) => log.operation === 'delete');
+}
+
+async function getMetaLevelIds(metaId: number) {
+  return db
+    .select({ levelId: metaLevels.levelId })
+    .from(metaLevels)
+    .where(eq(metaLevels.metaId, metaId))
+    .orderBy(asc(metaLevels.levelId));
+}
+
+async function getMetaLogs(groupId: number) {
+  return db
+    .select({
+      mapGroupId: mapGroupChanges.mapGroupId,
+      userId: mapGroupChanges.userId,
+      entityType: mapGroupChanges.entityType,
+      entityId: mapGroupChanges.entityId,
+      entityLabel: mapGroupChanges.entityLabel,
+      operation: mapGroupChanges.operation,
+      oldValue: mapGroupChanges.oldValue,
+      newValue: mapGroupChanges.newValue,
+      createdAt: mapGroupChanges.createdAt,
+    })
+    .from(mapGroupChanges)
+    .where(eq(mapGroupChanges.mapGroupId, groupId))
+    .orderBy(mapGroupChanges.id);
+}
+
+describe('PUT /api/internal/metas/', () => {
+  test('create requires permission in the target group', async () => {
+    await seedUser('owner-1');
+    await seedUser('outsider-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+
+    const response = await metaPutRequest(
+      'outsider-1',
+      metaBody({ mapGroupId: groupId }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await db.select().from(metas)).toEqual([]);
+    expect(await getMetaLogs(groupId)).toEqual([]);
+  });
+
+  test('create persists exact raw Markdown, sanitized HTML, levels, and a create log', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const beginner = await seedLevel(groupId, 'Beginner');
+    const advanced = await seedLevel(groupId, 'Advanced');
+    const note =
+      '# Header\n\n<script>alert(1)</script>\n\n**bold** [link](https://example.com)';
+    const footer = '## Sub\n\n<img src=x onerror=alert(1)>';
+
+    const response = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'France',
+        note,
+        footer,
+        noteFromPlonkit: true,
+        levels: [beginner, advanced],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const { id } = (await response.json()) as { id: number };
+
+    const [row] = await db.select().from(metas).where(eq(metas.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({
+        id,
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'France',
+        // raw Markdown persisted verbatim
+        note,
+        noteHtml:
+          '<h1>Header</h1>\n<p><strong>bold</strong> <a href="https://example.com" rel="nofollow" target="_blank">link</a></p>',
+        footer,
+        // script and img tags stripped by rehype-sanitize
+        footerHtml: '<h2>Sub</h2>',
+        noteFromPlonkit: true,
+        hasImage: false,
+        modifiedAt: expect.any(Number),
+      }),
+    );
+
+    expect(await getMetaLevelIds(id)).toEqual([
+      { levelId: beginner },
+      { levelId: advanced },
+    ]);
+
+    expect(await getMetaLogs(groupId)).toEqual([
+      {
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'meta',
+        entityId: id,
+        entityLabel: 'france',
+        operation: 'create',
+        oldValue: null,
+        newValue: {
+          tagName: 'france',
+          name: 'France',
+          note,
+          footer,
+          noteFromPlonkit: true,
+          levels: ['Advanced', 'Beginner'],
+        },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  test('update replaces fields and level assignments exactly and writes an update log', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const beginner = await seedLevel(groupId, 'Beginner');
+    const advanced = await seedLevel(groupId, 'Advanced');
+    const expert = await seedLevel(groupId, 'Expert');
+
+    const created = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'France',
+        note: '**old note**',
+        footer: 'old footer',
+        levels: [beginner, advanced],
+      }),
+    );
+    expect(created.status).toBe(200);
+    const { id } = (await created.json()) as { id: number };
+
+    const updated = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        id,
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'France Deux',
+        note: '<script>alert(2)</script>\n\n*new note*',
+        footer: 'new footer',
+        noteFromPlonkit: false,
+        levels: [advanced, expert],
+      }),
+    );
+    expect(updated.status).toBe(200);
+    expect(await updated.json()).toEqual({ id });
+
+    const [row] = await db.select().from(metas).where(eq(metas.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({
+        id,
+        mapGroupId: groupId,
+        name: 'France Deux',
+        note: '<script>alert(2)</script>\n\n*new note*',
+        noteHtml: '<p><em>new note</em></p>',
+        footer: 'new footer',
+        footerHtml: '<p>new footer</p>',
+        noteFromPlonkit: false,
+      }),
+    );
+
+    // exact replacement: beginner removed, expert added, advanced kept once
+    expect(await getMetaLevelIds(id)).toEqual([
+      { levelId: advanced },
+      { levelId: expert },
+    ]);
+
+    expect(await getMetaLogs(groupId)).toEqual([
+      {
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'meta',
+        entityId: id,
+        entityLabel: 'france',
+        operation: 'create',
+        oldValue: null,
+        newValue: {
+          tagName: 'france',
+          name: 'France',
+          note: '**old note**',
+          footer: 'old footer',
+          noteFromPlonkit: false,
+          levels: ['Advanced', 'Beginner'],
+        },
+        createdAt: expect.any(Number),
+      },
+      {
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'meta',
+        entityId: id,
+        entityLabel: 'france',
+        operation: 'update',
+        oldValue: {
+          tagName: 'france',
+          name: 'France',
+          note: '**old note**',
+          footer: 'old footer',
+          noteFromPlonkit: false,
+          levels: ['Advanced', 'Beginner'],
+        },
+        newValue: {
+          tagName: 'france',
+          name: 'France Deux',
+          note: '<script>alert(2)</script>\n\n*new note*',
+          footer: 'new footer',
+          noteFromPlonkit: false,
+          levels: ['Advanced', 'Expert'],
+        },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  test('update rolls back atomically when a level insert fails', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const beginner = await seedLevel(groupId, 'Beginner');
+
+    const created = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'France',
+        note: 'old note',
+        levels: [beginner],
+      }),
+    );
+    expect(created.status).toBe(200);
+    const { id } = (await created.json()) as { id: number };
+
+    const failed = await metaPutRequest(
+      'owner-1',
+      metaBody({
+        id,
+        mapGroupId: groupId,
+        tagName: 'france',
+        name: 'Should Not Persist',
+        note: 'should not persist',
+        levels: [999999],
+      }),
+    );
+    // FK violation is not a unique-tag conflict: it surfaces as 500
+    expect(failed.status).toBe(500);
+
+    const [row] = await db.select().from(metas).where(eq(metas.id, id));
+    expect(row).toEqual(
+      expect.objectContaining({
+        id,
+        name: 'France',
+        note: 'old note',
+      }),
+    );
+    expect(await getMetaLevelIds(id)).toEqual([{ levelId: beginner }]);
+    // the aborted update wrote no log
+    expect(await getMetaLogs(groupId)).toHaveLength(1);
+  });
+
+  describe('move between groups', () => {
+    test('requires permission in both source and target groups', async () => {
+      await seedUser('source-only-1');
+      await seedUser('target-only-1');
+      await seedUser('both-1');
+      const sourceGroup = await seedGroup('Source group');
+      const targetGroup = await seedGroup('Target group');
+      await seedPermission('source-only-1', sourceGroup);
+      await seedPermission('target-only-1', targetGroup);
+      await seedPermission('both-1', sourceGroup);
+      await seedPermission('both-1', targetGroup);
+      const sourceLevel = await seedLevel(sourceGroup, 'Source level');
+
+      const created = await metaPutRequest(
+        'both-1',
+        metaBody({
+          mapGroupId: sourceGroup,
+          tagName: 'france',
+          name: 'France',
+          levels: [sourceLevel],
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      const moveBody = metaBody({
+        id,
+        mapGroupId: targetGroup,
+        tagName: 'france',
+        name: 'France',
+        levels: [],
+      });
+
+      // only source permission: rejected before any write
+      const sourceOnly = await metaPutRequest('source-only-1', moveBody);
+      expect(sourceOnly.status).toBe(403);
+      // only target permission: rejected on the source-group check
+      const targetOnly = await metaPutRequest('target-only-1', moveBody);
+      expect(targetOnly.status).toBe(403);
+
+      // meta untouched, no departure/arrival logs anywhere
+      const [row] = await db.select().from(metas).where(eq(metas.id, id));
+      expect(row!.mapGroupId).toBe(sourceGroup);
+      expect(await getMetaLevelIds(id)).toEqual([{ levelId: sourceLevel }]);
+      expect(await getMetaLogs(sourceGroup)).toHaveLength(1);
+      expect(await getMetaLogs(targetGroup)).toEqual([]);
+    });
+
+    test('moves the meta, replaces levels with target levels, and logs departure and arrival', async () => {
+      await seedUser('owner-1');
+      const sourceGroup = await seedGroup('Source group');
+      const targetGroup = await seedGroup('Target group');
+      await seedPermission('owner-1', sourceGroup);
+      await seedPermission('owner-1', targetGroup);
+      const beginner = await seedLevel(sourceGroup, 'Beginner');
+      const advanced = await seedLevel(sourceGroup, 'Advanced');
+      const novice = await seedLevel(targetGroup, 'Novice');
+      const expert = await seedLevel(targetGroup, 'Expert');
+
+      const created = await metaPutRequest(
+        'owner-1',
+        metaBody({
+          mapGroupId: sourceGroup,
+          tagName: 'france',
+          name: 'France',
+          note: '**old note**',
+          footer: 'old footer',
+          levels: [beginner, advanced],
+        }),
+      );
+      expect(created.status).toBe(200);
+      const { id } = (await created.json()) as { id: number };
+
+      const moved = await metaPutRequest(
+        'owner-1',
+        metaBody({
+          id,
+          mapGroupId: targetGroup,
+          tagName: 'france',
+          name: 'France',
+          note: '**old note**',
+          footer: 'old footer',
+          levels: [novice, expert],
+        }),
+      );
+      expect(moved.status).toBe(200);
+      expect(await moved.json()).toEqual({ id });
+
+      const [row] = await db.select().from(metas).where(eq(metas.id, id));
+      expect(row!.mapGroupId).toBe(targetGroup);
+      expect(await getMetaLevelIds(id)).toEqual([
+        { levelId: novice },
+        { levelId: expert },
+      ]);
+
+      // the original create log plus the departure logged against the source
+      // group; the arrival is logged against the target group
+      expect(await getMetaLogs(sourceGroup)).toEqual([
+        {
+          mapGroupId: sourceGroup,
+          userId: 'owner-1',
+          entityType: 'meta',
+          entityId: id,
+          entityLabel: 'france',
+          operation: 'create',
+          oldValue: null,
+          newValue: {
+            tagName: 'france',
+            name: 'France',
+            note: '**old note**',
+            footer: 'old footer',
+            noteFromPlonkit: false,
+            levels: ['Advanced', 'Beginner'],
+          },
+          createdAt: expect.any(Number),
+        },
+        {
+          mapGroupId: sourceGroup,
+          userId: 'owner-1',
+          entityType: 'meta',
+          entityId: id,
+          entityLabel: 'france',
+          operation: 'delete',
+          oldValue: {
+            tagName: 'france',
+            name: 'France',
+            note: '**old note**',
+            footer: 'old footer',
+            noteFromPlonkit: false,
+            levels: ['Advanced', 'Beginner'],
+          },
+          newValue: { movedToGroupId: targetGroup },
+          createdAt: expect.any(Number),
+        },
+      ]);
+      expect(await getMetaLogs(targetGroup)).toEqual([
+        {
+          mapGroupId: targetGroup,
+          userId: 'owner-1',
+          entityType: 'meta',
+          entityId: id,
+          entityLabel: 'france',
+          operation: 'create',
+          oldValue: null,
+          newValue: {
+            tagName: 'france',
+            name: 'France',
+            note: '**old note**',
+            footer: 'old footer',
+            noteFromPlonkit: false,
+            levels: ['Expert', 'Novice'],
+            movedFromGroupId: sourceGroup,
+          },
+          createdAt: expect.any(Number),
+        },
+      ]);
+    });
+  });
+});
+
+describe('DELETE /api/internal/metas/', () => {
+  test('rejects a mix of existing and missing ids with 404 and deletes nothing', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const franceId = await seedMeta('owner-1', groupId, 'france');
+
+    const response = await metaDeleteRequest('owner-1', {
+      ids: [franceId, franceId + 1000],
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Some metas not found');
+    expect(
+      await db.select().from(metas).where(eq(metas.id, franceId)),
+    ).toHaveLength(1);
+    // only the create log remains; no delete log was written
+    expect(await getDeleteLogs(groupId)).toEqual([]);
+  });
+
+  test('rejects duplicate ids with 404 and deletes nothing', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const franceId = await seedMeta('owner-1', groupId, 'france');
+    const germanyId = await seedMeta('owner-1', groupId, 'germany');
+
+    // the duplicate inflates ids.length past the distinct metas found, so
+    // the request fails the not-found check before any write
+    const response = await metaDeleteRequest('owner-1', {
+      ids: [franceId, franceId],
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Some metas not found');
+    expect(
+      await db.select().from(metas).where(eq(metas.id, franceId)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(metas).where(eq(metas.id, germanyId)),
+    ).toHaveLength(1);
+    expect(await getDeleteLogs(groupId)).toEqual([]);
+  });
+
+  test('rejects ids from multiple map groups with 400 and deletes nothing', async () => {
+    await seedUser('owner-1');
+    const groupA = await seedGroup('Group A');
+    const groupB = await seedGroup('Group B');
+    await seedPermission('owner-1', groupA);
+    await seedPermission('owner-1', groupB);
+    const groupAMetaId = await seedMeta('owner-1', groupA, 'france');
+    const groupBMetaId = await seedMeta('owner-1', groupB, 'germany');
+
+    const response = await metaDeleteRequest('owner-1', {
+      ids: [groupAMetaId, groupBMetaId],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe(
+      'All metas must belong to the same map group',
+    );
+    expect(
+      await db.select().from(metas).where(eq(metas.id, groupAMetaId)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(metas).where(eq(metas.id, groupBMetaId)),
+    ).toHaveLength(1);
+    expect(await getDeleteLogs(groupA)).toEqual([]);
+    expect(await getDeleteLogs(groupB)).toEqual([]);
+  });
+
+  test('deletes metas, cascades associations, logs each meta, and leaves unrelated groups untouched', async () => {
+    await seedUser('owner-1');
+    const groupA = await seedGroup('Group A');
+    const groupB = await seedGroup('Group B');
+    await seedPermission('owner-1', groupA);
+    await seedPermission('owner-1', groupB);
+    const beginner = await seedLevel(groupA, 'Beginner');
+    const advanced = await seedLevel(groupA, 'Advanced');
+    const otherLevel = await seedLevel(groupB, 'Other level');
+
+    const franceId = await seedMeta('owner-1', groupA, 'france', {
+      note: '**bold** france',
+      levels: [beginner, advanced],
+    });
+    const germanyId = await seedMeta('owner-1', groupA, 'germany', {
+      note: 'germany note',
+      levels: [beginner],
+    });
+    // image associations are seeded directly: the POST image endpoint uploads
+    // to S3, which the test harness must not hit
+    await db.insert(metaImages).values([
+      { metaId: franceId, image_url: 'https://img.example/france.jpg' },
+      { metaId: germanyId, image_url: 'https://img.example/germany.jpg' },
+    ]);
+
+    // unrelated meta in another group, owned by the same user
+    const otherId = await seedMeta('owner-1', groupB, 'other', {
+      note: 'other note',
+      levels: [otherLevel],
+    });
+    await db.insert(metaImages).values({
+      metaId: otherId,
+      image_url: 'https://img.example/other.jpg',
+    });
+
+    const response = await metaDeleteRequest('owner-1', {
+      ids: [franceId, germanyId],
+    });
+
+    expect(response.status).toBe(200);
+
+    // both metas deleted
+    expect(
+      await db.select().from(metas).where(eq(metas.id, franceId)),
+    ).toHaveLength(0);
+    expect(
+      await db.select().from(metas).where(eq(metas.id, germanyId)),
+    ).toHaveLength(0);
+
+    // level and image associations cascade away with the metas
+    expect(
+      await db.select().from(metaLevels).where(eq(metaLevels.metaId, franceId)),
+    ).toHaveLength(0);
+    expect(
+      await db.select().from(metaImages).where(eq(metaImages.metaId, franceId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(metaLevels)
+        .where(eq(metaLevels.metaId, germanyId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(metaImages)
+        .where(eq(metaImages.metaId, germanyId)),
+    ).toHaveLength(0);
+
+    // levels themselves survive the cascade
+    expect(
+      await db.select().from(levels).where(eq(levels.id, beginner)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(levels).where(eq(levels.id, advanced)),
+    ).toHaveLength(1);
+
+    // one delete log per meta, snapshotting its values
+    const deleteLogs = await getDeleteLogs(groupA);
+    expect(deleteLogs).toHaveLength(2);
+    expect(deleteLogs.map((log) => log.entityId).sort()).toEqual(
+      [franceId, germanyId].sort(),
+    );
+    expect(deleteLogs.map((log) => log.entityLabel).sort()).toEqual([
+      'france',
+      'germany',
+    ]);
+    expect(deleteLogs.every((log) => log.userId === 'owner-1')).toBe(true);
+    const franceDeleteLog = deleteLogs.find(
+      (log) => log.entityId === franceId,
+    )!;
+    expect(franceDeleteLog.oldValue).toEqual({
+      tagName: 'france',
+      name: 'france',
+      note: '**bold** france',
+      footer: '',
+      noteFromPlonkit: false,
+    });
+
+    // unrelated meta in the other group survives with its associations
+    expect(
+      await db.select().from(metas).where(eq(metas.id, otherId)),
+    ).toHaveLength(1);
+    expect(await getMetaLevelIds(otherId)).toEqual([{ levelId: otherLevel }]);
+    expect(
+      await db.select().from(metaImages).where(eq(metaImages.metaId, otherId)),
+    ).toHaveLength(1);
+    expect(await getDeleteLogs(groupB)).toEqual([]);
+  });
+});
+
+describe('POST /api/internal/metas/levels', () => {
+  test('assigns same-group levels to every meta, resets sync, and logs the assignment', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const beginner = await seedLevel(groupId, 'Beginner');
+    const advanced = await seedLevel(groupId, 'Advanced');
+    const franceId = await seedMeta('owner-1', groupId, 'france');
+    const germanyId = await seedMeta('owner-1', groupId, 'germany');
+    await db
+      .update(mapGroups)
+      .set({ syncedAt: 1_000_000 })
+      .where(eq(mapGroups.id, groupId));
+
+    const response = await bulkLevelAssignRequest('owner-1', {
+      metaIds: [franceId, germanyId],
+      levelIds: [beginner, advanced],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      message: 'Successfully added 4 level assignments to 2 metas',
+      addedCount: 4,
+    });
+    expect(await getMetaLevelIds(franceId)).toEqual([
+      { levelId: beginner },
+      { levelId: advanced },
+    ]);
+    expect(await getMetaLevelIds(germanyId)).toEqual([
+      { levelId: beginner },
+      { levelId: advanced },
+    ]);
+
+    // rows were inserted, so the group sync marker resets
+    const [group] = await db
+      .select()
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    expect(group!.syncedAt).toBeNull();
+
+    const assignmentLog = (await getMetaLogs(groupId)).find(
+      (log) => log.entityType === 'meta_levels',
+    );
+    expect(assignmentLog).toEqual(
+      expect.objectContaining({
+        mapGroupId: groupId,
+        userId: 'owner-1',
+        entityType: 'meta_levels',
+        entityId: null,
+        entityLabel: '2 metas',
+        operation: 'update',
+        oldValue: null,
+        createdAt: expect.any(Number),
+      }),
+    );
+    const newValue = assignmentLog!.newValue as {
+      metaTags: string[];
+      levelNames: string[];
+    };
+    expect(newValue.metaTags.sort()).toEqual(['france', 'germany']);
+    expect(newValue.levelNames.sort()).toEqual(['Advanced', 'Beginner']);
+  });
+
+  test('repeated assignment is a no-op that preserves syncedAt and writes no log', async () => {
+    await seedUser('owner-1');
+    const groupId = await seedGroup('Target group');
+    await seedPermission('owner-1', groupId);
+    const beginner = await seedLevel(groupId, 'Beginner');
+    const franceId = await seedMeta('owner-1', groupId, 'france');
+
+    const first = await bulkLevelAssignRequest('owner-1', {
+      metaIds: [franceId],
+      levelIds: [beginner],
+    });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({
+      message: 'Successfully added 1 level assignments to 1 metas',
+      addedCount: 1,
+    });
+    await db
+      .update(mapGroups)
+      .set({ syncedAt: 1_000_000 })
+      .where(eq(mapGroups.id, groupId));
+
+    const repeat = await bulkLevelAssignRequest('owner-1', {
+      metaIds: [franceId],
+      levelIds: [beginner],
+    });
+    expect(repeat.status).toBe(200);
+    expect(await repeat.json()).toEqual({
+      message:
+        'No new levels to add (all selected levels already assigned or invalid)',
+      addedCount: 0,
+    });
+    expect(await getMetaLevelIds(franceId)).toEqual([{ levelId: beginner }]);
+
+    // nothing inserted, so the sync marker survives; only the first request's
+    // assignment log exists, no new one
+    const [group] = await db
+      .select()
+      .from(mapGroups)
+      .where(eq(mapGroups.id, groupId));
+    expect(group!.syncedAt).toBe(1_000_000);
+    const assignmentLogs = (await getMetaLogs(groupId)).filter(
+      (log) => log.entityType === 'meta_levels',
+    );
+    expect(assignmentLogs).toHaveLength(1);
+    expect(assignmentLogs[0]!.newValue).toEqual({
+      metaTags: ['france'],
+      levelNames: ['Beginner'],
+    });
+  });
+
+  test('rejects levels that belong to no requested meta group without touching anything', async () => {
+    await seedUser('owner-1');
+    const metaGroup = await seedGroup('Meta group');
+    const foreignGroup = await seedGroup('Foreign group');
+    await seedPermission('owner-1', metaGroup);
+    const foreignLevel = await seedLevel(foreignGroup, 'Foreign level');
+    const franceId = await seedMeta('owner-1', metaGroup, 'france');
+    await db
+      .update(mapGroups)
+      .set({ syncedAt: 2_000_000 })
+      .where(eq(mapGroups.id, metaGroup));
+
+    const response = await bulkLevelAssignRequest('owner-1', {
+      metaIds: [franceId],
+      levelIds: [foreignLevel],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      message:
+        'Invalid levels selected or levels do not belong to the correct map groups',
+    });
+    expect(await getMetaLevelIds(franceId)).toEqual([]);
+    const [group] = await db
+      .select()
+      .from(mapGroups)
+      .where(eq(mapGroups.id, metaGroup));
+    expect(group!.syncedAt).toBe(2_000_000);
+  });
+
+  test('pairs each meta only with levels of its own group and safely ignores foreign level ids', async () => {
+    await seedUser('owner-1');
+    const groupA = await seedGroup('Group A');
+    const groupB = await seedGroup('Group B');
+    const groupC = await seedGroup('Group C');
+    await seedPermission('owner-1', groupA);
+    await seedPermission('owner-1', groupB);
+    const levelA = await seedLevel(groupA, 'Level A');
+    const levelB = await seedLevel(groupB, 'Level B');
+    const levelC = await seedLevel(groupC, 'Level C');
+    const metaA = await seedMeta('owner-1', groupA, 'france');
+    const metaB = await seedMeta('owner-1', groupB, 'germany');
+    await db
+      .update(mapGroups)
+      .set({ syncedAt: 3_000_000 })
+      .where(inArray(mapGroups.id, [groupA, groupB, groupC]));
+
+    const response = await bulkLevelAssignRequest('owner-1', {
+      metaIds: [metaA, metaB],
+      levelIds: [levelA, levelB, levelC],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      message: 'Successfully added 2 level assignments to 2 metas',
+      addedCount: 2,
+    });
+    // no cross-group or foreign-group associations
+    expect(await getMetaLevelIds(metaA)).toEqual([{ levelId: levelA }]);
+    expect(await getMetaLevelIds(metaB)).toEqual([{ levelId: levelB }]);
+    expect(
+      await db.select().from(metaLevels).where(eq(metaLevels.levelId, levelC)),
+    ).toEqual([]);
+
+    // rows were inserted for groups A and B, resetting their sync markers;
+    // group C keeps its marker even though its level id was requested
+    for (const [groupId, expected] of [
+      [groupA, null],
+      [groupB, null],
+      [groupC, 3_000_000],
+    ] as [number, number | null][]) {
+      const [group] = await db
+        .select()
+        .from(mapGroups)
+        .where(eq(mapGroups.id, groupId));
+      expect(group!.syncedAt).toBe(expected);
+    }
+  });
+});
+
+describe('POST /api/internal/metas/copy', () => {
+  test('reproduces intended fields, images, and tag locations but not levels', async () => {
+    await seedUser('owner-1');
+    const sourceGroup = await seedGroup('Source group');
+    const targetGroup = await seedGroup('Target group');
+    await seedPermission('owner-1', sourceGroup);
+    await seedPermission('owner-1', targetGroup);
+    const beginner = await seedLevel(sourceGroup, 'Beginner');
+    const advanced = await seedLevel(sourceGroup, 'Advanced');
+    const note = '**bold** copy';
+    const footer = 'copied footer';
+
+    const sourceId = await seedMeta('owner-1', sourceGroup, 'france', {
+      name: 'France',
+      note,
+      footer,
+      noteFromPlonkit: true,
+      levels: [beginner, advanced],
+    });
+    // image and tag locations are seeded directly: image upload hits S3 and the
+    // locations upload path is out of scope for this endpoint
+    await db.insert(metaImages).values({
+      metaId: sourceId,
+      image_url: 'https://img.example/france.jpg',
+    });
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: sourceGroup,
+      lat: 48.85,
+      lng: 2.35,
+      heading: 1,
+      pitch: 2,
+      zoom: 3,
+      panoId: 'pano-france-1',
+      extraTag: 'france',
+      extraPanoId: 'extra-1',
+      extraPanoDate: '2024-01-01',
+    });
+
+    const response = await metaCopyRequest('owner-1', {
+      metaId: sourceId,
+      targetGroupId: targetGroup,
+    });
+    expect(response.status).toBe(200);
+
+    // the copy keeps every intended field, including the rendered HTML and the
+    // image flag, but belongs to the target group under a fresh id
+    const [sourceRow] = await db
+      .select()
+      .from(metas)
+      .where(eq(metas.id, sourceId));
+    const [copyRow] = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'france')),
+      );
+    expect(copyRow).toBeDefined();
+    expect(copyRow!.id).not.toBe(sourceId);
+    expect(copyRow).toEqual(
+      expect.objectContaining({
+        mapGroupId: targetGroup,
+        tagName: 'france',
+        name: 'France',
+        note,
+        noteHtml: sourceRow!.noteHtml,
+        footer,
+        footerHtml: sourceRow!.footerHtml,
+        noteFromPlonkit: true,
+        hasImage: sourceRow!.hasImage,
+      }),
+    );
+
+    // levels are deliberately not copied; the source keeps its assignments
+    expect(await getMetaLevelIds(copyRow!.id)).toEqual([]);
+    expect(await getMetaLevelIds(sourceId)).toEqual([
+      { levelId: beginner },
+      { levelId: advanced },
+    ]);
+
+    // images and the meta's tag locations follow the copy into the target group
+    const copiedImages = await db
+      .select()
+      .from(metaImages)
+      .where(eq(metaImages.metaId, copyRow!.id));
+    expect(copiedImages.map((image) => image.image_url)).toEqual([
+      'https://img.example/france.jpg',
+    ]);
+    const copiedLocations = await db
+      .select()
+      .from(mapGroupLocations)
+      .where(
+        and(
+          eq(mapGroupLocations.mapGroupId, targetGroup),
+          eq(mapGroupLocations.extraTag, 'france'),
+        ),
+      );
+    expect(copiedLocations).toHaveLength(1);
+    expect(copiedLocations[0]).toEqual(
+      expect.objectContaining({
+        mapGroupId: targetGroup,
+        lat: 48.85,
+        lng: 2.35,
+        heading: 1,
+        pitch: 2,
+        zoom: 3,
+        panoId: 'pano-france-1',
+        extraTag: 'france',
+        extraPanoId: 'extra-1',
+        extraPanoDate: '2024-01-01',
+      }),
+    );
+
+    // one create log against the target group marking the shared origin
+    expect(await getMetaLogs(targetGroup)).toEqual([
+      {
+        mapGroupId: targetGroup,
+        userId: 'owner-1',
+        entityType: 'meta',
+        entityId: copyRow!.id,
+        entityLabel: 'france',
+        operation: 'create',
+        oldValue: null,
+        newValue: {
+          tagName: 'france',
+          name: 'France',
+          note,
+          footer,
+          noteFromPlonkit: true,
+          sharedFromGroupId: sourceGroup,
+        },
+        createdAt: expect.any(Number),
+      },
+    ]);
+    // nothing new was logged against the source group
+    expect(await getMetaLogs(sourceGroup)).toHaveLength(1);
+  });
+
+  test('existing target tag is a no-op: returns 200 but copies nothing and writes no log', async () => {
+    await seedUser('owner-1');
+    const sourceGroup = await seedGroup('Source group');
+    const targetGroup = await seedGroup('Target group');
+    await seedPermission('owner-1', sourceGroup);
+    await seedPermission('owner-1', targetGroup);
+    const beginner = await seedLevel(sourceGroup, 'Beginner');
+    const targetLevel = await seedLevel(targetGroup, 'Target level');
+
+    const sourceId = await seedMeta('owner-1', sourceGroup, 'france', {
+      name: 'France Source',
+      note: 'source note',
+      levels: [beginner],
+    });
+    await db.insert(metaImages).values({
+      metaId: sourceId,
+      image_url: 'https://img.example/source.jpg',
+    });
+    const targetId = await seedMeta('owner-1', targetGroup, 'france', {
+      name: 'France Target',
+      note: 'target note',
+      levels: [targetLevel],
+    });
+
+    const response = await metaCopyRequest('owner-1', {
+      metaId: sourceId,
+      targetGroupId: targetGroup,
+    });
+    expect(response.status).toBe(200);
+
+    // no second meta with the same tag appeared in the target group
+    const targetMetas = await db
+      .select()
+      .from(metas)
+      .where(
+        and(eq(metas.mapGroupId, targetGroup), eq(metas.tagName, 'france')),
+      );
+    expect(targetMetas).toHaveLength(1);
+    expect(targetMetas[0]!.id).toBe(targetId);
+    expect(targetMetas[0]).toEqual(
+      expect.objectContaining({ name: 'France Target', note: 'target note' }),
+    );
+
+    // nothing leaked from the source into the existing target meta: no image,
+    // no tag locations, and the pre-existing level assignment survives
+    expect(
+      await db.select().from(metaImages).where(eq(metaImages.metaId, targetId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(mapGroupLocations)
+        .where(
+          and(
+            eq(mapGroupLocations.mapGroupId, targetGroup),
+            eq(mapGroupLocations.extraTag, 'france'),
+          ),
+        ),
+    ).toHaveLength(0);
+    expect(await getMetaLevelIds(targetId)).toEqual([{ levelId: targetLevel }]);
+
+    // the no-op writes no create log: the target group only has its own create
+    // log, and the source meta keeps its assignment
+    const targetLogs = await getMetaLogs(targetGroup);
+    expect(targetLogs).toHaveLength(1);
+    expect(targetLogs[0]!.entityId).toBe(targetId);
+    expect(targetLogs[0]!.operation).toBe('create');
+    expect(await getMetaLevelIds(sourceId)).toEqual([{ levelId: beginner }]);
+  });
+});

--- a/apps/api/src/routes/internal/metas.db.test.ts
+++ b/apps/api/src/routes/internal/metas.db.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { and, asc, eq, inArray, sql } from 'drizzle-orm';
-import { app } from '../../api';
+import { app } from '@api/api';
 import {
   levels,
   mapGroupChanges,
@@ -11,8 +10,9 @@ import {
   metaLevels,
   metas,
   users,
-} from '../../lib/db/schema';
-import { db } from '../../lib/drizzle';
+} from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
 
 async function seedUser(id: string) {
   await db.insert(users).values({ id, username: id });

--- a/apps/api/src/routes/userscript.db.test.ts
+++ b/apps/api/src/routes/userscript.db.test.ts
@@ -1,0 +1,578 @@
+import { describe, expect, test } from 'bun:test';
+import { app } from '../api';
+import {
+  mapGroupLocations,
+  mapGroupPermissions,
+  mapGroups,
+  maps,
+  syncedLocations,
+  syncedMapMetas,
+  syncedMetas,
+  users,
+} from '../lib/db/schema';
+import { db } from '../lib/drizzle';
+import { plonkitFooter } from '../lib/userscript/constants';
+
+async function requestLocation(mapId: string, panoId: string) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/userscript/location/?mapId=${mapId}&panoId=${panoId}`,
+    ),
+  );
+}
+
+async function requestLocationsExport(geoguessrId: string, token?: string) {
+  return app.handle(
+    new Request(
+      `http://localhost/api/userscript/map/${geoguessrId}/locations`,
+      {
+        headers: token ? { authorization: `Bearer ${token}` } : undefined,
+      },
+    ),
+  );
+}
+
+interface SeedExportMapOptions {
+  isPersonal?: boolean;
+  userId?: string | null;
+}
+
+async function seedExportMap(
+  geoguessrId: string,
+  options: SeedExportMapOptions = {},
+) {
+  const { isPersonal = false, userId = null } = options;
+
+  let mapGroupId: number | null = null;
+  if (!isPersonal) {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Export Group' })
+      .returning({ id: mapGroups.id });
+    mapGroupId = group!.id;
+  }
+
+  const [map] = await db
+    .insert(maps)
+    .values({
+      name: 'Export Map',
+      geoguessrId,
+      mapGroupId,
+      isPersonal,
+      userId,
+    })
+    .returning({ id: maps.id });
+
+  return { mapId: map!.id, mapGroupId };
+}
+
+interface SeedLocationInput {
+  geoguessrId: string;
+  panoId: string;
+  syncedMetaId: number;
+  country?: string | null;
+  isPersonal?: boolean;
+  metaName?: string;
+  note?: string;
+  metaFooter?: string;
+  noteFromPlonkit?: boolean;
+  images?: string[];
+  mapFooterHtml?: string;
+  authors?: string;
+  numberOfGamesPlayed?: number | null;
+}
+
+async function seedLocation({
+  geoguessrId,
+  panoId,
+  syncedMetaId,
+  country,
+  isPersonal = false,
+  metaName = 'Test Meta',
+  note = 'Test note',
+  metaFooter = 'Meta footer',
+  noteFromPlonkit = false,
+  images = ['img.jpg'],
+  mapFooterHtml = '<p>Map footer</p>',
+  authors = 'Map Author',
+  numberOfGamesPlayed = null,
+}: SeedLocationInput) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Test Group' })
+    .returning({ id: mapGroups.id });
+
+  const [map] = await db
+    .insert(maps)
+    .values({
+      name: 'Test Map',
+      geoguessrId,
+      mapGroupId: isPersonal ? null : group!.id,
+      isPersonal,
+      authors,
+      footerHtml: mapFooterHtml,
+      numberOfGamesPlayed,
+    })
+    .returning({ id: maps.id });
+
+  await db.insert(syncedMetas).values({
+    metaId: syncedMetaId,
+    mapGroupId: group!.id,
+    name: metaName,
+    note,
+    noteFromPlonkit,
+    footer: metaFooter,
+    images,
+  });
+
+  await db.insert(syncedMapMetas).values({
+    mapId: map!.id,
+    syncedMetaId,
+  });
+
+  await db.insert(syncedLocations).values({
+    syncedMetaId,
+    panoId,
+    country: country === undefined ? 'Czechia' : country,
+    lat: 1,
+    lng: 2,
+    heading: 3,
+    pitch: 4,
+    zoom: 5,
+    extraTag: 'tag',
+  });
+
+  return map!.id;
+}
+
+interface SeedExportLocationsInput {
+  mapId: number;
+  panoIds: string[];
+  syncedMetaId?: number;
+}
+
+async function seedExportLocations({
+  mapId,
+  panoIds,
+  syncedMetaId = 9001,
+}: SeedExportLocationsInput) {
+  const [group] = await db
+    .insert(mapGroups)
+    .values({ name: 'Export Locations Group' })
+    .returning({ id: mapGroups.id });
+
+  await db.insert(syncedMetas).values({
+    metaId: syncedMetaId,
+    mapGroupId: group!.id,
+    name: 'Export Meta',
+    note: 'Export note',
+    noteFromPlonkit: false,
+    footer: 'Export footer',
+    images: [],
+  });
+
+  await db.insert(syncedMapMetas).values({
+    mapId,
+    syncedMetaId,
+  });
+
+  await db.insert(syncedLocations).values(
+    panoIds.map((panoId) => ({
+      syncedMetaId,
+      panoId,
+      // internal fields that must never leak into the export response
+      country: 'Czechia',
+      lat: 1,
+      lng: 2,
+      heading: 3,
+      pitch: 4,
+      zoom: 5,
+      extraTag: 'internal-tag',
+      extraPanoId: 'internal-pano',
+      extraPanoDate: 'internal-date',
+    })),
+  );
+}
+
+describe('GET /api/userscript/location/', () => {
+  describe('missing and unsynced locations', () => {
+    test('unknown pano returns 404 with NOT_FOUND sentinel', async () => {
+      await seedLocation({
+        geoguessrId: 'map-a',
+        panoId: 'pano-known',
+        syncedMetaId: 1001,
+      });
+
+      const response = await requestLocation('map-a', 'pano-unknown');
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(['NOT_FOUND']);
+    });
+
+    test('pano present only in the draft upload table is invisible and returns 404', async () => {
+      const [group] = await db
+        .insert(mapGroups)
+        .values({ name: 'Draft Group' })
+        .returning({ id: mapGroups.id });
+      const [map] = await db
+        .insert(maps)
+        .values({
+          name: 'Not Yet Synced Map',
+          geoguessrId: 'map-draft',
+          mapGroupId: group!.id,
+        })
+        .returning({ id: maps.id });
+
+      // location uploaded but the map was never synced to the userscript tables
+      await db.insert(mapGroupLocations).values({
+        mapGroupId: group!.id,
+        panoId: 'pano-draft-only',
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        extraTag: 'tag',
+      });
+      await db.insert(syncedMetas).values({
+        metaId: 2002,
+        mapGroupId: group!.id,
+        name: 'Draft Meta',
+        note: 'Draft note',
+        noteFromPlonkit: false,
+        footer: '',
+        images: [],
+      });
+      await db.insert(syncedMapMetas).values({
+        mapId: map!.id,
+        syncedMetaId: 2002,
+      });
+
+      const response = await requestLocation('map-draft', 'pano-draft-only');
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(['NOT_FOUND']);
+    });
+  });
+
+  describe('found responses', () => {
+    test('returns public fields and turns a null country into an empty string', async () => {
+      await seedLocation({
+        geoguessrId: 'map-a',
+        panoId: 'pano-null-country',
+        syncedMetaId: 1001,
+        country: null,
+        metaFooter: '',
+        mapFooterHtml: '',
+      });
+
+      const response = await requestLocation('map-a', 'pano-null-country');
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        country: '',
+        metaName: 'Test Meta',
+        note: 'Test note',
+        images: ['img.jpg'],
+        // no meta or map footer and no country: generic plonkit footer
+        footer: plonkitFooter,
+      });
+    });
+
+    test('appends original-map attribution for a personal map', async () => {
+      const [group] = await db
+        .insert(mapGroups)
+        .values({ name: 'Attribution Group' })
+        .returning({ id: mapGroups.id });
+
+      const [personalMap] = await db
+        .insert(maps)
+        .values({
+          name: 'Personal Map',
+          geoguessrId: 'map-personal',
+          mapGroupId: null,
+          isPersonal: true,
+          authors: 'Personal Author',
+          footerHtml: '<p>Personal footer</p>',
+        })
+        .returning({ id: maps.id });
+
+      const [originalMap] = await db
+        .insert(maps)
+        .values({
+          name: 'Original Map',
+          geoguessrId: 'map-original',
+          mapGroupId: group!.id,
+          isPersonal: false,
+          authors: 'Original Author',
+          footerHtml: '<p>Original footer</p>',
+          numberOfGamesPlayed: 100,
+        })
+        .returning({ id: maps.id });
+
+      await db.insert(syncedMetas).values({
+        metaId: 3003,
+        mapGroupId: group!.id,
+        name: 'Shared Meta',
+        note: 'Shared note',
+        noteFromPlonkit: false,
+        footer: 'Shared meta footer',
+        images: ['shared.jpg'],
+      });
+
+      await db.insert(syncedMapMetas).values([
+        { mapId: personalMap!.id, syncedMetaId: 3003 },
+        { mapId: originalMap!.id, syncedMetaId: 3003 },
+      ]);
+
+      await db.insert(syncedLocations).values({
+        syncedMetaId: 3003,
+        panoId: 'pano-personal',
+        country: 'Italy',
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        extraTag: 'tag',
+      });
+
+      const response = await requestLocation('map-personal', 'pano-personal');
+      const body = (await response.json()) as {
+        country: string;
+        footer: string;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.country).toBe('Italy');
+      expect(body.footer).toBe(
+        'Shared meta footer' +
+          '<p>Meta taken from <a href="https://learnablemeta.com/maps/map-original" rel ="nofollow" target="_blank"> Original Map </a> by <b>Original Author</b></p>',
+      );
+    });
+  });
+});
+
+describe('GET /api/userscript/map/:geoguessrId/locations authorization', () => {
+  test('returns 401 when no bearer token is sent', async () => {
+    await db.insert(users).values({ id: 'owner', username: 'owner' });
+    await seedExportMap('export-map', { isPersonal: true, userId: 'owner' });
+
+    const response = await requestLocationsExport('export-map');
+
+    expect(response.status).toBe(401);
+  });
+
+  test('returns 403 for a token that matches no user', async () => {
+    await seedExportMap('export-map');
+
+    const response = await requestLocationsExport('export-map', 'ghost-token');
+
+    expect(response.status).toBe(403);
+  });
+
+  test('returns 200 for the personal map owner', async () => {
+    await db
+      .insert(users)
+      .values({ id: 'owner', username: 'owner', apiToken: 'owner-token' });
+    await seedExportMap('export-map', { isPersonal: true, userId: 'owner' });
+
+    const response = await requestLocationsExport('export-map', 'owner-token');
+
+    expect(response.status).toBe(200);
+    expect((await response.json()) as { customCoordinates: unknown[] }).toEqual(
+      { customCoordinates: [] },
+    );
+  });
+
+  test('returns 403 for a personal map when the token belongs to another user', async () => {
+    await db
+      .insert(users)
+      .values({ id: 'owner', username: 'owner', apiToken: 'owner-token' });
+    await db.insert(users).values({
+      id: 'stranger',
+      username: 'stranger',
+      apiToken: 'stranger-token',
+    });
+    await seedExportMap('export-map', { isPersonal: true, userId: 'owner' });
+
+    const response = await requestLocationsExport(
+      'export-map',
+      'stranger-token',
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  test('returns 200 for a group map owner', async () => {
+    await db.insert(users).values({
+      id: 'group-owner',
+      username: 'group-owner',
+      apiToken: 'group-owner-token',
+    });
+    const { mapGroupId } = await seedExportMap('export-map');
+    await db.insert(mapGroupPermissions).values({
+      mapGroupId: mapGroupId!,
+      userId: 'group-owner',
+      role: 'owner',
+    });
+
+    const response = await requestLocationsExport(
+      'export-map',
+      'group-owner-token',
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()) as { customCoordinates: unknown[] }).toEqual(
+      { customCoordinates: [] },
+    );
+  });
+
+  test('returns 200 for a group map editor', async () => {
+    await db.insert(users).values({
+      id: 'group-editor',
+      username: 'group-editor',
+      apiToken: 'group-editor-token',
+    });
+    const { mapGroupId } = await seedExportMap('export-map');
+    await db.insert(mapGroupPermissions).values({
+      mapGroupId: mapGroupId!,
+      userId: 'group-editor',
+      role: 'editor',
+    });
+
+    const response = await requestLocationsExport(
+      'export-map',
+      'group-editor-token',
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()) as { customCoordinates: unknown[] }).toEqual(
+      { customCoordinates: [] },
+    );
+  });
+});
+
+describe('GET /api/userscript/map/:geoguessrId/locations response shape', () => {
+  test('populated map exports the exact GeoGuessr shape and omits internal location fields', async () => {
+    await db.insert(users).values({
+      id: 'shape-owner',
+      username: 'shape-owner',
+      apiToken: 'shape-owner-token',
+    });
+    const { mapId } = await seedExportMap('shape-map', {
+      isPersonal: true,
+      userId: 'shape-owner',
+    });
+    await seedExportLocations({ mapId, panoIds: ['pano-b', 'pano-a'] });
+
+    const response = await requestLocationsExport(
+      'shape-map',
+      'shape-owner-token',
+    );
+    const body = (await response.json()) as {
+      customCoordinates: {
+        lat: number;
+        lng: number;
+        heading: number;
+        pitch: number;
+        zoom: number;
+        panoId: string;
+        countryCode: null;
+        stateCode: null;
+      }[];
+    };
+
+    expect(response.status).toBe(200);
+    expect(
+      body.customCoordinates.sort((a, b) => a.panoId.localeCompare(b.panoId)),
+    ).toEqual([
+      {
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        panoId: 'pano-a',
+        countryCode: null,
+        stateCode: null,
+      },
+      {
+        lat: 1,
+        lng: 2,
+        heading: 3,
+        pitch: 4,
+        zoom: 5,
+        panoId: 'pano-b',
+        countryCode: null,
+        stateCode: null,
+      },
+    ]);
+  });
+});
+
+describe('GET /api/userscript/map/:geoguessrId', () => {
+  test('personal map returns mapFound true, isPersonal true, and stable userscript version', async () => {
+    await db.insert(maps).values({
+      name: 'Personal Map',
+      geoguessrId: 'map-lookup-personal',
+      isPersonal: true,
+      mapGroupId: null,
+    });
+
+    const response = await app.handle(
+      new Request('http://localhost/api/userscript/map/map-lookup-personal'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      mapFound: true,
+      isPersonal: true,
+      userscriptVersion: '0.90',
+    });
+  });
+
+  test('group map returns mapFound true and isPersonal false', async () => {
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Lookup Group' })
+      .returning({ id: mapGroups.id });
+    await db.insert(maps).values({
+      name: 'Group Map',
+      geoguessrId: 'map-lookup-group',
+      mapGroupId: group!.id,
+      isPersonal: false,
+    });
+
+    const response = await app.handle(
+      new Request('http://localhost/api/userscript/map/map-lookup-group'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      mapFound: true,
+      isPersonal: false,
+      userscriptVersion: '0.90',
+    });
+  });
+
+  test('missing map returns 404 with mapFound false and stable userscript version', async () => {
+    // an unrelated map exists, so the 404 proves the lookup is by geoguessrId
+    await db.insert(maps).values({
+      name: 'Existing Map',
+      geoguessrId: 'map-lookup-existing',
+      isPersonal: true,
+      mapGroupId: null,
+    });
+
+    const response = await app.handle(
+      new Request('http://localhost/api/userscript/map/map-lookup-missing'),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      mapFound: false,
+      userscriptVersion: '0.90',
+    });
+  });
+});


### PR DESCRIPTION
JWT memoization, batch rollback, meta omission/cascade, mapLocations view, personal attribution.