### PR TITLE
feat: update synchronized maps from the userscript

### DIFF
--- a/apps/api/src/lib/db/migrations/0036_sparkling_jack_flag.sql
+++ b/apps/api/src/lib/db/migrations/0036_sparkling_jack_flag.sql
@@ -1,0 +1,2 @@
+DROP TABLE "map_data" CASCADE;--> statement-breakpoint
+ALTER TABLE "maps" DROP COLUMN "auto_update";

--- a/apps/api/src/lib/db/migrations/meta/0036_snapshot.json
+++ b/apps/api/src/lib/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,1882 @@
+{
+  "id": "ceffb441-8d62-45ae-8879-79070d8befc3",
+  "prevId": "31f95612-5b3e-4bea-b773-8a8b2e7f29b2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cache": {
+      "name": "cache",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.levels": {
+      "name": "levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "levels_unique": {
+          "name": "levels_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "levels_map_group_id_map_groups_id_fk": {
+          "name": "levels_map_group_id_map_groups_id_fk",
+          "tableFrom": "levels",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_filters": {
+      "name": "map_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_like": {
+          "name": "tag_like",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_exclude": {
+          "name": "is_exclude",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "map_filters_unique": {
+          "name": "map_filters_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_like",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_filters_map_id_maps_id_fk": {
+          "name": "map_filters_map_id_maps_id_fk",
+          "tableFrom": "map_filters",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_group_changes": {
+      "name": "map_group_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_label": {
+          "name": "entity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "map_group_changes_group_created_idx": {
+          "name": "map_group_changes_group_created_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_group_changes_map_group_id_map_groups_id_fk": {
+          "name": "map_group_changes_map_group_id_map_groups_id_fk",
+          "tableFrom": "map_group_changes",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_group_changes_user_id_user_id_fk": {
+          "name": "map_group_changes_user_id_user_id_fk",
+          "tableFrom": "map_group_changes",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_group_locations": {
+      "name": "map_group_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_on_street_view": {
+          "name": "is_on_street_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1730419200
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_tag": {
+          "name": "extra_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "map_group_locations_unique": {
+          "name": "map_group_locations_unique",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pano_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "map_group_locations_map_group_tag_idx": {
+          "name": "map_group_locations_map_group_tag_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extra_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "map_group_locations_map_group_modified_idx": {
+          "name": "map_group_locations_map_group_modified_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_group_locations_map_group_id_map_groups_id_fk": {
+          "name": "map_group_locations_map_group_id_map_groups_id_fk",
+          "tableFrom": "map_group_locations",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_group_permissions": {
+      "name": "map_group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {
+        "map_group_permissions_unique": {
+          "name": "map_group_permissions_unique",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_group_permissions_map_group_id_map_groups_id_fk": {
+          "name": "map_group_permissions_map_group_id_map_groups_id_fk",
+          "tableFrom": "map_group_permissions",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_group_permissions_user_id_user_id_fk": {
+          "name": "map_group_permissions_user_id_user_id_fk",
+          "tableFrom": "map_group_permissions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_groups": {
+      "name": "map_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_include_locations_not_on_street_view": {
+          "name": "sync_include_locations_not_on_street_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_levels": {
+      "name": "map_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "map_levels_unique": {
+          "name": "map_levels_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_levels_map_id_maps_id_fk": {
+          "name": "map_levels_map_id_maps_id_fk",
+          "tableFrom": "map_levels",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_levels_level_id_levels_id_fk": {
+          "name": "map_levels_level_id_levels_id_fk",
+          "tableFrom": "map_levels",
+          "tableTo": "levels",
+          "columnsFrom": ["level_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.map_regions": {
+      "name": "map_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "map_region_unique": {
+          "name": "map_region_unique",
+          "columns": [
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "map_regions_map_id_maps_id_fk": {
+          "name": "map_regions_map_id_maps_id_fk",
+          "tableFrom": "map_regions",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "map_regions_region_id_regions_id_fk": {
+          "name": "map_regions_region_id_regions_id_fk",
+          "tableFrom": "map_regions",
+          "tableTo": "regions",
+          "columnsFrom": ["region_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maps": {
+      "name": "maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geoguessr_id": {
+          "name": "geoguessr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "ordering": {
+          "name": "ordering",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_html": {
+          "name": "footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1730419200
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "number_of_games_played": {
+          "name": "number_of_games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_games_played_diminished": {
+          "name": "number_of_games_played_diminished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "maps_map_group_modified_idx": {
+          "name": "maps_map_group_modified_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maps_map_group_id_map_groups_id_fk": {
+          "name": "maps_map_group_id_map_groups_id_fk",
+          "tableFrom": "maps",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maps_user_id_user_id_fk": {
+          "name": "maps_user_id_user_id_fk",
+          "tableFrom": "maps",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maps_geoguessr_id_unique": {
+          "name": "maps_geoguessr_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["geoguessr_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "map_group_id_not_null": {
+          "name": "map_group_id_not_null",
+          "value": "(\"maps\".\"is_personal\" AND \"maps\".\"map_group_id\" IS NULL)\n          OR (NOT \"maps\".\"is_personal\" AND \"maps\".\"map_group_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.meta_images": {
+      "name": "meta_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "meta_image_unique": {
+          "name": "meta_image_unique",
+          "columns": [
+            {
+              "expression": "meta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "image_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_images_meta_id_metas_id_fk": {
+          "name": "meta_images_meta_id_metas_id_fk",
+          "tableFrom": "meta_images",
+          "tableTo": "metas",
+          "columnsFrom": ["meta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_levels": {
+      "name": "meta_levels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "meta_levels_unique": {
+          "name": "meta_levels_unique",
+          "columns": [
+            {
+              "expression": "meta_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meta_levels_meta_id_metas_id_fk": {
+          "name": "meta_levels_meta_id_metas_id_fk",
+          "tableFrom": "meta_levels",
+          "tableTo": "metas",
+          "columnsFrom": ["meta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meta_levels_level_id_levels_id_fk": {
+          "name": "meta_levels_level_id_levels_id_fk",
+          "tableFrom": "meta_levels",
+          "tableTo": "levels",
+          "columnsFrom": ["level_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_locations_count_view": {
+      "name": "meta_locations_count_view",
+      "schema": "",
+      "columns": {
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_locations_count_view_meta_id_metas_id_fk": {
+          "name": "meta_locations_count_view_meta_id_metas_id_fk",
+          "tableFrom": "meta_locations_count_view",
+          "tableTo": "metas",
+          "columnsFrom": ["meta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_suggestions": {
+      "name": "meta_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_nickname": {
+          "name": "author_nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'new'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metas": {
+      "name": "metas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_name": {
+          "name": "tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_html": {
+          "name": "note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_html": {
+          "name": "footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "note_from_plonkit": {
+          "name": "note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_image": {
+          "name": "has_image",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1730419200
+        }
+      },
+      "indexes": {
+        "metas_unique": {
+          "name": "metas_unique",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "metas_map_group_modified_idx": {
+          "name": "metas_map_group_modified_idx",
+          "columns": [
+            {
+              "expression": "map_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metas_map_group_id_map_groups_id_fk": {
+          "name": "metas_map_group_id_map_groups_id_fk",
+          "tableFrom": "metas",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering": {
+          "name": "ordering",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_locations": {
+      "name": "synced_locations",
+      "schema": "",
+      "columns": {
+        "synced_meta_id": {
+          "name": "synced_meta_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_tag": {
+          "name": "extra_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_locations_synced_meta_id_synced_metas_meta_id_fk": {
+          "name": "synced_locations_synced_meta_id_synced_metas_meta_id_fk",
+          "tableFrom": "synced_locations",
+          "tableTo": "synced_metas",
+          "columnsFrom": ["synced_meta_id"],
+          "columnsTo": ["meta_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "synced_locations_synced_meta_id_pano_id_pk": {
+          "name": "synced_locations_synced_meta_id_pano_id_pk",
+          "columns": ["synced_meta_id", "pano_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_map_metas": {
+      "name": "synced_map_metas",
+      "schema": "",
+      "columns": {
+        "map_id": {
+          "name": "map_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_meta_id": {
+          "name": "synced_meta_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_map_metas_map_id_maps_id_fk": {
+          "name": "synced_map_metas_map_id_maps_id_fk",
+          "tableFrom": "synced_map_metas",
+          "tableTo": "maps",
+          "columnsFrom": ["map_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "synced_map_metas_synced_meta_id_synced_metas_meta_id_fk": {
+          "name": "synced_map_metas_synced_meta_id_synced_metas_meta_id_fk",
+          "tableFrom": "synced_map_metas",
+          "tableTo": "synced_metas",
+          "columnsFrom": ["synced_meta_id"],
+          "columnsTo": ["meta_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "synced_map_metas_map_id_synced_meta_id_pk": {
+          "name": "synced_map_metas_map_id_synced_meta_id_pk",
+          "columns": ["map_id", "synced_meta_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_metas": {
+      "name": "synced_metas",
+      "schema": "",
+      "columns": {
+        "meta_id": {
+          "name": "meta_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_from_plonkit": {
+          "name": "note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_metas_map_group_id_map_groups_id_fk": {
+          "name": "synced_metas_map_group_id_map_groups_id_fk",
+          "tableFrom": "synced_metas",
+          "tableTo": "map_groups",
+          "columnsFrom": ["map_group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_superadmin": {
+          "name": "is_superadmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_api_token_unique": {
+          "name": "user_api_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.location_metas_view": {
+      "columns": {
+        "map_group_id": {
+          "name": "map_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_tag": {
+          "name": "extra_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_modified_at": {
+          "name": "meta_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "location_metas_view",
+      "schema": "public",
+      "isExisting": true,
+      "materialized": false
+    },
+    "public.map_locations_view": {
+      "columns": {
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pano_id": {
+          "name": "pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_name": {
+          "name": "meta_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extra_pano_id": {
+          "name": "extra_pano_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_pano_date": {
+          "name": "extra_pano_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_name": {
+          "name": "tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note": {
+          "name": "meta_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_html": {
+          "name": "meta_note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_from_plonkit": {
+          "name": "meta_note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meta_id": {
+          "name": "meta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_modified_at": {
+          "name": "meta_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_modified_at": {
+          "name": "map_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "map_locations_view",
+      "schema": "public",
+      "isExisting": true,
+      "materialized": false
+    },
+    "public.map_metas_view": {
+      "columns": {
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_footer_html": {
+          "name": "map_footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geoguessr_id": {
+          "name": "geoguessr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_name": {
+          "name": "meta_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_tag": {
+          "name": "meta_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_html": {
+          "name": "meta_note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_image_urls": {
+          "name": "meta_image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_footer_html": {
+          "name": "meta_footer_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_note_from_plonkit": {
+          "name": "meta_note_from_plonkit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "map_metas_view",
+      "schema": "public",
+      "isExisting": true,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/lib/db/migrations/meta/_journal.json
+++ b/apps/api/src/lib/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1785007158030,
       "tag": "0035_map_group_collaboration",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1785995428743,
+      "tag": "0036_sparkling_jack_flag",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/lib/db/schema.db.test.ts
+++ b/apps/api/src/lib/db/schema.db.test.ts
@@ -4,7 +4,6 @@ import type { AnyPgTable } from 'drizzle-orm/pg-core';
 import { db } from '../drizzle';
 import {
   levels,
-  mapData,
   mapFilters,
   mapGroupLocations,
   mapGroups,
@@ -210,7 +209,6 @@ describe('group deletion cascade', () => {
     });
 
     // Map-owned relations.
-    await db.insert(mapData).values({ mapId });
     await db.insert(mapLevels).values({ mapId, levelId });
     await db.insert(mapFilters).values({ mapId, tagLike: 'filter' });
     await db.insert(mapRegions).values({ mapId, regionId: region!.id });
@@ -255,7 +253,6 @@ describe('group deletion cascade', () => {
       ['map_levels', mapLevels],
       ['map_filters', mapFilters],
       ['map_regions', mapRegions],
-      ['map_data', mapData],
       ['meta_levels', metaLevels],
       ['meta_images', metaImages],
       ['synced_metas', syncedMetas],

--- a/apps/api/src/lib/db/schema.ts
+++ b/apps/api/src/lib/db/schema.ts
@@ -109,7 +109,6 @@ export const maps = pgTable(
     userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
     authors: text('authors').default(''),
     ordering: integer('ordering').notNull().default(0),
-    autoUpdate: boolean('auto_update').notNull().default(false),
     footer: text('footer').notNull().default(''),
     footerHtml: text('footer_html').notNull().default(''),
     modifiedAt: integer('modified_at').default(1730419200).notNull(),
@@ -377,27 +376,6 @@ export const mapGroupPermissionsRelations = relations(
     }),
   }),
 );
-
-export const mapData = pgTable(
-  'map_data',
-  {
-    id: bigserial('id', { mode: 'number' }).primaryKey(),
-    mapId: integer('map_id')
-      .notNull()
-      .references(() => maps.id, { onDelete: 'cascade' }),
-    lastUpdatedPanoids: text('last_updated_panoids')
-      .notNull()
-      .$type<string[]>()
-      .default(sql`'[]'`),
-  },
-  (t) => ({
-    mapDataUnique: uniqueIndex('map_data_unique').on(t.mapId),
-  }),
-);
-
-export const mapDataRelations = relations(mapData, ({ one }) => ({
-  map: one(maps, { fields: [mapData.mapId], references: [maps.id] }),
-}));
 
 export const regions = pgTable('regions', {
   id: bigserial('id', { mode: 'number' }).primaryKey(),

--- a/apps/api/src/lib/userscript/map-fingerprint.ts
+++ b/apps/api/src/lib/userscript/map-fingerprint.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+
+export type ManagedMapCoordinate = {
+  panoId: string | null;
+  lat: number;
+  lng: number;
+  heading: number;
+  pitch: number;
+  zoom: number;
+};
+
+export function canonicalizeMapCoordinates(
+  coordinates: ManagedMapCoordinate[],
+): string {
+  const tuples = coordinates.map(
+    ({ panoId, lat, lng, heading, pitch, zoom }) =>
+      [panoId, lat, lng, heading, pitch, zoom] as const,
+  );
+  tuples.sort((left, right) => {
+    const leftJson = JSON.stringify(left);
+    const rightJson = JSON.stringify(right);
+    return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+  });
+  return JSON.stringify(tuples);
+}
+
+export function fingerprintMapCoordinates(
+  coordinates: ManagedMapCoordinate[],
+): string {
+  return createHash('sha256')
+    .update(canonicalizeMapCoordinates(coordinates))
+    .digest('hex');
+}

--- a/apps/api/src/lib/userscript/map-fingerprint.unit.test.ts
+++ b/apps/api/src/lib/userscript/map-fingerprint.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  canonicalizeMapCoordinates,
+  fingerprintMapCoordinates,
+  type ManagedMapCoordinate,
+} from './map-fingerprint';
+
+const first: ManagedMapCoordinate = {
+  panoId: 'pano-a',
+  lat: 1,
+  lng: 2,
+  heading: 3,
+  pitch: 4,
+  zoom: 5,
+};
+const second: ManagedMapCoordinate = {
+  panoId: 'pano-b',
+  lat: 6,
+  lng: 7,
+  heading: 8,
+  pitch: 9,
+  zoom: 10,
+};
+
+describe('map coordinate fingerprint', () => {
+  test('is independent of coordinate order', () => {
+    expect(fingerprintMapCoordinates([first, second])).toBe(
+      fingerprintMapCoordinates([second, first]),
+    );
+  });
+
+  test.each([
+    'panoId',
+    'lat',
+    'lng',
+    'heading',
+    'pitch',
+    'zoom',
+  ] as const)('changes when %s changes', (field) => {
+    const changed = {
+      ...first,
+      [field]: field === 'panoId' ? 'different' : first[field] + 0.5,
+    };
+    expect(fingerprintMapCoordinates([changed])).not.toBe(
+      fingerprintMapCoordinates([first]),
+    );
+  });
+
+  test('has a stable canonical test vector for the userscript', () => {
+    expect(canonicalizeMapCoordinates([second, first])).toBe(
+      '[["pano-a",1,2,3,4,5],["pano-b",6,7,8,9,10]]',
+    );
+    expect(fingerprintMapCoordinates([second, first])).toBe(
+      '4a2121be5c5e4a594afa0a8bea69118650531865e779f5f338671b0423cf126f',
+    );
+  });
+});

--- a/apps/api/src/lib/userscript/map-snapshots.ts
+++ b/apps/api/src/lib/userscript/map-snapshots.ts
@@ -1,0 +1,78 @@
+import { maps, syncedLocations, syncedMapMetas } from '@api/lib/db/schema';
+import { db } from '@api/lib/drizzle';
+import { eq, inArray } from 'drizzle-orm';
+import { fingerprintMapCoordinates } from './map-fingerprint';
+
+export async function getSynchronizedGroupMapSnapshots(groupId: number) {
+  const groupMaps = await db.$primary.query.maps.findMany({
+    where: eq(maps.mapGroupId, groupId),
+    columns: { id: true, name: true, geoguessrId: true },
+    orderBy: (map, { asc }) => [asc(map.name), asc(map.id)],
+  });
+  const locationsByMapId = new Map<
+    number,
+    {
+      panoId: string | null;
+      lat: number;
+      lng: number;
+      heading: number;
+      pitch: number;
+      zoom: number;
+    }[]
+  >();
+
+  if (groupMaps.length !== 0) {
+    const locationRows = await db.$primary
+      .select({
+        mapId: syncedMapMetas.mapId,
+        panoId: syncedLocations.panoId,
+        lat: syncedLocations.lat,
+        lng: syncedLocations.lng,
+        heading: syncedLocations.heading,
+        pitch: syncedLocations.pitch,
+        zoom: syncedLocations.zoom,
+      })
+      .from(syncedMapMetas)
+      .innerJoin(
+        syncedLocations,
+        eq(syncedLocations.syncedMetaId, syncedMapMetas.syncedMetaId),
+      )
+      .where(
+        inArray(
+          syncedMapMetas.mapId,
+          groupMaps.map((map) => map.id),
+        ),
+      );
+
+    for (const row of locationRows) {
+      const locations = locationsByMapId.get(row.mapId) ?? [];
+      locations.push(row);
+      locationsByMapId.set(row.mapId, locations);
+    }
+  }
+
+  return groupMaps.map((map) => {
+    const locations = locationsByMapId.get(map.id) ?? [];
+    return {
+      mapId: map.id,
+      name: map.name,
+      geoguessrId: map.geoguessrId,
+      locationCount: locations.length,
+      fingerprint: fingerprintMapCoordinates(locations),
+    };
+  });
+}
+
+export function havePublishableMapLocationsChanged(
+  before: Awaited<ReturnType<typeof getSynchronizedGroupMapSnapshots>>,
+  after: Awaited<ReturnType<typeof getSynchronizedGroupMapSnapshots>>,
+) {
+  const oldFingerprintByMapId = new Map(
+    before.map((map) => [map.mapId, map.fingerprint]),
+  );
+  return after.some(
+    (map) =>
+      map.locationCount > 0 &&
+      oldFingerprintByMapId.get(map.mapId) !== map.fingerprint,
+  );
+}

--- a/apps/api/src/routes/internal/map-groups.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups.db.test.ts
@@ -1172,6 +1172,7 @@ describe('POST /api/internal/map-groups/:id/sync', () => {
     const after = Math.floor(Date.now() / 1000);
 
     expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ hasMapUpdates: true });
 
     // the source meta is mirrored into the synced tables with its exact
     // rendered payload
@@ -1230,6 +1231,78 @@ describe('POST /api/internal/map-groups/:id/sync', () => {
         createdAt: syncedTimestamp,
       },
     ]);
+  });
+
+  test('does not advertise map updates for a group without maps', async () => {
+    await seedUser('sync-mapless-owner');
+    const groupId = await seedOwnerGroup(
+      'sync-mapless-owner',
+      'Mapless group',
+      { syncedAt: null, syncIncludeLocationsNotOnStreetView: true },
+    );
+
+    const response = await syncRequest('sync-mapless-owner', groupId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ hasMapUpdates: false });
+  });
+
+  test('ignores meta-only syncs but advertises managed location changes', async () => {
+    await seedUser('sync-change-owner');
+    const { groupId, metaId } = await seedSyncFixture(
+      'sync-change-owner',
+      'Changed locations group',
+      'changed-locations-map',
+    );
+    await syncRequest('sync-change-owner', groupId);
+    const firstGroup = await getGroup(groupId);
+
+    await db
+      .update(metas)
+      .set({
+        note: 'Changed note only',
+        noteHtml: '<p>Changed note only</p>',
+        modifiedAt: firstGroup.syncedAt! + 1,
+      })
+      .where(eq(metas.id, metaId));
+    const metaOnlyResponse = await syncRequest('sync-change-owner', groupId);
+
+    expect(metaOnlyResponse.status).toBe(200);
+    expect(await metaOnlyResponse.json()).toEqual({ hasMapUpdates: false });
+
+    const secondGroup = await getGroup(groupId);
+    await db.insert(mapGroupLocations).values({
+      mapGroupId: groupId,
+      panoId: 'pano-added-after-meta-sync',
+      extraTag: 'us',
+      lat: 9,
+      lng: 8,
+      heading: 7,
+      pitch: 6,
+      zoom: 5,
+      modifiedAt: secondGroup.syncedAt! + 1,
+    });
+    expect(
+      await db
+        .select({ lat: mapGroupLocations.lat })
+        .from(mapGroupLocations)
+        .where(eq(mapGroupLocations.panoId, 'pano-added-after-meta-sync')),
+    ).toEqual([{ lat: 9 }]);
+    const locationResponse = await syncRequest('sync-change-owner', groupId);
+
+    expect(locationResponse.status).toBe(200);
+    expect(
+      await db
+        .select({ lat: syncedLocations.lat })
+        .from(syncedLocations)
+        .where(
+          and(
+            eq(syncedLocations.syncedMetaId, metaId),
+            eq(syncedLocations.panoId, 'pano-added-after-meta-sync'),
+          ),
+        ),
+    ).toEqual([{ lat: 9 }]);
+    expect(await locationResponse.json()).toEqual({ hasMapUpdates: true });
   });
 
   test('editor is denied with source and synced state unchanged', async () => {

--- a/apps/api/src/routes/internal/map-groups.ts
+++ b/apps/api/src/routes/internal/map-groups.ts
@@ -22,6 +22,10 @@ import {
 import { ensureOwner, ensurePermissions } from '@api/lib/internal/permissions';
 import { syncMapGroup } from '@api/lib/internal/sync';
 import { geoguessrMapJson } from '@api/lib/internal/utils';
+import {
+  getSynchronizedGroupMapSnapshots,
+  havePublishableMapLocationsChanged,
+} from '@api/lib/userscript/map-snapshots';
 import { isPgError } from '@api/lib/utils/common';
 import {
   and,
@@ -974,7 +978,11 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
       if (!group) {
         return status(404);
       }
+      const snapshotsBeforeSync =
+        await getSynchronizedGroupMapSnapshots(groupId);
       const syncedAt = await syncMapGroup(group);
+      const snapshotsAfterSync =
+        await getSynchronizedGroupMapSnapshots(groupId);
       // stamped with the sync's own timestamp so the marker sits exactly on
       // the synced/unsynced boundary instead of classifying itself unsynced
       await logChange(db.$primary, {
@@ -986,7 +994,12 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         operation: 'update',
         createdAt: syncedAt,
       });
-      return;
+      return {
+        hasMapUpdates: havePublishableMapLocationsChanged(
+          snapshotsBeforeSync,
+          snapshotsAfterSync,
+        ),
+      };
     },
     {
       params: t.Object({ id: t.Integer() }),

--- a/apps/api/src/routes/internal/maps/group.db.test.ts
+++ b/apps/api/src/routes/internal/maps/group.db.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { app } from '@api/api';
 import {
   levels,
-  mapData,
   mapFilters,
   mapGroupChanges,
   mapGroupLocations,
@@ -115,7 +114,6 @@ function groupMapBody(overrides: Record<string, unknown> = {}) {
     isShared: true,
     authors: 'Author',
     ordering: 3,
-    autoUpdate: true,
     difficulty: 2,
     isVerified: true,
     levels: [],
@@ -234,7 +232,6 @@ describe('PUT /api/internal/maps/group', () => {
         userId: null,
         authors: 'Author',
         ordering: 3,
-        autoUpdate: true,
         footer: '**Footer**',
         footerHtml: '<p><strong>Footer</strong></p>',
         modifiedAt: expect.any(Number),
@@ -309,7 +306,6 @@ describe('PUT /api/internal/maps/group', () => {
         isShared: false,
         authors: null,
         ordering: 0,
-        autoUpdate: false,
         difficulty: 5,
         isVerified: false,
         levels: [levelB, levelC],
@@ -336,7 +332,6 @@ describe('PUT /api/internal/maps/group', () => {
         isShared: false,
         authors: null,
         ordering: 0,
-        autoUpdate: false,
         footer: 'New footer',
         footerHtml: '<p>New footer</p>',
         difficulty: 5,
@@ -385,7 +380,6 @@ describe('PUT /api/internal/maps/group', () => {
       const requested = {
         isPublished: true,
         ordering: 7,
-        autoUpdate: true,
         isVerified: true,
       };
 
@@ -432,7 +426,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: false,
           ordering: 0,
-          autoUpdate: false,
           isVerified: false,
           // ungated fields are honored for every role
           name: 'Map Name',
@@ -452,7 +445,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: true,
           ordering: 0,
-          autoUpdate: false,
           isVerified: false,
         }),
       );
@@ -466,7 +458,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: true,
           ordering: 7,
-          autoUpdate: true,
           isVerified: true,
         }),
       );
@@ -487,7 +478,6 @@ describe('PUT /api/internal/maps/group', () => {
           geoguessrId: 'admin-zero-map',
           isPublished: false,
           ordering: 0,
-          autoUpdate: false,
           isVerified: false,
         }),
       );
@@ -499,7 +489,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: false,
           ordering: 0,
-          autoUpdate: false,
           isVerified: false,
         }),
       );
@@ -522,7 +511,6 @@ describe('PUT /api/internal/maps/group', () => {
           geoguessrId: 'retained-map',
           isPublished: true,
           ordering: 7,
-          autoUpdate: true,
           isVerified: true,
         }),
       );
@@ -535,7 +523,6 @@ describe('PUT /api/internal/maps/group', () => {
         geoguessrId: 'retained-map',
         isPublished: false,
         ordering: 0,
-        autoUpdate: false,
         isVerified: false,
       });
 
@@ -547,7 +534,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: true,
           ordering: 7,
-          autoUpdate: true,
           isVerified: true,
         }),
       );
@@ -563,7 +549,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: false,
           ordering: 7,
-          autoUpdate: true,
           isVerified: true,
         }),
       );
@@ -576,7 +561,6 @@ describe('PUT /api/internal/maps/group', () => {
         expect.objectContaining({
           isPublished: false,
           ordering: 0,
-          autoUpdate: false,
           isVerified: false,
         }),
       );
@@ -874,7 +858,6 @@ describe('PUT /api/internal/maps/group', () => {
         footer: '**Footer**',
         difficulty: 2,
         ordering: 0,
-        autoUpdate: false,
         isVerified: false,
         regions: ['Europe'],
         levels: ['Beginner'],
@@ -1084,7 +1067,7 @@ describe('DELETE /api/internal/maps/group/:id', () => {
     restoreNfcaToken();
   });
 
-  test('owner delete cascades map level/filter/region/data/meta associations and leaves unrelated rows', async () => {
+  test('owner delete cascades map associations and leaves unrelated rows', async () => {
     await seedUser('owner-1');
     const groupId = await seedGroup('Test group');
     await seedGroupOwner('owner-1', groupId);
@@ -1119,7 +1102,7 @@ describe('DELETE /api/internal/maps/group/:id', () => {
     expect(survivor.status).toBe(200);
     const { id: survivorId } = (await survivor.json()) as { id: number };
 
-    // data and meta associations are not settable through the PUT route: seed directly
+    // synced meta associations are not settable through the PUT route: seed directly
     const [syncedMeta] = await db
       .insert(syncedMetas)
       .values({
@@ -1132,7 +1115,6 @@ describe('DELETE /api/internal/maps/group/:id', () => {
         images: [],
       })
       .returning({ metaId: syncedMetas.metaId });
-    await db.insert(mapData).values([{ mapId: id }, { mapId: survivorId }]);
     await db.insert(syncedMapMetas).values([
       { mapId: id, syncedMetaId: syncedMeta!.metaId },
       { mapId: survivorId, syncedMetaId: syncedMeta!.metaId },
@@ -1151,9 +1133,6 @@ describe('DELETE /api/internal/maps/group/:id', () => {
     ).toEqual([]);
     expect(
       await db.select().from(mapRegions).where(eq(mapRegions.mapId, id)),
-    ).toEqual([]);
-    expect(
-      await db.select().from(mapData).where(eq(mapData.mapId, id)),
     ).toEqual([]);
     expect(
       await db
@@ -1184,9 +1163,6 @@ describe('DELETE /api/internal/maps/group/:id', () => {
         .from(mapRegions)
         .where(eq(mapRegions.mapId, survivorId)),
     ).toEqual([{ regionId }]);
-    expect(
-      await db.select().from(mapData).where(eq(mapData.mapId, survivorId)),
-    ).toHaveLength(1);
     expect(
       await db
         .select({ syncedMetaId: syncedMapMetas.syncedMetaId })
@@ -1275,7 +1251,6 @@ describe('DELETE /api/internal/maps/group/:id', () => {
         images: [],
       })
       .returning({ metaId: syncedMetas.metaId });
-    await db.insert(mapData).values([{ mapId: id }]);
     await db
       .insert(syncedMapMetas)
       .values([{ mapId: id, syncedMetaId: syncedMeta!.metaId }]);
@@ -1304,9 +1279,6 @@ describe('DELETE /api/internal/maps/group/:id', () => {
         .from(mapRegions)
         .where(eq(mapRegions.mapId, id)),
     ).toEqual([{ regionId }]);
-    expect(
-      await db.select().from(mapData).where(eq(mapData.mapId, id)),
-    ).toHaveLength(1);
     expect(
       await db
         .select({ syncedMetaId: syncedMapMetas.syncedMetaId })

--- a/apps/api/src/routes/internal/maps/group.ts
+++ b/apps/api/src/routes/internal/maps/group.ts
@@ -118,7 +118,6 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
           footer: savedData.footer,
           difficulty: savedData.difficulty,
           ordering: savedData.ordering,
-          autoUpdate: savedData.autoUpdate,
           isVerified: savedData.isVerified,
           regions: regionNames(oldRegions.map((mr) => mr.regionId)),
           levels: levelNames(oldLevels.map((ml) => ml.levelId)),
@@ -161,7 +160,6 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
         ...baseValues,
         ...(user.isSuperadmin && {
           ordering: dataNoId.ordering,
-          autoUpdate: dataNoId.autoUpdate,
           isVerified: dataNoId.isVerified,
         }),
         ...((user.isSuperadmin || user.isTrusted) && {
@@ -255,9 +253,6 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
             ordering: user.isSuperadmin
               ? dataNoId.ordering
               : (savedData?.ordering ?? 0),
-            autoUpdate: user.isSuperadmin
-              ? dataNoId.autoUpdate
-              : (savedData?.autoUpdate ?? false),
             isVerified: user.isSuperadmin
               ? dataNoId.isVerified
               : (savedData?.isVerified ?? false),
@@ -329,7 +324,6 @@ export const groupMapsRouter = new Elysia({ prefix: '/group' })
         isShared: t.Boolean(),
         authors: t.Union([t.String(), t.Null()]),
         ordering: t.Number(),
-        autoUpdate: t.Boolean(),
         footer: t.String(),
         isVerified: t.Boolean(),
         includeFilters: t.Array(t.String()),

--- a/apps/api/src/routes/userscript.db.test.ts
+++ b/apps/api/src/routes/userscript.db.test.ts
@@ -621,8 +621,11 @@ describe('GET /api/userscript/map-group/:groupId/maps', () => {
       401,
     );
     expect((await requestGroupManifest(groupId, 'stranger-token')).status).toBe(
-      403,
+      404,
     );
+    expect(
+      (await requestGroupManifest(groupId + 10_000, 'stranger-token')).status,
+    ).toBe(404);
   });
 
   test('returns every group map with stable synchronized fingerprints', async () => {

--- a/apps/api/src/routes/userscript.db.test.ts
+++ b/apps/api/src/routes/userscript.db.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../lib/db/schema';
 import { db } from '../lib/drizzle';
 import { plonkitFooter } from '../lib/userscript/constants';
+import { fingerprintMapCoordinates } from '../lib/userscript/map-fingerprint';
 
 async function requestLocation(mapId: string, panoId: string) {
   return app.handle(
@@ -21,14 +22,29 @@ async function requestLocation(mapId: string, panoId: string) {
   );
 }
 
-async function requestLocationsExport(geoguessrId: string, token?: string) {
+async function requestLocationsExport(
+  geoguessrId: string,
+  token?: string,
+  expectedFingerprint?: string,
+) {
+  const query = expectedFingerprint
+    ? `?expectedFingerprint=${expectedFingerprint}`
+    : '';
   return app.handle(
     new Request(
-      `http://localhost/api/userscript/map/${geoguessrId}/locations`,
+      `http://localhost/api/userscript/map/${geoguessrId}/locations${query}`,
       {
         headers: token ? { authorization: `Bearer ${token}` } : undefined,
       },
     ),
+  );
+}
+
+async function requestGroupManifest(groupId: number, token?: string) {
+  return app.handle(
+    new Request(`http://localhost/api/userscript/map-group/${groupId}/maps`, {
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    }),
   );
 }
 
@@ -509,6 +525,151 @@ describe('GET /api/userscript/map/:geoguessrId/locations response shape', () => 
       },
     ]);
   });
+
+  test('accepts a matching fingerprint and rejects a stale fingerprint', async () => {
+    await db.insert(users).values({
+      id: 'fingerprint-owner',
+      username: 'fingerprint-owner',
+      apiToken: 'fingerprint-owner-token',
+    });
+    const { mapId } = await seedExportMap('fingerprint-map', {
+      isPersonal: true,
+      userId: 'fingerprint-owner',
+    });
+    await seedExportLocations({ mapId, panoIds: ['pano-a'] });
+    const fingerprint = fingerprintMapCoordinates([
+      { panoId: 'pano-a', lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5 },
+    ]);
+
+    const matching = await requestLocationsExport(
+      'fingerprint-map',
+      'fingerprint-owner-token',
+      fingerprint,
+    );
+    const stale = await requestLocationsExport(
+      'fingerprint-map',
+      'fingerprint-owner-token',
+      '0'.repeat(64),
+    );
+
+    expect(matching.status).toBe(200);
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({
+      message: 'Synchronized map data changed; scan the group again',
+    });
+  });
+});
+
+describe('GET /api/userscript/map-group/:groupId/maps', () => {
+  async function seedManifestGroup() {
+    await db.insert(users).values([
+      { id: 'manifest-owner', username: 'owner', apiToken: 'manifest-token' },
+      {
+        id: 'manifest-stranger',
+        username: 'stranger',
+        apiToken: 'stranger-token',
+      },
+    ]);
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Manifest Group', syncedAt: 1_700_000_000 })
+      .returning({ id: mapGroups.id });
+    await db.insert(mapGroupPermissions).values({
+      mapGroupId: group!.id,
+      userId: 'manifest-owner',
+      role: 'owner',
+    });
+    const insertedMaps = await db
+      .insert(maps)
+      .values([
+        {
+          name: 'Populated Map',
+          geoguessrId: 'manifest-populated',
+          mapGroupId: group!.id,
+        },
+        {
+          name: 'Empty Map',
+          geoguessrId: 'manifest-empty',
+          mapGroupId: group!.id,
+        },
+      ])
+      .returning({ id: maps.id, geoguessrId: maps.geoguessrId });
+    const populated = insertedMaps.find(
+      (map) => map.geoguessrId === 'manifest-populated',
+    )!;
+    await seedExportLocations({
+      mapId: populated.id,
+      panoIds: ['pano-b', 'pano-a'],
+      syncedMetaId: 9100,
+    });
+    return group!.id;
+  }
+
+  test('requires a valid token and group permission', async () => {
+    const groupId = await seedManifestGroup();
+
+    expect((await requestGroupManifest(groupId)).status).toBe(401);
+    expect((await requestGroupManifest(groupId, 'unknown-token')).status).toBe(
+      401,
+    );
+    expect((await requestGroupManifest(groupId, 'stranger-token')).status).toBe(
+      403,
+    );
+  });
+
+  test('returns every group map with stable synchronized fingerprints', async () => {
+    const groupId = await seedManifestGroup();
+    const response = await requestGroupManifest(groupId, 'manifest-token');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      group: {
+        id: groupId,
+        name: 'Manifest Group',
+        syncedAt: 1_700_000_000,
+      },
+      maps: [
+        {
+          name: 'Empty Map',
+          geoguessrId: 'manifest-empty',
+          locationCount: 0,
+          fingerprint: fingerprintMapCoordinates([]),
+        },
+        {
+          name: 'Populated Map',
+          geoguessrId: 'manifest-populated',
+          locationCount: 2,
+          fingerprint: fingerprintMapCoordinates([
+            { panoId: 'pano-a', lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5 },
+            { panoId: 'pano-b', lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5 },
+          ]),
+        },
+      ],
+    });
+  });
+
+  test('rejects a group that has never been synchronized', async () => {
+    await db.insert(users).values({
+      id: 'unsynced-owner',
+      username: 'owner',
+      apiToken: 'unsynced-token',
+    });
+    const [group] = await db
+      .insert(mapGroups)
+      .values({ name: 'Unsynced Group', syncedAt: null })
+      .returning({ id: mapGroups.id });
+    await db.insert(mapGroupPermissions).values({
+      mapGroupId: group!.id,
+      userId: 'unsynced-owner',
+      role: 'owner',
+    });
+
+    const response = await requestGroupManifest(group!.id, 'unsynced-token');
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      message: 'Map group has not been synchronized',
+    });
+  });
 });
 
 describe('GET /api/userscript/map/:geoguessrId', () => {
@@ -528,7 +689,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(await response.json()).toEqual({
       mapFound: true,
       isPersonal: true,
-      userscriptVersion: '0.90',
+      userscriptVersion: '0.91',
     });
   });
 
@@ -552,7 +713,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(await response.json()).toEqual({
       mapFound: true,
       isPersonal: false,
-      userscriptVersion: '0.90',
+      userscriptVersion: '0.91',
     });
   });
 
@@ -572,7 +733,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({
       mapFound: false,
-      userscriptVersion: '0.90',
+      userscriptVersion: '0.91',
     });
   });
 });

--- a/apps/api/src/routes/userscript.db.test.ts
+++ b/apps/api/src/routes/userscript.db.test.ts
@@ -48,6 +48,14 @@ async function requestGroupManifest(groupId: number, token?: string) {
   );
 }
 
+async function requestAccessibleGroups(token?: string) {
+  return app.handle(
+    new Request('http://localhost/api/userscript/map-groups', {
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    }),
+  );
+}
+
 interface SeedExportMapOptions {
   isPersonal?: boolean;
   userId?: string | null;
@@ -668,6 +676,122 @@ describe('GET /api/userscript/map-group/:groupId/maps', () => {
     expect(response.status).toBe(409);
     expect(await response.json()).toEqual({
       message: 'Map group has not been synchronized',
+    });
+  });
+});
+
+describe('GET /api/userscript/map-groups', () => {
+  test('requires a valid token', async () => {
+    await db.insert(users).values({
+      id: 'group-list-owner',
+      username: 'group-list-owner',
+      apiToken: 'group-list-token',
+    });
+
+    expect((await requestAccessibleGroups()).status).toBe(401);
+    expect((await requestAccessibleGroups('unknown-token')).status).toBe(401);
+  });
+
+  test('returns only synchronized groups with maps that the user can access', async () => {
+    await db.insert(users).values([
+      {
+        id: 'group-list-owner',
+        username: 'group-list-owner',
+        apiToken: 'group-list-token',
+      },
+      {
+        id: 'group-list-stranger',
+        username: 'group-list-stranger',
+        apiToken: 'group-list-stranger-token',
+      },
+    ]);
+    const insertedGroups = await db
+      .insert(mapGroups)
+      .values([
+        { name: 'Available B', syncedAt: 1_700_000_002 },
+        { name: 'Available A', syncedAt: 1_700_000_001 },
+        { name: 'Unsynced', syncedAt: null },
+        { name: 'Mapless', syncedAt: 1_700_000_003 },
+        { name: 'Someone Else', syncedAt: 1_700_000_004 },
+      ])
+      .returning({ id: mapGroups.id, name: mapGroups.name });
+    const byName = new Map(
+      insertedGroups.map((group) => [group.name, group.id]),
+    );
+
+    await db.insert(mapGroupPermissions).values([
+      {
+        mapGroupId: byName.get('Available A')!,
+        userId: 'group-list-owner',
+        role: 'owner',
+      },
+      {
+        mapGroupId: byName.get('Available B')!,
+        userId: 'group-list-owner',
+        role: 'editor',
+      },
+      {
+        mapGroupId: byName.get('Unsynced')!,
+        userId: 'group-list-owner',
+        role: 'owner',
+      },
+      {
+        mapGroupId: byName.get('Mapless')!,
+        userId: 'group-list-owner',
+        role: 'owner',
+      },
+      {
+        mapGroupId: byName.get('Someone Else')!,
+        userId: 'group-list-stranger',
+        role: 'owner',
+      },
+    ]);
+    await db.insert(maps).values([
+      {
+        mapGroupId: byName.get('Available A')!,
+        name: 'Available A map 1',
+        geoguessrId: 'group-list-a-1',
+      },
+      {
+        mapGroupId: byName.get('Available A')!,
+        name: 'Available A map 2',
+        geoguessrId: 'group-list-a-2',
+      },
+      {
+        mapGroupId: byName.get('Available B')!,
+        name: 'Available B map',
+        geoguessrId: 'group-list-b',
+      },
+      {
+        mapGroupId: byName.get('Unsynced')!,
+        name: 'Unsynced map',
+        geoguessrId: 'group-list-unsynced',
+      },
+      {
+        mapGroupId: byName.get('Someone Else')!,
+        name: 'Someone else map',
+        geoguessrId: 'group-list-other',
+      },
+    ]);
+
+    const response = await requestAccessibleGroups('group-list-token');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      groups: [
+        {
+          id: byName.get('Available A'),
+          name: 'Available A',
+          syncedAt: 1_700_000_001,
+          mapCount: 2,
+        },
+        {
+          id: byName.get('Available B'),
+          name: 'Available B',
+          syncedAt: 1_700_000_002,
+          mapCount: 1,
+        },
+      ],
     });
   });
 });

--- a/apps/api/src/routes/userscript.ts
+++ b/apps/api/src/routes/userscript.ts
@@ -140,23 +140,22 @@ export const userscriptRouter = new Elysia({
         return status(401);
       }
 
-      const group = await db.$primary.query.mapGroups.findFirst({
-        where: eq(mapGroups.id, groupId),
-        columns: { id: true, name: true, syncedAt: true },
-      });
+      const [group] = await db.$primary
+        .select({
+          id: mapGroups.id,
+          name: mapGroups.name,
+          syncedAt: mapGroups.syncedAt,
+        })
+        .from(mapGroupPermissions)
+        .innerJoin(mapGroups, eq(mapGroups.id, mapGroupPermissions.mapGroupId))
+        .where(
+          and(
+            eq(mapGroupPermissions.userId, user.id),
+            eq(mapGroups.id, groupId),
+          ),
+        );
       if (!group) {
         return status(404);
-      }
-
-      const permission = await db.$primary.query.mapGroupPermissions.findFirst({
-        where: and(
-          eq(mapGroupPermissions.mapGroupId, groupId),
-          eq(mapGroupPermissions.userId, user.id),
-        ),
-        columns: { id: true },
-      });
-      if (!permission) {
-        return status(403);
       }
       if (group.syncedAt === null) {
         return status(409, { message: 'Map group has not been synchronized' });

--- a/apps/api/src/routes/userscript.ts
+++ b/apps/api/src/routes/userscript.ts
@@ -1,15 +1,21 @@
-import { mapGroupPermissions, maps, users } from '@api/lib/db/schema';
+import {
+  mapGroupPermissions,
+  mapGroups,
+  maps,
+  syncedLocations,
+  syncedMapMetas,
+  users,
+} from '@api/lib/db/schema';
 import { db } from '@api/lib/drizzle';
 import { bearer } from '@api/lib/internal/auth';
-import {
-  locationSelect,
-  mapLocationsExportSelect,
-} from '@api/lib/userscript/locations';
+import { locationSelect } from '@api/lib/userscript/locations';
+import { fingerprintMapCoordinates } from '@api/lib/userscript/map-fingerprint';
+import { getSynchronizedGroupMapSnapshots } from '@api/lib/userscript/map-snapshots';
 import { generateFooter } from '@api/lib/userscript/utils';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { Elysia, t } from 'elysia';
 
-const userscriptVersion = '0.90';
+const userscriptVersion = '0.91';
 
 const mapInfoQuery = db.query.maps
   .findFirst({
@@ -86,15 +92,67 @@ export const userscriptRouter = new Elysia({
   )
   .use(bearer())
   .get(
+    '/map-group/:groupId/maps',
+    async ({ params: { groupId }, status, bearer }) => {
+      if (!bearer) {
+        return status(401);
+      }
+
+      const user = await db.$primary.query.users.findFirst({
+        where: eq(users.apiToken, bearer),
+        columns: { id: true },
+      });
+      if (!user) {
+        return status(401);
+      }
+
+      const group = await db.$primary.query.mapGroups.findFirst({
+        where: eq(mapGroups.id, groupId),
+        columns: { id: true, name: true, syncedAt: true },
+      });
+      if (!group) {
+        return status(404);
+      }
+
+      const permission = await db.$primary.query.mapGroupPermissions.findFirst({
+        where: and(
+          eq(mapGroupPermissions.mapGroupId, groupId),
+          eq(mapGroupPermissions.userId, user.id),
+        ),
+        columns: { id: true },
+      });
+      if (!permission) {
+        return status(403);
+      }
+      if (group.syncedAt === null) {
+        return status(409, { message: 'Map group has not been synchronized' });
+      }
+
+      const groupMaps = await getSynchronizedGroupMapSnapshots(groupId);
+
+      return {
+        group: {
+          id: group.id,
+          name: group.name,
+          syncedAt: group.syncedAt,
+        },
+        maps: groupMaps.map(({ mapId: _mapId, ...map }) => map),
+      };
+    },
+    {
+      params: t.Object({ groupId: t.Integer() }),
+    },
+  )
+  .get(
     '/map/:geoguessrId/locations',
-    async ({ params: { geoguessrId }, status, bearer }) => {
+    async ({ params: { geoguessrId }, query, status, bearer }) => {
       if (!bearer) {
         return status(401);
       }
 
       // authorized = the token belongs to the personal map's owner, or to a
       // user with permissions on the map's group
-      const [data] = await db
+      const [data] = await db.$primary
         .select({
           mapId: maps.id,
           authorized: sql<boolean>`
@@ -123,9 +181,29 @@ export const userscriptRouter = new Elysia({
       if (!data.authorized) {
         return status(403);
       }
-      const locations = await mapLocationsExportSelect.execute({
-        mapId: data.mapId,
-      });
+      const locations = await db.$primary
+        .select({
+          panoId: syncedLocations.panoId,
+          lat: syncedLocations.lat,
+          lng: syncedLocations.lng,
+          heading: syncedLocations.heading,
+          pitch: syncedLocations.pitch,
+          zoom: syncedLocations.zoom,
+        })
+        .from(syncedMapMetas)
+        .innerJoin(
+          syncedLocations,
+          eq(syncedLocations.syncedMetaId, syncedMapMetas.syncedMetaId),
+        )
+        .where(eq(syncedMapMetas.mapId, data.mapId));
+      if (
+        query.expectedFingerprint !== undefined &&
+        fingerprintMapCoordinates(locations) !== query.expectedFingerprint
+      ) {
+        return status(409, {
+          message: 'Synchronized map data changed; scan the group again',
+        });
+      }
       return {
         customCoordinates: locations.map((location) => ({
           lat: location.lat,
@@ -138,5 +216,13 @@ export const userscriptRouter = new Elysia({
           stateCode: null,
         })),
       };
+    },
+    {
+      params: t.Object({ geoguessrId: t.String() }),
+      query: t.Object({
+        expectedFingerprint: t.Optional(
+          t.String({ pattern: '^[a-f0-9]{64}$' }),
+        ),
+      }),
     },
   );

--- a/apps/api/src/routes/userscript.ts
+++ b/apps/api/src/routes/userscript.ts
@@ -12,7 +12,7 @@ import { locationSelect } from '@api/lib/userscript/locations';
 import { fingerprintMapCoordinates } from '@api/lib/userscript/map-fingerprint';
 import { getSynchronizedGroupMapSnapshots } from '@api/lib/userscript/map-snapshots';
 import { generateFooter } from '@api/lib/userscript/utils';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, asc, eq, isNotNull, sql } from 'drizzle-orm';
 import { Elysia, t } from 'elysia';
 
 const userscriptVersion = '0.91';
@@ -91,6 +91,40 @@ export const userscriptRouter = new Elysia({
     },
   )
   .use(bearer())
+  .get('/map-groups', async ({ status, bearer }) => {
+    if (!bearer) {
+      return status(401);
+    }
+
+    const user = await db.$primary.query.users.findFirst({
+      where: eq(users.apiToken, bearer),
+      columns: { id: true },
+    });
+    if (!user) {
+      return status(401);
+    }
+
+    const groups = await db.$primary
+      .select({
+        id: mapGroups.id,
+        name: mapGroups.name,
+        syncedAt: mapGroups.syncedAt,
+        mapCount: sql<number>`count(${maps.id})::int`.mapWith(Number),
+      })
+      .from(mapGroupPermissions)
+      .innerJoin(mapGroups, eq(mapGroups.id, mapGroupPermissions.mapGroupId))
+      .innerJoin(maps, eq(maps.mapGroupId, mapGroups.id))
+      .where(
+        and(
+          eq(mapGroupPermissions.userId, user.id),
+          isNotNull(mapGroups.syncedAt),
+        ),
+      )
+      .groupBy(mapGroups.id, mapGroups.name, mapGroups.syncedAt)
+      .orderBy(asc(mapGroups.name), asc(mapGroups.id));
+
+    return { groups };
+  })
   .get(
     '/map-group/:groupId/maps',
     async ({ params: { groupId }, status, bearer }) => {

--- a/apps/frontend/src/lib/db/schema.ts
+++ b/apps/frontend/src/lib/db/schema.ts
@@ -47,7 +47,6 @@ export const maps = pgTable(
     userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
     authors: text('authors').default(''),
     ordering: integer('ordering').notNull().default(0),
-    autoUpdate: boolean('auto_update').notNull().default(false),
     footer: text('footer').notNull().default(''),
     footerHtml: text('footer_html').notNull().default(''),
     modifiedAt: integer('modified_at').default(1730419200).notNull(),

--- a/apps/frontend/src/lib/form-schema.ts
+++ b/apps/frontend/src/lib/form-schema.ts
@@ -76,7 +76,6 @@ export const insertMapsSchema = z
     isShared: z.boolean().prefault(false),
     authors: z.string().nullable().prefault(''),
     ordering: z.coerce.number().prefault(0),
-    autoUpdate: z.boolean().prefault(false),
     footer: z.string().prefault(''),
     isVerified: z.boolean().prefault(false),
     includeFilters: z.array(z.string()).prefault([]),

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.server.ts
@@ -474,7 +474,7 @@ export const actions = {
   prepareUserScriptData: async (event) => {
     const groupId = getGroupId(event.params);
     // make it so every request has this user id as header
-    const { error: apiError } = await api.internal['map-groups']({ id: groupId }).sync.post(
+    const { data, error: apiError } = await api.internal['map-groups']({ id: groupId }).sync.post(
       undefined,
       {
         headers: {
@@ -485,5 +485,6 @@ export const actions = {
     if (apiError) {
       error(500);
     }
+    return { hasMapUpdates: data?.hasMapUpdates ?? false };
   }
 };

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
@@ -190,11 +190,6 @@
             syncingUserScript = false;
             if (result.type === 'success') {
               await applyAction(result);
-              if (data.group.id === 1) {
-                const updateCount = result.data?.updateCount || 0;
-                toast.push(`Updated ${updateCount} map(s)`);
-              }
-
               toast.push('Updated', {
                 duration: 10000
               });

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
@@ -9,6 +9,7 @@
   import VirtualizedTable from '$lib/components/VirtualizedTable.svelte';
   import { columns } from './columns';
   import { Button } from '$lib/components/ui/button';
+  import * as Dialog from '$lib/components/ui/dialog';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import MetaEditDialog from '$routes/(admin)/map-making/groups/[id]/MetaEditDialog.svelte';
   import MapUploadDialog from '$routes/(admin)/map-making/groups/[id]/MapUploadDialog.svelte';
@@ -86,6 +87,7 @@
   }
 
   let syncingUserScript = $state(false);
+  let showMapUpdatePrompt = $state(false);
   let sharingMetas = $state(false);
 
   // Dialog state for adding levels
@@ -190,9 +192,10 @@
             syncingUserScript = false;
             if (result.type === 'success') {
               await applyAction(result);
-              toast.push('Updated', {
+              toast.push('Userscript data synchronized', {
                 duration: 10000
               });
+              showMapUpdatePrompt = result.data?.hasMapUpdates === true;
             } else if (result.type === 'failure') {
               const errorMessage = result.data?.message || 'Something went wrong';
               toast.push(errorMessage, {
@@ -403,6 +406,32 @@
     </div>
   {/if}
 </div>
+
+<Dialog.Root bind:open={showMapUpdatePrompt}>
+  <Dialog.Content>
+    <Dialog.Header>
+      <Dialog.Title>Update your GeoGuessr maps?</Dialog.Title>
+      <Dialog.Description>
+        LearnableMeta has finished synchronizing this group. Continue to GeoGuessr to compare and
+        publish changed map locations with the LearnableMeta userscript.
+      </Dialog.Description>
+    </Dialog.Header>
+    <p class="text-sm text-muted-foreground">
+      This requires userscript version 0.91 or newer. You can review every map and deselect any you
+      do not want to update before publishing.
+    </p>
+    <Dialog.Footer>
+      <Button variant="outline" onclick={() => (showMapUpdatePrompt = false)}>Not now</Button>
+      <Button
+        href={`https://www.geoguessr.com/creator-hub?learnableMetaGroupId=${data.group.id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onclick={() => (showMapUpdatePrompt = false)}>
+        Continue to GeoGuessr
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>
 
 <MetaEditDialog
   bind:isMetaDialogOpen

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/maps/MapEditDialog.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/maps/MapEditDialog.svelte
@@ -59,7 +59,6 @@
           description: map.description,
           isPublished: map.isPublished,
           authors: map.authors,
-          autoUpdate: map.autoUpdate,
           levels: map.mapLevels.map((item) => item.levelId),
           regions: map.mapRegions.map((item) => item.regionId),
           difficulty: map.difficulty,
@@ -82,7 +81,6 @@
           description: '',
           isPublished: false,
           authors: '',
-          autoUpdate: false,
           levels: [],
           regions: [],
           includeFilters: [],
@@ -237,20 +235,6 @@
                   <Checkbox {...props} bind:checked={$formMapData.isVerified} />
                   <div class="space-y-1 leading-none">
                     <FormLabelWithTooltip label="Verified" tooltipContent="" />
-                  </div>
-                {/snippet}
-              </Form.Control>
-            </Form.Field>
-
-            <Form.Field
-              form={formMap}
-              name="autoUpdate"
-              class="flex flex-row items-start space-x-1 space-y-0">
-              <Form.Control>
-                {#snippet children({ props })}
-                  <Checkbox {...props} bind:checked={$formMapData.autoUpdate} />
-                  <div class="space-y-1 leading-none">
-                    <FormLabelWithTooltip label="Auto Update" tooltipContent="" />
                   </div>
                 {/snippet}
               </Form.Control>

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -25,24 +25,19 @@
 
 ## [0.91]
 
-- Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
-- Added a Creator Hub button for choosing any synchronized map group you can access
-- Added review and selection before updating changed maps
-- Added sequential draft updates, publishing, per-map progress, and retryable failures
-- Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
+- Added map-group updates after syncing and from Creator Hub
+- Detects changed GeoGuessr maps before updating
+- Added map selection, publishing progress, and retries
+- Refreshed dialogs and API token management
 
 ## [0.90]
 
-- Added meta pins on challenge results pages (geoguessr.com/results/...), with support for any round count
-- Fixed memory leaks from meta windows never being unmounted (drag handlers piled up every round)
-- Fixed live challenge windows stacking up instead of replacing each other
-- Fixed the upload button possibly keeping a previous map's id after map-maker navigation
-- Moved the map label to the new GeoGuessr map page layout and darkened its background
-- Restyled the upload button and notifications for the new map-maker top bar
-- Upload errors now show a readable message with the technical error underneath for reports
-- Added an in-page 🔑 button to view, replace or clear the LearnableMeta API key
-- Features now initialize independently, so one failing no longer disables the rest
-- Moved this changelog to CHANGELOG.md
+- Added meta pins to challenge results
+- Fixed meta window leaks and live challenge stacking
+- Fixed stale map IDs after Map Maker navigation
+- Updated the map label and upload UI for new GeoGuessr layouts
+- Added API key management and clearer upload errors
+- Isolated features so one failure does not disable the rest
 
 ## [0.89]
 
@@ -179,7 +174,7 @@
 
   const d=new Set;const importCSS = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
 
-  importCSS(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.group-list.svelte-axobi4{display:grid;gap:8px;overflow-y:auto;margin:14px 24px 0}.group-row.svelte-axobi4{display:flex;align-items:center;justify-content:space-between;gap:16px;width:100%;border:1px solid #d9dee7;border-radius:9px;padding:13px 15px;background:#fff;color:#172033;text-align:left;cursor:pointer}.group-row.svelte-axobi4:hover{border-color:#d3a300;background:#fffaf0}.group-row.svelte-axobi4 span:where(.svelte-axobi4){flex:none;color:#667085;font-size:12px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
+  importCSS(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.help-toggle-button.svelte-1j2rmt2{background:transparent;border:none;padding:0;cursor:pointer}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center;gap:6px}.saved-key.svelte-1plj3lz{border-radius:4px;padding:2px 5px;background:var(--lm-muted);color:var(--lm-foreground);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:12px}.subtitle.svelte-axobi4{margin:6px 0 0;color:var(--lm-muted-foreground);font-size:14px}.map-update-close.svelte-axobi4{width:32px;height:32px;padding:0}.map-update-close.svelte-axobi4 svg:where(.svelte-axobi4){width:18px;height:18px;fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:2}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:13px 15px;border:1px solid var(--lm-border);border-radius:var(--lm-radius);background:var(--lm-muted);color:var(--lm-muted-foreground);font-size:14px;line-height:1.45}.fatal.svelte-axobi4{display:grid;gap:10px;border-color:#dc262659;background:#dc262617;color:var(--lm-destructive)}.fatal.svelte-axobi4 .learnablemeta-button:where(.svelte-axobi4){justify-self:start}.summary.svelte-axobi4{border-color:#16a34a4d;background:#16a34a1a;color:#166534}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;gap:16px;padding:18px 24px 10px;color:var(--lm-muted-foreground);font-size:13px;font-weight:500}.toolbar.svelte-axobi4>div:where(.svelte-axobi4){display:flex;gap:4px}.group-list.svelte-axobi4{display:grid;gap:8px;overflow-y:auto;max-height:390px;margin:14px 24px 0;padding:1px}.group-row.svelte-axobi4{display:flex;align-items:center;justify-content:space-between;gap:16px;width:100%;min-height:62px;border:1px solid var(--lm-border);border-radius:var(--lm-radius);padding:12px 14px;background:var(--lm-card);color:var(--lm-card-foreground);box-shadow:0 1px 2px #0000000d;text-align:left;cursor:pointer;transition:border-color .15s ease,background-color .15s ease,box-shadow .15s ease}.group-row.svelte-axobi4:hover{border-color:var(--lm-ring);background:color-mix(in srgb,var(--lm-primary) 6%,var(--lm-card));box-shadow:0 1px 4px #0000001a}.group-row.svelte-axobi4:focus-visible{outline:none;box-shadow:0 0 0 3px color-mix(in srgb,var(--lm-ring) 30%,transparent)}.group-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.group-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;font-size:14px;font-weight:600;text-overflow:ellipsis;white-space:nowrap}.group-details.svelte-axobi4>span:where(.svelte-axobi4){color:var(--lm-muted-foreground);font-size:12px}.group-count.svelte-axobi4{display:inline-flex;flex:none;align-items:center;gap:6px;color:var(--lm-muted-foreground);font-size:12px;font-weight:500}.group-count.svelte-axobi4 svg:where(.svelte-axobi4){width:16px;height:16px;fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:2}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid var(--lm-border);border-radius:var(--lm-radius);background:var(--lm-card)}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid var(--lm-border);color:var(--lm-card-foreground);transition:background-color .15s ease}.map-row.svelte-axobi4:hover{background:var(--lm-muted)}.map-row.selected.svelte-axobi4{background:color-mix(in srgb,var(--lm-primary) 7%,var(--lm-card))}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:#dc26260f}.map-row.svelte-axobi4 input[type=checkbox]:where(.svelte-axobi4){width:16px;height:16px;accent-color:var(--lm-primary)}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;font-size:14px;font-weight:600;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:var(--lm-muted-foreground);font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:var(--lm-destructive);white-space:normal}.status.svelte-axobi4{padding:3px 8px;border:1px solid transparent;border-radius:calc(var(--lm-radius) - 2px);font-size:12px;font-weight:500;white-space:nowrap}.status.good.svelte-axobi4{border-color:#bbf7d0;background:#dcfce7;color:#166534}.status.warning.svelte-axobi4{border-color:#fde68a;background:#fef3c7;color:#854d0e}.status.bad.svelte-axobi4{border-color:#fecaca;background:#fee2e2;color:#991b1b}.status.working.svelte-axobi4{border-color:#bfdbfe;background:#dbeafe;color:#1e40af}.status.neutral.svelte-axobi4{border-color:var(--lm-border);background:var(--lm-muted);color:var(--lm-muted-foreground)}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px 0}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0;font-size:14px;line-height:1.5}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:var(--lm-muted-foreground);font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:var(--lm-link);text-underline-offset:3px}.token-actions.svelte-axobi4{margin:8px -24px 0}.error-text.svelte-axobi4{margin:0;color:var(--lm-destructive);font-size:13px}@media(prefers-color-scheme:dark){.summary.svelte-axobi4{color:#86efac}.status.good.svelte-axobi4{border-color:#22c55e66;background:#16a34a2e;color:#86efac}.status.warning.svelte-axobi4{border-color:#f59e0b66;background:#b4530933;color:#fde68a}.status.bad.svelte-axobi4{border-color:#ef444466;background:#b91c1c33;color:#fca5a5}.status.working.svelte-axobi4{border-color:#3b82f666;background:#1e40af38;color:#93c5fd}}@media(max-width:620px){.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.group-details.svelte-axobi4>span:where(.svelte-axobi4){display:none}.status.svelte-axobi4{grid-column:2;justify-self:start}} `);
 
   var _GM_getValue = (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = (() => typeof GM_info != "undefined" ? GM_info : void 0)();
@@ -187,186 +182,6 @@
   var _GM_setValue = (() => typeof GM_setValue != "undefined" ? GM_setValue : void 0)();
   var _GM_xmlhttpRequest = (() => typeof GM_xmlhttpRequest != "undefined" ? GM_xmlhttpRequest : void 0)();
   var _unsafeWindow = (() => typeof unsafeWindow != "undefined" ? unsafeWindow : void 0)();
-  function waitForElement(selector) {
-    return new Promise((resolve) => {
-      try {
-        const existingElement = document.querySelector(selector);
-        if (existingElement) {
-          resolve(existingElement);
-          return;
-        }
-      } catch {
-      }
-      const observer = new MutationObserver(() => {
-        try {
-          const element = document.querySelector(selector);
-          if (element) {
-            observer.disconnect();
-            removeUrlChangeListener();
-            resolve(element);
-            return;
-          }
-        } catch {
-        }
-      });
-      const handleUrlChange = () => {
-        observer.disconnect();
-        removeUrlChangeListener();
-        resolve(null);
-      };
-      const removeUrlChangeListener = () => {
-        window.removeEventListener("urlchange", handleUrlChange);
-      };
-      window.addEventListener("urlchange", handleUrlChange);
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ["class"]
-      });
-    });
-  }
-  function localStorageGetInt(name) {
-    const savedValue = _unsafeWindow.localStorage.getItem(name);
-    if (!savedValue) {
-      return null;
-    }
-    const savedInt = parseInt(savedValue, 10);
-    if (isNaN(savedInt)) {
-      return null;
-    }
-    return savedInt;
-  }
-  async function fetchMapInfo(url) {
-    return new Promise((resolve, reject) => {
-      _GM_xmlhttpRequest({
-        method: "GET",
-        url,
-        onload: (response) => {
-          if (response.status === 200 || response.status === 404) {
-            try {
-              const mapInfo = JSON.parse(response.responseText);
-              logInfo("fetched map info", mapInfo);
-              resolve(mapInfo);
-            } catch (e) {
-              logInfo("failed to parse map info response", e);
-              reject("Failed to parse response");
-            }
-          } else {
-            logInfo("failed to fetch map info", response);
-            reject(`HTTP error! status: ${response.status}`);
-          }
-        },
-        onerror: () => {
-          reject("An error occurred while fetching data");
-        }
-      });
-    });
-  }
-  const MAP_FOUND_CACHE_MS = 24 * 60 * 60 * 1e3;
-  const MAP_NOT_FOUND_CACHE_MS = 60 * 60 * 1e3;
-  function getCachedMapInfo(key) {
-    const savedMapInfo = _unsafeWindow.localStorage.getItem(key);
-    if (!savedMapInfo) {
-      return null;
-    }
-    try {
-      const parsed = JSON.parse(savedMapInfo);
-      if (parsed && parsed.mapInfo && typeof parsed.fetchedAt === "number") {
-        return parsed;
-      }
-    } catch {
-    }
-    return null;
-  }
-  async function getMapInfo(geoguessrId, forceUpdate) {
-    const localStorageMapInfoKey = `geometa:map-info:${geoguessrId}`;
-    const cached = getCachedMapInfo(localStorageMapInfoKey);
-    if (!forceUpdate && cached) {
-      const ttl = cached.mapInfo.mapFound ? MAP_FOUND_CACHE_MS : MAP_NOT_FOUND_CACHE_MS;
-      if (Date.now() - cached.fetchedAt < ttl) {
-        logInfo("using saved map info", cached.mapInfo);
-        return cached.mapInfo;
-      }
-    }
-    const url = `https://learnablemeta.com/api/userscript/map/${geoguessrId}`;
-    let mapInfo;
-    try {
-      mapInfo = await fetchMapInfo(url);
-    } catch (e) {
-      if (cached) {
-        logInfo("map info fetch failed - using stale cached map info", e);
-        return cached.mapInfo;
-      }
-      throw e;
-    }
-    const toCache = { mapInfo, fetchedAt: Date.now() };
-    _unsafeWindow.localStorage.setItem(localStorageMapInfoKey, JSON.stringify(toCache));
-    _unsafeWindow.localStorage.setItem("geometa:latest-version", mapInfo.userscriptVersion);
-    return mapInfo;
-  }
-  function getLatestVersionInfo() {
-    return _unsafeWindow.localStorage.getItem("geometa:latest-version");
-  }
-  function isNewerVersion(candidate, current) {
-    const a = candidate.split(".").map(Number);
-    const b = current.split(".").map(Number);
-    for (let i = 0; i < Math.max(a.length, b.length); i++) {
-      const diff = (a[i] || 0) - (b[i] || 0);
-      if (diff) return diff > 0;
-    }
-    return false;
-  }
-  function checkIfOutdated() {
-    const latest = getLatestVersionInfo();
-    if (!latest) {
-      return false;
-    }
-    return isNewerVersion(latest, _GM_info.script.version);
-  }
-  function markHelpMessageAsRead() {
-    _unsafeWindow.localStorage.setItem("geometa:help-message-read", "true");
-  }
-  function wasHelpMessageRead() {
-    return _unsafeWindow.localStorage.getItem("geometa:help-message-read") == "true";
-  }
-  const getChallengeId = () => {
-    const regexp = /.*\/live-challenge\/(.*)/;
-    const matches = location.pathname.match(regexp);
-    if (matches && matches.length > 1) {
-      return matches[1];
-    }
-    return null;
-  };
-  async function getChallengeInfo(id) {
-    const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;
-    const response = await fetch(url, {
-      method: "GET",
-      credentials: "include"
-    });
-    const data = await response.json();
-    const mapId = data.options.mapSlug;
-    const currentRound = data.currentRoundNumber - 1;
-    const rounds = data.rounds;
-    const panorama = rounds[currentRound].question.panoramaQuestionPayload.panorama;
-    const panoIdHex = panorama.panoId;
-    const panoId = decodePanoId(panoIdHex);
-    return { mapId, panoId };
-  }
-  function decodePanoId(encoded) {
-    let panoId = "";
-    for (let i = 0; i + 2 <= encoded.length; i += 2) {
-      panoId += String.fromCharCode(parseInt(encoded.slice(i, i + 2), 16));
-    }
-    return panoId;
-  }
-  function logInfo(name, data) {
-    console.log(`ALM: ${name}`, data);
-  }
-  function extractMapIdFromUrl(url) {
-    const match = url.match(/\/maps\/([^\/]+)/);
-    return match ? match[1] : null;
-  }
   const DEV = false;
   var is_array = Array.isArray;
   var index_of = Array.prototype.indexOf;
@@ -3530,6 +3345,31 @@ get_first_child(node2)
       }
     });
   }
+  function action(dom, action2, get_value) {
+    effect(() => {
+      var payload = untrack(() => action2(dom, get_value?.()) || {});
+      if (get_value && payload?.update) {
+        var inited = false;
+        var prev = (
+{}
+        );
+        render_effect(() => {
+          var value = get_value();
+          deep_read_state(value);
+          if (inited && safe_not_equal(prev, value)) {
+            prev = value;
+            payload.update(value);
+          }
+        });
+        inited = true;
+      }
+      if (payload?.destroy) {
+        return () => (
+payload.destroy()
+        );
+      }
+    });
+  }
   function r(e) {
     var t, f, n = "";
     if ("string" == typeof e || "number" == typeof e) n += e;
@@ -4218,14 +4058,194 @@ context.l
     );
     return l.u ??= { a: [], b: [], m: [] };
   }
+  function waitForElement(selector) {
+    return new Promise((resolve) => {
+      try {
+        const existingElement = document.querySelector(selector);
+        if (existingElement) {
+          resolve(existingElement);
+          return;
+        }
+      } catch {
+      }
+      const observer = new MutationObserver(() => {
+        try {
+          const element = document.querySelector(selector);
+          if (element) {
+            observer.disconnect();
+            removeUrlChangeListener();
+            resolve(element);
+            return;
+          }
+        } catch {
+        }
+      });
+      const handleUrlChange = () => {
+        observer.disconnect();
+        removeUrlChangeListener();
+        resolve(null);
+      };
+      const removeUrlChangeListener = () => {
+        window.removeEventListener("urlchange", handleUrlChange);
+      };
+      window.addEventListener("urlchange", handleUrlChange);
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["class"]
+      });
+    });
+  }
+  function localStorageGetInt(name) {
+    const savedValue = _unsafeWindow.localStorage.getItem(name);
+    if (!savedValue) {
+      return null;
+    }
+    const savedInt = parseInt(savedValue, 10);
+    if (isNaN(savedInt)) {
+      return null;
+    }
+    return savedInt;
+  }
+  async function fetchMapInfo(url) {
+    return new Promise((resolve, reject) => {
+      _GM_xmlhttpRequest({
+        method: "GET",
+        url,
+        onload: (response) => {
+          if (response.status === 200 || response.status === 404) {
+            try {
+              const mapInfo = JSON.parse(response.responseText);
+              logInfo("fetched map info", mapInfo);
+              resolve(mapInfo);
+            } catch (e) {
+              logInfo("failed to parse map info response", e);
+              reject("Failed to parse response");
+            }
+          } else {
+            logInfo("failed to fetch map info", response);
+            reject(`HTTP error! status: ${response.status}`);
+          }
+        },
+        onerror: () => {
+          reject("An error occurred while fetching data");
+        }
+      });
+    });
+  }
+  const MAP_FOUND_CACHE_MS = 24 * 60 * 60 * 1e3;
+  const MAP_NOT_FOUND_CACHE_MS = 60 * 60 * 1e3;
+  function getCachedMapInfo(key) {
+    const savedMapInfo = _unsafeWindow.localStorage.getItem(key);
+    if (!savedMapInfo) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(savedMapInfo);
+      if (parsed && parsed.mapInfo && typeof parsed.fetchedAt === "number") {
+        return parsed;
+      }
+    } catch {
+    }
+    return null;
+  }
+  async function getMapInfo(geoguessrId, forceUpdate) {
+    const localStorageMapInfoKey = `geometa:map-info:${geoguessrId}`;
+    const cached = getCachedMapInfo(localStorageMapInfoKey);
+    if (!forceUpdate && cached) {
+      const ttl = cached.mapInfo.mapFound ? MAP_FOUND_CACHE_MS : MAP_NOT_FOUND_CACHE_MS;
+      if (Date.now() - cached.fetchedAt < ttl) {
+        logInfo("using saved map info", cached.mapInfo);
+        return cached.mapInfo;
+      }
+    }
+    const url = `https://learnablemeta.com/api/userscript/map/${geoguessrId}`;
+    let mapInfo;
+    try {
+      mapInfo = await fetchMapInfo(url);
+    } catch (e) {
+      if (cached) {
+        logInfo("map info fetch failed - using stale cached map info", e);
+        return cached.mapInfo;
+      }
+      throw e;
+    }
+    const toCache = { mapInfo, fetchedAt: Date.now() };
+    _unsafeWindow.localStorage.setItem(localStorageMapInfoKey, JSON.stringify(toCache));
+    _unsafeWindow.localStorage.setItem("geometa:latest-version", mapInfo.userscriptVersion);
+    return mapInfo;
+  }
+  function getLatestVersionInfo() {
+    return _unsafeWindow.localStorage.getItem("geometa:latest-version");
+  }
+  function isNewerVersion(candidate, current) {
+    const a = candidate.split(".").map(Number);
+    const b = current.split(".").map(Number);
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      const diff = (a[i] || 0) - (b[i] || 0);
+      if (diff) return diff > 0;
+    }
+    return false;
+  }
+  function checkIfOutdated() {
+    const latest = getLatestVersionInfo();
+    if (!latest) {
+      return false;
+    }
+    return isNewerVersion(latest, _GM_info.script.version);
+  }
+  function markHelpMessageAsRead() {
+    _unsafeWindow.localStorage.setItem("geometa:help-message-read", "true");
+  }
+  function wasHelpMessageRead() {
+    return _unsafeWindow.localStorage.getItem("geometa:help-message-read") == "true";
+  }
+  const getChallengeId = () => {
+    const regexp = /.*\/live-challenge\/(.*)/;
+    const matches = location.pathname.match(regexp);
+    if (matches && matches.length > 1) {
+      return matches[1];
+    }
+    return null;
+  };
+  async function getChallengeInfo(id) {
+    const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;
+    const response = await fetch(url, {
+      method: "GET",
+      credentials: "include"
+    });
+    const data = await response.json();
+    const mapId = data.options.mapSlug;
+    const currentRound = data.currentRoundNumber - 1;
+    const rounds = data.rounds;
+    const panorama = rounds[currentRound].question.panoramaQuestionPayload.panorama;
+    const panoIdHex = panorama.panoId;
+    const panoId = decodePanoId(panoIdHex);
+    return { mapId, panoId };
+  }
+  function decodePanoId(encoded) {
+    let panoId = "";
+    for (let i = 0; i + 2 <= encoded.length; i += 2) {
+      panoId += String.fromCharCode(parseInt(encoded.slice(i, i + 2), 16));
+    }
+    return panoId;
+  }
+  function logInfo(name, data) {
+    console.log(`ALM: ${name}`, data);
+  }
+  function extractMapIdFromUrl(url) {
+    const match = url.match(/\/maps\/([^\/]+)/);
+    return match ? match[1] : null;
+  }
   const PUBLIC_VERSION = "5";
   if (typeof window !== "undefined") {
     ((window.__svelte ??= {}).v ??= new Set()).add(PUBLIC_VERSION);
   }
   enable_legacy_mode_flag();
-  var root$6 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
+  var root$7 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
   function Spinner($$anchor) {
-    var div = root$6();
+    var div = root$7();
     append($$anchor, div);
   }
   var root_1$3 = from_html(`<img class="fi svelte-tdzec4"/>`);
@@ -4540,7 +4560,7 @@ context.l
   var root_3$2 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
   var root_6$3 = from_html(`<button></button>`);
   var root_5$3 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
-  var root$5 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
+  var root$6 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
   function Carousel($$anchor, $$props) {
     push($$props, false);
     let images = prop($$props, "images", 24, () => []);
@@ -4571,7 +4591,7 @@ context.l
       set(lensY, event2.clientY - rect.top);
     }
     init();
-    var div = root$5();
+    var div = root$6();
     var node = child(div);
     {
       var consequent_2 = ($$anchor2) => {
@@ -4757,18 +4777,81 @@ context.l
       console.warn("LocalStorage Error: Could not save last dismissed announcement timestamp.", e);
     }
   }
+  const focusableSelector = [
+    "a[href]",
+    "button:not(:disabled)",
+    "input:not(:disabled)",
+    "select:not(:disabled)",
+    "textarea:not(:disabled)",
+    '[tabindex]:not([tabindex="-1"])'
+  ].join(",");
+  function focusableElements(node) {
+    return Array.from(node.querySelectorAll(focusableSelector)).filter(
+      (element) => !element.hidden && element.getClientRects().length > 0
+    );
+  }
+  function modalDialog(node, initialOptions) {
+    let options = initialOptions;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    function focusDialog() {
+      if (!node.isConnected || node.contains(document.activeElement)) return;
+      const initialFocus = node.querySelector("[data-modal-initial-focus]") ?? focusableElements(node)[0];
+      if (initialFocus) {
+        initialFocus.focus();
+      } else {
+        node.tabIndex = -1;
+        node.focus();
+      }
+    }
+    function handleKeydown(event2) {
+      if (event2.key === "Escape" && options.closeOnEscape !== false) {
+        event2.preventDefault();
+        event2.stopPropagation();
+        options.onClose();
+        return;
+      }
+      if (event2.key !== "Tab") return;
+      const elements = focusableElements(node);
+      if (elements.length === 0) {
+        event2.preventDefault();
+        node.focus();
+        return;
+      }
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      const activeElement = document.activeElement;
+      if (event2.shiftKey && (activeElement === first || !node.contains(activeElement))) {
+        event2.preventDefault();
+        last.focus();
+      } else if (!event2.shiftKey && (activeElement === last || !node.contains(activeElement))) {
+        event2.preventDefault();
+        first.focus();
+      }
+    }
+    node.addEventListener("keydown", handleKeydown);
+    requestAnimationFrame(focusDialog);
+    return {
+      update(nextOptions) {
+        options = nextOptions;
+      },
+      destroy() {
+        node.removeEventListener("keydown", handleKeydown);
+        if (previouslyFocused?.isConnected) previouslyFocused.focus();
+      }
+    };
+  }
   var root_2$2 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
   var root_3$1 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
   var root_6$2 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
   var root_7 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
   var root_5$2 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
-  var root_9 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
-  var root_11$1 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
-  var root_10$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
-              on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View Map meta list:</strong> Click the list icon to see all the metas included
-              in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the Community:</strong> Click the Discord icon to share feedback, suggest
-              improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-1j2rmt2">Close</button></div></div>`);
-  var root$4 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-1j2rmt2"><span></span></button></div></div> <!> <!> <!></div>`);
+  var root_9 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui svelte-1j2rmt2" role="presentation"><div class="learnablemeta-modal svelte-1j2rmt2" role="dialog" aria-modal="true" aria-labelledby="external-link-title"><div class="learnablemeta-modal-header svelte-1j2rmt2"><p class="learnablemeta-modal-eyebrow svelte-1j2rmt2">LearnableMeta</p> <h2 class="learnablemeta-modal-title svelte-1j2rmt2" id="external-link-title">Open external link?</h2> <p class="learnablemeta-modal-description svelte-1j2rmt2">This link will open in a new browser tab.</p></div> <div class="learnablemeta-modal-body svelte-1j2rmt2"><p class="learnablemeta-modal-code svelte-1j2rmt2"> </p></div> <div class="learnablemeta-modal-actions svelte-1j2rmt2"><button type="button" data-modal-initial-focus="" class="learnablemeta-button learnablemeta-button--outline svelte-1j2rmt2">Cancel</button> <button type="button" class="learnablemeta-button learnablemeta-button--primary svelte-1j2rmt2">Continue</button></div></div></div>`);
+  var root_11$1 = from_html(`<p class="learnablemeta-modal-alert svelte-1j2rmt2"> </p>`);
+  var root_10$1 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui svelte-1j2rmt2" role="presentation"><div class="learnablemeta-modal learnablemeta-modal--wide svelte-1j2rmt2" role="dialog" aria-modal="true" aria-labelledby="learnablemeta-help-title"><div class="learnablemeta-modal-header svelte-1j2rmt2"><p class="learnablemeta-modal-eyebrow svelte-1j2rmt2">LearnableMeta</p> <h2 class="learnablemeta-modal-title svelte-1j2rmt2" id="learnablemeta-help-title">Userscript guide</h2> <p class="learnablemeta-modal-description svelte-1j2rmt2">Quick tips for using LearnableMeta while you play.</p></div> <div class="learnablemeta-modal-body svelte-1j2rmt2"><!> <ul class="learnablemeta-help-list svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to move:</strong> Click and drag the top of the note to reposition it anywhere
+              on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View map meta list:</strong> Click the list icon to see all the metas included
+              in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the community:</strong> Click the Discord icon to share feedback, suggest
+              improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated script:</strong> The question mark icon blinks when an update is available.</li></ul></div> <div class="learnablemeta-modal-actions svelte-1j2rmt2"><button type="button" class="learnablemeta-button learnablemeta-button--primary svelte-1j2rmt2">Close</button></div></div></div>`);
+  var root$5 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button class="help-toggle-button svelte-1j2rmt2" aria-label="More information"><span></span></button></div></div> <!> <!> <!></div>`);
   function App($$anchor, $$props) {
     push($$props, true);
     let geoInfo = state(null);
@@ -4880,7 +4963,7 @@ context.l
       }
     });
     let lastDismissedTimestamp = state(proxy(getLastDismissedAnnouncementTimestamp()));
-    var div = root$4();
+    var div = root$5();
     var node = child(div);
     await_block(node, getAnnouncement, null, ($$anchor2, announcement) => {
       var fragment = comment();
@@ -4996,13 +5079,15 @@ context.l
       var consequent_5 = ($$anchor2) => {
         var div_6 = root_9();
         var div_7 = child(div_6);
-        var p_3 = sibling(child(div_7), 2);
+        var div_8 = sibling(child(div_7), 2);
+        var p_3 = child(div_8);
         var text_3 = child(p_3);
-        var div_8 = sibling(p_3, 2);
-        var button_2 = child(div_8);
-        button_2.__click = proceed;
+        var div_9 = sibling(div_8, 2);
+        var button_2 = child(div_9);
+        button_2.__click = cancel;
         var button_3 = sibling(button_2, 2);
-        button_3.__click = cancel;
+        button_3.__click = proceed;
+        action(div_7, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: cancel }));
         template_effect(() => set_text(text_3, get(currentUrl)));
         append($$anchor2, div_6);
       };
@@ -5013,25 +5098,26 @@ context.l
     var node_12 = sibling(node_11, 2);
     {
       var consequent_7 = ($$anchor2) => {
-        var div_9 = root_10$1();
-        var div_10 = child(div_9);
+        var div_10 = root_10$1();
         var div_11 = child(div_10);
-        var node_13 = child(div_11);
+        var div_12 = sibling(child(div_11), 2);
+        var node_13 = child(div_12);
         {
           var consequent_6 = ($$anchor3) => {
             var p_4 = root_11$1();
-            var strong_1 = child(p_4);
-            var text_4 = child(strong_1);
-            template_effect(($0) => set_text(text_4, `Your script version is out of date - please install the latest version (${$0 ?? ""})!`), [getLatestVersionInfo]);
+            var text_4 = child(p_4);
+            template_effect(($0) => set_text(text_4, `Your userscript is out of date. Install the latest version (${$0 ?? ""}).`), [getLatestVersionInfo]);
             append($$anchor3, p_4);
           };
           if_block(node_13, ($$render) => {
             if (checkIfOutdated()) $$render(consequent_6);
           });
         }
-        var button_4 = sibling(div_11, 2);
+        var div_13 = sibling(div_12, 2);
+        var button_4 = child(div_13);
         button_4.__click = togglePopup;
-        append($$anchor2, div_9);
+        action(div_11, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: togglePopup }));
+        append($$anchor2, div_10);
       };
       if_block(node_12, ($$render) => {
         if (get(showHelpPopup)) $$render(consequent_7);
@@ -5283,9 +5369,9 @@ roundNumber: 4,
       return result;
     };
   }
-  var root$3 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
+  var root$4 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
   function MapLabel($$anchor, $$props) {
-    var div = root$3();
+    var div = root$4();
     var a = sibling(child(div), 2);
     template_effect(() => set_attribute(a, "href", `https://learnablemeta.com/maps/${$$props.mapId}`));
     append($$anchor, div);
@@ -5521,10 +5607,10 @@ roundNumber: 4,
     };
   }
   var root_1$2 = from_html(`<span class="toast-detail svelte-w17ltc"> </span>`);
-  var root$2 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
+  var root$3 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
   function ToastNotification($$anchor, $$props) {
     let type = prop($$props, "type", 3, "info");
-    var div = root$2();
+    var div = root$3();
     var div_1 = child(div);
     var span = child(div_1);
     var text = child(span);
@@ -5565,13 +5651,13 @@ roundNumber: 4,
   function clearApiKey() {
     _GM_setValue(API_KEY_STORAGE_NAME, "");
   }
-  var root_2$1 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
-  var root_4 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
-          to replace it, or clear the saved key.</p>`);
-  var root_5$1 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
-  var root_6$1 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
-  var root_1$1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
-  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="learnablemeta-yellow-button"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
+  var root_2$1 = from_html(`<p>An API token is required before locations can be uploaded.</p>`);
+  var root_4 = from_html(`<p>A token ending in <code class="saved-key svelte-1plj3lz"> </code> is saved. Paste
+            a new token to replace it, or clear the saved token.</p>`);
+  var root_5$1 = from_html(`<p>No API token is saved yet.</p>`);
+  var root_6$1 = from_html(`<button type="button" class="learnablemeta-button learnablemeta-button--destructive learnablemeta-modal-action-leading">Clear token</button>`);
+  var root_1$1 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation"><div class="learnablemeta-modal" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="learnablemeta-modal-header"><p class="learnablemeta-modal-eyebrow">LearnableMeta</p> <h2 class="learnablemeta-modal-title" id="apiKeyModalTitle">API token</h2> <p class="learnablemeta-modal-description">Manage the token used to download synchronized locations.</p></div> <div class="learnablemeta-modal-body"><!> <p>Generate or replace your token on the <a target="_blank" rel="noopener noreferrer">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API token" aria-label="LearnableMeta API token" data-modal-initial-focus="" class="learnablemeta-modal-input"/> <p class="learnablemeta-modal-note">The token is stored only in your browser's userscript storage.</p></div> <div class="learnablemeta-modal-actions"><!> <button type="button" class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button type="button" class="learnablemeta-button learnablemeta-button--primary"> </button></div></div></div>`);
+  var root$2 = from_html(`<div class="upload-label-container learnablemeta-ui svelte-1plj3lz"><button class="learnablemeta-geoguessr-button"> </button> <button class="learnablemeta-geoguessr-button learnablemeta-geoguessr-button--icon" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
     let showApiKeyModal = state(false);
@@ -5690,7 +5776,7 @@ roundNumber: 4,
       set(showApiKeyModal, false);
       set(apiKeyInput, "");
     }
-    var fragment = root$1();
+    var fragment = root$2();
     var div = first_child(fragment);
     var button = child(div);
     button.__click = handleUploadClick;
@@ -5702,7 +5788,8 @@ roundNumber: 4,
       var consequent_3 = ($$anchor2) => {
         var div_1 = root_1$1();
         var div_2 = child(div_1);
-        var node_1 = sibling(child(div_2), 2);
+        var div_3 = sibling(child(div_2), 2);
+        var node_1 = child(div_3);
         {
           var consequent = ($$anchor3) => {
             var p = root_2$1();
@@ -5742,8 +5829,8 @@ roundNumber: 4,
         var p_3 = sibling(node_1, 2);
         var a = sibling(child(p_3));
         var input = sibling(p_3, 2);
-        var div_3 = sibling(input, 2);
-        var node_3 = child(div_3);
+        var div_4 = sibling(div_3, 2);
+        var node_3 = child(div_4);
         {
           var consequent_2 = ($$anchor3) => {
             var button_2 = root_6$1();
@@ -5755,13 +5842,14 @@ roundNumber: 4,
           });
         }
         var button_3 = sibling(node_3, 2);
-        button_3.__click = handleSaveApiKey;
-        var text_2 = child(button_3);
+        button_3.__click = handleCancelModal;
         var button_4 = sibling(button_3, 2);
-        button_4.__click = handleCancelModal;
+        button_4.__click = handleSaveApiKey;
+        var text_2 = child(button_4);
+        action(div_2, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: handleCancelModal }));
         template_effect(() => {
           set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
-          set_text(text_2, get(modalMode) === "upload" ? "Save & Upload" : "Save");
+          set_text(text_2, get(modalMode) === "upload" ? "Save and upload" : "Save");
         });
         bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
         append($$anchor2, div_1);
@@ -5910,24 +5998,24 @@ roundNumber: 4,
   }
   var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
   var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
-  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and continue</button></div></div>`);
+  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="learnablemeta-modal-input" data-modal-initial-focus=""/> <!> <div class="learnablemeta-modal-actions token-actions svelte-axobi4"><button class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button class="learnablemeta-button learnablemeta-button--primary">Save and continue</button></div></div>`);
   var root_6 = from_html(`<div class="notice svelte-axobi4">Loading your synchronized map groups…</div>`);
-  var root_8 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load your map groups.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
-  var root_11 = from_html(`<button class="group-row svelte-axobi4"><strong> </strong> <span class="svelte-axobi4"> </span></button>`);
+  var root_8 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load your map groups.</strong> <span> </span> <button class="learnablemeta-button learnablemeta-button--outline svelte-axobi4">Try again</button></div>`);
+  var root_11 = from_html(`<button class="group-row svelte-axobi4"><span class="group-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4">Synchronized and ready to compare</span></span> <span class="group-count svelte-axobi4"> <svg viewBox="0 0 24 24" aria-hidden="true" class="svelte-axobi4"><path d="m9 18 6-6-6-6"></path></svg></span></button>`);
   var root_10 = from_html(`<div class="notice svelte-axobi4">Select a synchronized LearnableMeta group to compare its maps.</div> <div class="group-list svelte-axobi4"></div>`, 1);
   var root_12 = from_html(`<div class="notice svelte-axobi4">You have no synchronized map groups containing maps.</div>`);
-  var root_5 = from_html(`<!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button></footer>`, 1);
+  var root_5 = from_html(`<!> <footer class="learnablemeta-modal-actions"><button class="learnablemeta-button learnablemeta-button--link learnablemeta-modal-action-leading">Change API token</button> <button class="learnablemeta-button learnablemeta-button--outline">Close</button></footer>`, 1);
   var root_14 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
-  var root_15 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_15 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="learnablemeta-button learnablemeta-button--outline svelte-axobi4">Try again</button></div>`);
   var root_18 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
-  var root_17 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
-  var root_16 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
+  var root_17 = from_html(`<label><input type="checkbox" class="svelte-axobi4"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
+  var root_16 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div class="svelte-axobi4"><button class="learnablemeta-button learnablemeta-button--link">Select changed</button> <button class="learnablemeta-button learnablemeta-button--link">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
   var root_20 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
   var root_21 = from_html(`<div class="summary svelte-axobi4"> </div>`);
-  var root_22 = from_html(`<button class="link-button svelte-axobi4">Change group</button>`);
-  var root_23 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
-  var root_13 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <!> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
-  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4"> </h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
+  var root_22 = from_html(`<button class="learnablemeta-button learnablemeta-button--link">Change group</button>`);
+  var root_23 = from_html(`<button class="learnablemeta-button learnablemeta-button--outline"> </button>`);
+  var root_13 = from_html(`<!> <!> <!> <!> <footer class="learnablemeta-modal-actions"><button class="learnablemeta-button learnablemeta-button--link learnablemeta-modal-action-leading">Change API token</button> <!> <button class="learnablemeta-button learnablemeta-button--outline">Close</button> <!> <button class="learnablemeta-button learnablemeta-button--primary"> </button></footer>`, 1);
+  var root$1 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation"><div class="learnablemeta-modal learnablemeta-modal--map-update" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="learnablemeta-modal-header learnablemeta-modal-header--row"><div><p class="learnablemeta-modal-eyebrow">LearnableMeta</p> <h1 class="learnablemeta-modal-title learnablemeta-modal-title--large" id="group-update-title"> </h1> <!></div> <button class="learnablemeta-button learnablemeta-button--ghost map-update-close svelte-axobi4" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true" class="svelte-axobi4"><path d="M18 6 6 18M6 6l12 12"></path></svg></button></header> <!></div></div>`);
   function MapGroupUpdate($$anchor, $$props) {
     push($$props, true);
     const canChooseGroup = $$props.groupId === void 0;
@@ -6159,7 +6247,14 @@ roundNumber: 4,
       };
       return labels[row.status];
     }
-    var div = root();
+    function statusTone(row) {
+      if (row.status === "current" || row.status === "success") return "good";
+      if (["scan-error", "update-error", "publish-error"].includes(row.status)) return "bad";
+      if (["scanning", "updating", "publishing"].includes(row.status)) return "working";
+      if (row.status === "empty") return "neutral";
+      return "warning";
+    }
+    var div = root$1();
     var div_1 = child(div);
     var header = child(div_1);
     var div_2 = child(header);
@@ -6247,13 +6342,14 @@ roundNumber: 4,
                         each(div_7, 21, () => get(accessibleGroups), (group) => group.id, ($$anchor7, group) => {
                           var button_4 = root_11();
                           button_4.__click = () => selectGroup(get(group).id);
-                          var strong = child(button_4);
+                          var span_1 = child(button_4);
+                          var strong = child(span_1);
                           var text_4 = child(strong);
-                          var span_1 = sibling(strong, 2);
-                          var text_5 = child(span_1);
+                          var span_2 = sibling(span_1, 2);
+                          var text_5 = child(span_2);
                           template_effect(() => {
                             set_text(text_4, get(group).name);
-                            set_text(text_5, `${get(group).mapCount ?? ""} map${get(group).mapCount === 1 ? "" : "s"}`);
+                            set_text(text_5, `${get(group).mapCount ?? ""} map${get(group).mapCount === 1 ? "" : "s"} `);
                           });
                           append($$anchor7, button_4);
                         });
@@ -6315,9 +6411,9 @@ roundNumber: 4,
             {
               var consequent_8 = ($$anchor4) => {
                 var div_10 = root_15();
-                var span_2 = sibling(child(div_10), 2);
-                var text_6 = child(span_2);
-                var button_7 = sibling(span_2, 2);
+                var span_3 = sibling(child(div_10), 2);
+                var text_6 = child(span_3);
+                var button_7 = sibling(span_3, 2);
                 button_7.__click = scanGroup;
                 template_effect(() => set_text(text_6, get(fatalError)));
                 append($$anchor4, div_10);
@@ -6331,9 +6427,9 @@ roundNumber: 4,
               var consequent_10 = ($$anchor4) => {
                 var fragment_6 = root_16();
                 var div_11 = first_child(fragment_6);
-                var span_3 = child(div_11);
-                var text_7 = child(span_3);
-                var div_12 = sibling(span_3, 2);
+                var span_4 = child(div_11);
+                var text_7 = child(span_4);
+                var div_12 = sibling(span_4, 2);
                 var button_8 = child(div_12);
                 button_8.__click = () => selectChanged(true);
                 var button_9 = sibling(button_8, 2);
@@ -6343,39 +6439,37 @@ roundNumber: 4,
                   var label = root_17();
                   let classes;
                   var input_1 = child(label);
-                  var span_4 = sibling(input_1, 2);
-                  var strong_1 = child(span_4);
+                  var span_5 = sibling(input_1, 2);
+                  var strong_1 = child(span_5);
                   var text_8 = child(strong_1);
-                  var span_5 = sibling(strong_1, 2);
-                  var text_9 = child(span_5);
-                  var node_10 = sibling(span_5, 2);
+                  var span_6 = sibling(strong_1, 2);
+                  var text_9 = child(span_6);
+                  var node_10 = sibling(span_6, 2);
                   {
                     var consequent_9 = ($$anchor6) => {
-                      var span_6 = root_18();
-                      var text_10 = child(span_6);
+                      var span_7 = root_18();
+                      var text_10 = child(span_7);
                       template_effect(() => set_text(text_10, get(row).error));
-                      append($$anchor6, span_6);
+                      append($$anchor6, span_7);
                     };
                     if_block(node_10, ($$render) => {
                       if (get(row).error) $$render(consequent_9);
                     });
                   }
-                  var span_7 = sibling(span_4, 2);
-                  let classes_1;
-                  var text_11 = child(span_7);
+                  var span_8 = sibling(span_5, 2);
+                  var text_11 = child(span_8);
                   template_effect(
-                    ($0, $1) => {
-                      classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
+                    ($0, $1, $2) => {
+                      classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error, selected: get(row).selected });
                       input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
                       set_text(text_8, get(row).name);
                       set_text(text_9, `${$0 ?? ""} synchronized locations`);
-                      classes_1 = set_class(span_7, 1, "status svelte-axobi4", null, classes_1, {
-                        good: get(row).status === "current" || get(row).status === "success"
-                      });
-                      set_text(text_11, $1);
+                      set_class(span_8, 1, `status ${$1 ?? ""}`, "svelte-axobi4");
+                      set_text(text_11, $2);
                     },
                     [
                       () => get(row).locationCount.toLocaleString(),
+                      () => statusTone(get(row)),
                       () => statusLabel(get(row))
                     ]
                   );
@@ -6482,6 +6576,10 @@ roundNumber: 4,
         else $$render(alternate_5, false);
       });
     }
+    action(div_1, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({
+      onClose: $$props.onClose,
+      closeOnEscape: get(phase) !== "updating"
+    }));
     template_effect(() => {
       set_text(text, get(phase) === "groups" ? "Choose a map group" : "Update GeoGuessr maps");
       button.disabled = get(phase) === "updating";
@@ -6535,7 +6633,7 @@ roundNumber: 4,
     if (document.getElementById(launcherButtonId)) return;
     const launcher = document.createElement("button");
     launcher.id = launcherButtonId;
-    launcher.className = "learnablemeta-yellow-button";
+    launcher.className = "learnablemeta-geoguessr-button";
     launcher.type = "button";
     launcher.setAttribute("aria-label", "Update LearnableMeta maps");
     launcher.textContent = "Update maps";
@@ -6565,16 +6663,55 @@ roundNumber: 4,
     handleCreatorHubNavigation();
     window.addEventListener("urlchange", handleCreatorHubNavigation);
   }
-  const buttonsCss = ".learnablemeta-yellow-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;appearance:none;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.learnablemeta-yellow-button:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.learnablemeta-yellow-button:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:inset 0 2px 4px #0003;transform:translateY(1px)}.learnablemeta-yellow-button:focus-visible{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.learnablemeta-yellow-button:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.learnablemeta-map-actions{display:flex!important;flex-direction:row!important;align-items:center!important;gap:.75rem!important}";
+  var root = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation"><div class="learnablemeta-modal" role="dialog" aria-modal="true" aria-labelledby="reset-layout-title"><div class="learnablemeta-modal-header"><p class="learnablemeta-modal-eyebrow">LearnableMeta</p> <h2 class="learnablemeta-modal-title" id="reset-layout-title">Reset window layout?</h2> <p class="learnablemeta-modal-description">The meta window will return to its default position and size.</p></div> <div class="learnablemeta-modal-actions"><button type="button" data-modal-initial-focus="" class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button type="button" class="learnablemeta-button learnablemeta-button--primary">Reset layout</button></div></div></div>`);
+  function ResetLayoutConfirmation($$anchor, $$props) {
+    var div = root();
+    var div_1 = child(div);
+    var div_2 = sibling(child(div_1), 2);
+    var button = child(div_2);
+    button.__click = function(...$$args) {
+      $$props.onCancel?.apply(this, $$args);
+    };
+    var button_1 = sibling(button, 2);
+    button_1.__click = function(...$$args) {
+      $$props.onConfirm?.apply(this, $$args);
+    };
+    action(div_1, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: $$props.onCancel }));
+    append($$anchor, div);
+  }
+  delegate(["click"]);
+  const themeCss = ".learnablemeta-ui{--lm-background: hsl(0 0% 100%);--lm-foreground: hsl(240 10% 3.9%);--lm-card: hsl(0 0% 100%);--lm-card-foreground: hsl(240 10% 3.9%);--lm-primary: hsl(161 92% 25%);--lm-primary-hover: hsl(161 92% 22%);--lm-primary-foreground: hsl(355.7 100% 97.3%);--lm-secondary: hsl(240 4.8% 95.9%);--lm-secondary-foreground: hsl(240 5.9% 10%);--lm-muted: hsl(240 4.8% 95.9%);--lm-muted-foreground: hsl(240 3.8% 46.1%);--lm-accent: hsl(240 4.8% 95.9%);--lm-accent-foreground: hsl(240 5.9% 10%);--lm-destructive: hsl(0 72.22% 50.59%);--lm-border: hsl(240 5.9% 90%);--lm-input: hsl(240 5.9% 90%);--lm-ring: hsl(142.1 76.2% 36.3%);--lm-link: hsl(220.3 82.9% 52.7%);--lm-radius: .5rem;color:var(--lm-foreground);font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}@media(prefers-color-scheme:dark){.learnablemeta-ui{--lm-background: hsl(0 0% 10%);--lm-foreground: hsl(0 0% 95%);--lm-card: hsl(24 9.8% 10%);--lm-card-foreground: hsl(0 0% 95%);--lm-primary: hsl(161 92% 25%);--lm-primary-hover: hsl(161 92% 29%);--lm-primary-foreground: hsl(0 0% 98%);--lm-secondary: hsl(240 3.7% 20.9%);--lm-secondary-foreground: hsl(0 0% 98%);--lm-muted: hsl(0 0% 15%);--lm-muted-foreground: hsl(240 5% 64.9%);--lm-accent: hsl(12 6.5% 15.1%);--lm-accent-foreground: hsl(0 0% 98%);--lm-destructive: hsl(0 72% 60%);--lm-border: hsl(240 3.7% 22%);--lm-input: hsl(240 3.7% 25.5%);--lm-ring: hsl(142.4 71.8% 35%);--lm-link: hsl(217.1 92.7% 67.6%);color-scheme:dark}}";
+  importCSS(themeCss);
+  const buttonsCss = ".learnablemeta-button{display:inline-flex;height:36px;flex:none;align-items:center;justify-content:center;gap:8px;padding:8px 16px;appearance:none;font-family:inherit;font-size:14px;font-weight:500;line-height:20px;white-space:nowrap;border:1px solid transparent;border-radius:var(--lm-radius, .5rem);cursor:pointer;transition:background-color .15s ease,border-color .15s ease,color .15s ease,box-shadow .15s ease}.learnablemeta-button--primary{background:var(--lm-primary, hsl(161 92% 25%));color:var(--lm-primary-foreground, #fff);box-shadow:0 1px 2px #0000001f}.learnablemeta-button--primary:hover:not(:disabled){background:var(--lm-primary-hover, hsl(161 92% 22%))}.learnablemeta-button--outline{border-color:var(--lm-border, hsl(240 5.9% 90%));background:var(--lm-background, #fff);color:var(--lm-secondary-foreground, hsl(240 5.9% 10%));box-shadow:0 1px 2px #0000000f}.learnablemeta-button--outline:hover:not(:disabled){background:var(--lm-accent, hsl(240 4.8% 95.9%));color:var(--lm-accent-foreground, hsl(240 5.9% 10%))}.learnablemeta-button--ghost{background:transparent;color:var(--lm-muted-foreground, hsl(240 3.8% 46.1%));box-shadow:none}.learnablemeta-button--ghost:hover:not(:disabled){background:var(--lm-accent, hsl(240 4.8% 95.9%));color:var(--lm-accent-foreground, hsl(240 5.9% 10%))}.learnablemeta-button--link{height:auto;padding:5px 7px;background:transparent;color:var(--lm-link, hsl(220.3 82.9% 52.7%));font-size:13px;box-shadow:none}.learnablemeta-button--link:hover:not(:disabled){text-decoration:underline;text-underline-offset:3px}.learnablemeta-button--destructive{background:var(--lm-destructive, hsl(0 72.22% 50.59%));color:#fff;box-shadow:0 1px 2px #0000001f}.learnablemeta-button--destructive:hover:not(:disabled){background:color-mix(in srgb,var(--lm-destructive, #dc2626) 88%,#000)}.learnablemeta-button--icon{width:36px;padding:0}.learnablemeta-button:active:not(:disabled){box-shadow:inset 0 1px 3px #00000040}.learnablemeta-button--ghost:active:not(:disabled),.learnablemeta-button--link:active:not(:disabled){box-shadow:none}.learnablemeta-button:focus-visible{outline:none;box-shadow:0 0 0 3px color-mix(in srgb,var(--lm-ring, #16a34a) 35%,transparent)}.learnablemeta-button:disabled{opacity:.5;cursor:not-allowed}.learnablemeta-geoguessr-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;appearance:none;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.learnablemeta-geoguessr-button:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.learnablemeta-geoguessr-button:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:inset 0 2px 4px #0003;transform:translateY(1px)}.learnablemeta-geoguessr-button:focus-visible{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.learnablemeta-geoguessr-button:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.learnablemeta-geoguessr-button--icon{width:30px;height:30px;padding:0;border-radius:50%;font-size:14px}.learnablemeta-geoguessr-button--icon:hover:not(:disabled){box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transform:none}.learnablemeta-geoguessr-button--icon:active:not(:disabled){transform:none}.learnablemeta-map-actions{display:flex!important;flex-direction:row!important;align-items:center!important;gap:.75rem!important}";
   importCSS(buttonsCss);
-  if (typeof _GM_registerMenuCommand === "function") {
-    _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", () => {
-      if (confirm("Reset the LearnableMeta window position and size?")) {
-        resetContainerPosition();
-        resetContainerDimensions();
-        window.location.reload();
+  const modalsCss = '.learnablemeta-modal-backdrop{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;box-sizing:border-box;padding:24px;background:#000000c2;-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px)}.learnablemeta-modal,.learnablemeta-modal *{box-sizing:border-box}.learnablemeta-modal{position:relative;width:min(460px,100%);max-height:calc(100vh - 48px);overflow-y:auto;border:1px solid var(--lm-border);border-radius:calc(var(--lm-radius) + 4px);background:var(--lm-background);color:var(--lm-foreground);box-shadow:0 24px 70px #00000080;text-align:left}.learnablemeta-modal--wide{width:min(600px,100%)}.learnablemeta-modal--map-update{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden}.learnablemeta-modal:before{position:absolute;inset:0 0 auto;height:4px;background:linear-gradient(90deg,#057a55,#0b87c1);content:""}.learnablemeta-modal-header{display:grid;gap:6px;padding:26px 24px 0}.learnablemeta-modal-header--row{display:flex;align-items:flex-start;justify-content:space-between;gap:24px;padding:26px 24px 20px;border-bottom:1px solid var(--lm-border);background:var(--lm-card)}.learnablemeta-modal-eyebrow{margin:0;color:var(--lm-primary);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase}.learnablemeta-modal-title{margin:0;color:var(--lm-foreground);font-size:20px;font-weight:650;line-height:1.3;letter-spacing:-.025em}.learnablemeta-modal-title--large{margin-top:4px;color:var(--lm-card-foreground);font-size:22px;line-height:1.25}.learnablemeta-modal-description{margin:0;color:var(--lm-muted-foreground);font-size:14px;line-height:1.5}.learnablemeta-modal-body{display:grid;gap:14px;padding:20px 24px 0;color:var(--lm-foreground);font-size:14px;line-height:1.5}.learnablemeta-modal-body p{margin:0}.learnablemeta-modal-body a{color:var(--lm-link);text-decoration:underline;text-underline-offset:3px}.learnablemeta-modal-input{width:100%;height:38px;border:1px solid var(--lm-input);border-radius:var(--lm-radius);padding:7px 12px;outline:none;background:var(--lm-background);color:var(--lm-foreground);font:inherit;font-size:14px;box-shadow:0 1px 2px #0000000a;transition:border-color .15s ease,box-shadow .15s ease}.learnablemeta-modal-input::placeholder{color:var(--lm-muted-foreground)}.learnablemeta-modal-input:focus-visible{border-color:var(--lm-ring);box-shadow:0 0 0 3px color-mix(in srgb,var(--lm-ring) 25%,transparent)}.learnablemeta-modal-code{overflow-wrap:anywhere;border:1px solid var(--lm-border);border-radius:var(--lm-radius);padding:10px 12px;background:var(--lm-muted);color:var(--lm-link);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:12px;line-height:1.45;-webkit-user-select:text;user-select:text}.learnablemeta-modal-note{color:var(--lm-muted-foreground);font-size:12px;line-height:1.45}.learnablemeta-modal-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;margin-top:20px;padding:16px 24px;border-top:1px solid var(--lm-border);background:var(--lm-card)}.learnablemeta-modal-action-leading{margin-right:auto}.learnablemeta-modal-alert{border:1px solid rgba(220,38,38,.3);border-radius:var(--lm-radius);padding:12px 14px;background:#dc262617;color:var(--lm-destructive);font-size:13px}.learnablemeta-modal .learnablemeta-modal-body .learnablemeta-help-list{display:grid;gap:10px;margin:0;padding-left:20px;list-style:disc}.learnablemeta-modal .learnablemeta-help-list strong{color:var(--lm-foreground);font-weight:600}@media(max-width:620px){.learnablemeta-modal-backdrop{padding:8px}.learnablemeta-modal{max-height:calc(100vh - 16px)}.learnablemeta-modal-actions{flex-wrap:wrap}.learnablemeta-modal-action-leading{width:100%;margin-right:0}.learnablemeta-modal-actions .learnablemeta-button--primary,.learnablemeta-modal-actions .learnablemeta-button--outline,.learnablemeta-modal-actions .learnablemeta-button--destructive{flex:1}}';
+  importCSS(modalsCss);
+  let resetDialogApp = null;
+  function openResetLayoutDialog() {
+    if (resetDialogApp) return;
+    const target = document.createElement("div");
+    target.id = "learnablemeta-reset-layout-dialog";
+    document.body.appendChild(target);
+    function closeDialog() {
+      if (resetDialogApp) unmount(resetDialogApp);
+      resetDialogApp = null;
+      target.remove();
+    }
+    resetDialogApp = mount(ResetLayoutConfirmation, {
+      target,
+      props: {
+        onCancel: closeDialog,
+        onConfirm: () => {
+          resetContainerPosition();
+          resetContainerDimensions();
+          closeDialog();
+          window.location.reload();
+        }
       }
     });
+  }
+  if (typeof _GM_registerMenuCommand === "function") {
+    _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", openResetLayoutDialog);
   }
   initURLChangeEvent();
   if (document.readyState === "loading") {

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Learnable Meta
 // @namespace    geometa
-// @version      0.90
+// @version      0.91
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
 // @downloadURL  https://github.com/likeon/geometa/raw/main/userscript/dist/geometa.user.js
@@ -22,6 +22,13 @@
 
 /*
 # Changelog
+
+## [0.91]
+
+- Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
+- Added review and selection before updating changed maps
+- Added sequential draft updates, publishing, per-map progress, and retryable failures
+- Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
 
 ## [0.90]
 
@@ -171,7 +178,7 @@
 
   const d=new Set;const e = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
 
-  e(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.custom-yellow-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-1plj3lz:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-1plj3lz:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center} `);
+  e(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.custom-yellow-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-1plj3lz:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-1plj3lz:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
 
   var _GM_getValue = (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = (() => typeof GM_info != "undefined" ? GM_info : void 0)();
@@ -1464,6 +1471,11 @@ current_batch
       }
       next(promise);
     });
+  }
+function user_derived(fn) {
+    const d = derived(fn);
+    push_reaction_value(d);
+    return d;
   }
 function derived_safe_equal(fn) {
     const signal = derived(fn);
@@ -3537,10 +3549,29 @@ get_first_child(node2)
       return value ?? "";
     }
   }
+  const whitespace = [..." 	\n\r\f \v\uFEFF"];
   function to_class(value, hash, directives) {
     var classname = value == null ? "" : "" + value;
     if (hash) {
       classname = classname ? classname + " " + hash : hash;
+    }
+    if (directives) {
+      for (var key in directives) {
+        if (directives[key]) {
+          classname = classname ? classname + " " + key : key;
+        } else if (classname.length) {
+          var len = key.length;
+          var a = 0;
+          while ((a = classname.indexOf(key, a)) >= 0) {
+            var b = a + len;
+            if ((a === 0 || whitespace.includes(classname[a - 1])) && (b === classname.length || whitespace.includes(classname[b]))) {
+              classname = (a === 0 ? "" : classname.substring(0, a)) + classname.substring(b + 1);
+            } else {
+              a = b;
+            }
+          }
+        }
+      }
     }
     return classname === "" ? null : classname;
   }
@@ -3550,7 +3581,7 @@ get_first_child(node2)
   function set_class(dom, is_html, value, hash, prev_classes, next_classes) {
     var prev = dom.__className;
     if (prev !== value || prev === void 0) {
-      var next_class_name = to_class(value, hash);
+      var next_class_name = to_class(value, hash, next_classes);
       {
         if (next_class_name == null) {
           dom.removeAttribute("class");
@@ -3559,6 +3590,13 @@ get_first_child(node2)
         }
       }
       dom.__className = value;
+    } else if (next_classes && prev_classes !== next_classes) {
+      for (var key in next_classes) {
+        var is_present = !!next_classes[key];
+        if (prev_classes == null || is_present !== !!prev_classes[key]) {
+          dom.classList.toggle(key, is_present);
+        }
+      }
     }
     return next_classes;
   }
@@ -3933,6 +3971,23 @@ previous_batch ?? current_batch
       }
     });
   }
+  function bind_checked(input, get2, set2 = get2) {
+    listen_to_event_and_reset_event(input, "change", (is_reset) => {
+      var value = is_reset ? input.defaultChecked : input.checked;
+      set2(value);
+    });
+    if (
+
+
+untrack(get2) == null
+    ) {
+      set2(input.checked);
+    }
+    render_effect(() => {
+      var value = get2();
+      input.checked = Boolean(value);
+    });
+  }
   function is_numberlike_input(input) {
     var type = input.type;
     return type === "number" || type === "range";
@@ -4167,12 +4222,12 @@ context.l
     ((window.__svelte ??= {}).v ??= new Set()).add(PUBLIC_VERSION);
   }
   enable_legacy_mode_flag();
-  var root$5 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
+  var root$6 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
   function Spinner($$anchor) {
-    var div = root$5();
+    var div = root$6();
     append($$anchor, div);
   }
-  var root_1$2 = from_html(`<img class="fi svelte-tdzec4"/>`);
+  var root_1$3 = from_html(`<img class="fi svelte-tdzec4"/>`);
   function CountryFlag($$anchor, $$props) {
     const countryCodes = {
       Afghanistan: "af",
@@ -4380,7 +4435,7 @@ context.l
     var node = first_child(fragment);
     {
       var consequent = ($$anchor2) => {
-        var img = root_1$2();
+        var img = root_1$3();
         template_effect(
           ($0) => {
             set_attribute(img, "alt", $$props.countryName);
@@ -4480,11 +4535,11 @@ context.l
       _unsafeWindow.localStorage.setItem(heightKey, Math.floor(containerHeight).toString());
     }
   }
-  var root_4$1 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
-  var root_3$1 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
-  var root_6$2 = from_html(`<button></button>`);
-  var root_5$2 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
-  var root$4 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
+  var root_4$2 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
+  var root_3$2 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
+  var root_6$3 = from_html(`<button></button>`);
+  var root_5$3 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
+  var root$5 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
   function Carousel($$anchor, $$props) {
     push($$props, false);
     let images = prop($$props, "images", 24, () => []);
@@ -4515,7 +4570,7 @@ context.l
       set(lensY, event2.clientY - rect.top);
     }
     init();
-    var div = root$4();
+    var div = root$5();
     var node = child(div);
     {
       var consequent_2 = ($$anchor2) => {
@@ -4526,7 +4581,7 @@ context.l
           var node_2 = first_child(fragment_1);
           {
             var consequent_1 = ($$anchor4) => {
-              var div_1 = root_3$1();
+              var div_1 = root_3$2();
               div_1.__mousemove = handleMouseMove;
               var img = child(div_1);
               set_attribute(img, "alt", `Image ${index2 + 1}`);
@@ -4534,7 +4589,7 @@ context.l
               var node_3 = sibling(img, 2);
               {
                 var consequent = ($$anchor5) => {
-                  var div_2 = root_4$1();
+                  var div_2 = root_4$2();
                   template_effect(() => set_style(div_2, `
                 /* Position the lens so the mouse is in its center */
                 top: ${get(lensY) - lensSize / 2}px;
@@ -4573,7 +4628,7 @@ context.l
     var node_4 = sibling(node, 2);
     {
       var consequent_3 = ($$anchor2) => {
-        var fragment_2 = root_5$2();
+        var fragment_2 = root_5$3();
         var div_3 = first_child(fragment_2);
         var button = child(div_3);
         button.__click = prev;
@@ -4581,7 +4636,7 @@ context.l
         button_1.__click = next;
         var div_4 = sibling(div_3, 2);
         each(div_4, 5, images, index, ($$anchor3, _, index2) => {
-          var button_2 = root_6$2();
+          var button_2 = root_6$3();
           set_attribute(button_2, "aria-label", `Switch to image ${index2 + 1}`);
           button_2.__click = () => set(currentIndex, index2);
           template_effect(() => set_class(button_2, 1, `indicator ${index2 === get(currentIndex) ? "active" : ""}`, "svelte-8ojyxu"));
@@ -4701,18 +4756,18 @@ context.l
       console.warn("LocalStorage Error: Could not save last dismissed announcement timestamp.", e);
     }
   }
-  var root_2$1 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
-  var root_3 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
-  var root_6$1 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
-  var root_7 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
-  var root_5$1 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
-  var root_9 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
-  var root_11 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
+  var root_2$2 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
+  var root_3$1 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
+  var root_6$2 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
+  var root_7$1 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
+  var root_5$2 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
+  var root_9$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
+  var root_11$1 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
   var root_10 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
               on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View Map meta list:</strong> Click the list icon to see all the metas included
               in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the Community:</strong> Click the Discord icon to share feedback, suggest
               improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-1j2rmt2">Close</button></div></div>`);
-  var root$3 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-1j2rmt2"><span></span></button></div></div> <!> <!> <!></div>`);
+  var root$4 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-1j2rmt2"><span></span></button></div></div> <!> <!> <!></div>`);
   function App($$anchor, $$props) {
     push($$props, true);
     let geoInfo = state(null);
@@ -4824,14 +4879,14 @@ context.l
       }
     });
     let lastDismissedTimestamp = state(proxy(getLastDismissedAnnouncementTimestamp()));
-    var div = root$3();
+    var div = root$4();
     var node = child(div);
     await_block(node, getAnnouncement, null, ($$anchor2, announcement) => {
       var fragment = comment();
       var node_1 = first_child(fragment);
       {
         var consequent = ($$anchor3) => {
-          var div_1 = root_2$1();
+          var div_1 = root_2$2();
           var div_2 = child(div_1);
           var node_2 = child(div_2);
           html(node_2, () => get(announcement).htmlMessage);
@@ -4858,7 +4913,7 @@ context.l
     var node_3 = sibling(div_3, 2);
     {
       var consequent_1 = ($$anchor2) => {
-        var p = root_3();
+        var p = root_3$1();
         var text = child(p);
         template_effect(() => set_text(text, `Error: ${get(error) ?? ""}`));
         append($$anchor2, p);
@@ -4868,7 +4923,7 @@ context.l
         var node_4 = first_child(fragment_1);
         {
           var consequent_4 = ($$anchor3) => {
-            var fragment_2 = root_5$1();
+            var fragment_2 = root_5$2();
             var p_1 = first_child(fragment_2);
             var node_5 = child(p_1);
             CountryFlag(node_5, {
@@ -4885,7 +4940,7 @@ context.l
             var node_7 = sibling(div_5, 2);
             {
               var consequent_2 = ($$anchor4) => {
-                var p_2 = root_6$1();
+                var p_2 = root_6$2();
                 var node_8 = child(p_2);
                 html(node_8, () => get(geoInfo).footer);
                 append($$anchor4, p_2);
@@ -4897,7 +4952,7 @@ context.l
             var node_9 = sibling(node_7, 2);
             {
               var consequent_3 = ($$anchor4) => {
-                var fragment_3 = root_7();
+                var fragment_3 = root_7$1();
                 var node_10 = sibling(first_child(fragment_3), 2);
                 Carousel(node_10, {
                   get images() {
@@ -4938,7 +4993,7 @@ context.l
     var node_11 = sibling(node_3, 2);
     {
       var consequent_5 = ($$anchor2) => {
-        var div_6 = root_9();
+        var div_6 = root_9$1();
         var div_7 = child(div_6);
         var p_3 = sibling(child(div_7), 2);
         var text_3 = child(p_3);
@@ -4963,7 +5018,7 @@ context.l
         var node_13 = child(div_11);
         {
           var consequent_6 = ($$anchor3) => {
-            var p_4 = root_11();
+            var p_4 = root_11$1();
             var strong_1 = child(p_4);
             var text_4 = child(strong_1);
             template_effect(($0) => set_text(text_4, `Your script version is out of date - please install the latest version (${$0 ?? ""})!`), [getLatestVersionInfo]);
@@ -5227,9 +5282,9 @@ roundNumber: 4,
       return result;
     };
   }
-  var root$2 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
+  var root$3 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
   function MapLabel($$anchor, $$props) {
-    var div = root$2();
+    var div = root$3();
     var a = sibling(child(div), 2);
     template_effect(() => set_attribute(a, "href", `https://learnablemeta.com/maps/${$$props.mapId}`));
     append($$anchor, div);
@@ -5279,6 +5334,64 @@ roundNumber: 4,
       }
     });
   }
+  class LearnableMetaApiError extends Error {
+    constructor(status, message) {
+      super(message);
+      this.status = status;
+      this.name = "LearnableMetaApiError";
+    }
+  }
+  function requestJson(url, apiToken) {
+    return new Promise((resolve, reject) => {
+      _GM_xmlhttpRequest({
+        method: "GET",
+        url,
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json"
+        },
+        timeout: 15e3,
+        onload: (response) => {
+          let body;
+          try {
+            body = response.responseText ? JSON.parse(response.responseText) : null;
+          } catch {
+            body = response.responseText;
+          }
+          if (response.status >= 200 && response.status < 300) {
+            resolve(body);
+            return;
+          }
+          const apiMessage = body && typeof body === "object" && "message" in body ? String(body.message) : response.statusText || "Request failed";
+          reject(
+            new LearnableMetaApiError(
+              response.status,
+              `LearnableMeta API error (${response.status}): ${apiMessage}`
+            )
+          );
+        },
+        onerror: () => reject(new LearnableMetaApiError(0, "Could not reach LearnableMeta")),
+        ontimeout: () => reject(new LearnableMetaApiError(0, "LearnableMeta request timed out"))
+      });
+    });
+  }
+  function fetchMapGroupManifest(groupId, apiToken) {
+    return requestJson(
+      `https://learnablemeta.com/api/userscript/map-group/${groupId}/maps`,
+      apiToken
+    );
+  }
+  async function fetchSyncedMapLocations(geoguessrId, apiToken, expectedFingerprint) {
+    const query = expectedFingerprint ? `?expectedFingerprint=${encodeURIComponent(expectedFingerprint)}` : "";
+    const data = await requestJson(
+      `https://learnablemeta.com/api/userscript/map/${geoguessrId}/locations${query}`,
+      apiToken
+    );
+    if (!Array.isArray(data.customCoordinates)) {
+      throw new LearnableMetaApiError(0, "Received invalid map location data");
+    }
+    return data.customCoordinates;
+  }
   async function geoguessrAPIFetch(url, options = {}) {
     const { method = "GET", headers: initialHeaders, body, ...restOptions } = options;
     const effectiveHeaders = new Headers(initialHeaders);
@@ -5321,21 +5434,45 @@ roundNumber: 4,
     }
     return response;
   }
+  function draftUrl(geoguessrId) {
+    return `https://www.geoguessr.com/api/v4/user-maps/drafts/${geoguessrId}`;
+  }
+  async function getGeoguessrDraft(geoguessrId) {
+    const response = await geoguessrAPIFetch(draftUrl(geoguessrId));
+    return response.json();
+  }
+  async function updateGeoguessrDraft(geoguessrId, draft, customCoordinates) {
+    const { avatar, description, highlighted, name, version } = draft;
+    await geoguessrAPIFetch(draftUrl(geoguessrId), {
+      method: "PUT",
+      body: JSON.stringify({
+        avatar,
+        description,
+        highlighted,
+        name,
+        customCoordinates,
+        version: version + 1
+      })
+    });
+  }
+  async function publishGeoguessrDraft(geoguessrId) {
+    await geoguessrAPIFetch(`${draftUrl(geoguessrId)}/publish`, {
+      method: "PUT",
+      body: JSON.stringify({})
+    });
+  }
   async function uploadLocations(geoguessrId, apiKey) {
-    const geoguessrDraftApiUrl = `https://www.geoguessr.com/api/v4/user-maps/drafts/${geoguessrId}`;
     let geoguessrMapDetails;
     try {
-      const response = await geoguessrAPIFetch(geoguessrDraftApiUrl);
-      geoguessrMapDetails = await response.json();
+      geoguessrMapDetails = await getGeoguessrDraft(geoguessrId);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to fetch Geoguessr map info:", error);
       throw new Error(`Geoguessr Error: Could not fetch map details. ${errorMessage}`);
     }
-    const { avatar, description, highlighted, name, version } = geoguessrMapDetails;
     let locationsToUpload;
     try {
-      locationsToUpload = await fetchMapLocationsGM(geoguessrId, apiKey);
+      locationsToUpload = await fetchSyncedMapLocations(geoguessrId, apiKey);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to fetch map locations from backend:", error);
@@ -5346,19 +5483,8 @@ roundNumber: 4,
       console.warn(errorMessage);
       throw new Error(errorMessage);
     }
-    const mapDataToUpload = {
-      avatar,
-      description,
-      highlighted,
-      name,
-      customCoordinates: locationsToUpload,
-      version: version + 1
-    };
     try {
-      await geoguessrAPIFetch(geoguessrDraftApiUrl, {
-        method: "PUT",
-        body: JSON.stringify(mapDataToUpload)
-      });
+      await updateGeoguessrDraft(geoguessrId, geoguessrMapDetails, locationsToUpload);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to update Geoguessr map draft:", error);
@@ -5366,83 +5492,12 @@ roundNumber: 4,
     }
     try {
       console.log("Publishing Geoguessr map...");
-      await geoguessrAPIFetch(`${geoguessrDraftApiUrl}/publish`, {
-        method: "PUT",
-        body: JSON.stringify({})
-      });
+      await publishGeoguessrDraft(geoguessrId);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to publish Geoguessr map:", error);
       throw new Error(`Geoguessr Error: Could not publish map. ${errorMessage}`);
     }
-  }
-  function fetchMapLocationsGM(geoguessrId, apiToken) {
-    return new Promise((resolve, reject) => {
-      const apiUrl = `https://learnablemeta.com/api/userscript/map/${geoguessrId}/locations`;
-      _GM_xmlhttpRequest({
-        method: "GET",
-        url: apiUrl,
-        headers: {
-          Authorization: `Bearer ${apiToken}`,
-          "Content-Type": "application/json"
-        },
-        timeout: 15e3,
-onload: (response) => {
-          if (response.status >= 200 && response.status < 300) {
-            try {
-              const data = JSON.parse(response.responseText);
-              if (data && Array.isArray(data.customCoordinates)) {
-                resolve(data.customCoordinates);
-              } else {
-                console.error("Unexpected data structure from backend:", data);
-                reject(new Error("Received invalid location data structure from backend."));
-              }
-            } catch (parseError) {
-              console.error(
-                "Error parsing JSON response from backend:",
-                parseError,
-                response.responseText
-              );
-              reject(
-                new Error(
-                  `Backend Error: Failed to parse location data: ${parseError.message.substring(0, 100)}`
-                )
-              );
-            }
-          } else {
-            let errorMessage = `Backend Error (${response.status}): ${response.statusText || "Failed to fetch locations"}`;
-            let rawErrorResponse = response.responseText;
-            try {
-              const parsedJsonError = JSON.parse(response.responseText);
-              if (parsedJsonError && parsedJsonError.message) {
-                errorMessage = `Backend Error (${response.status}): ${parsedJsonError.message}`;
-              } else if (parsedJsonError) {
-                errorMessage = `Backend Error (${response.status}): ${JSON.stringify(parsedJsonError).substring(0, 100)}...`;
-              }
-              rawErrorResponse = parsedJsonError;
-            } catch (e) {
-              if (response.responseText) {
-                errorMessage = `Backend Error (${response.status}): ${response.responseText.substring(0, 100)}...`;
-              }
-            }
-            console.error(
-              `Error fetching map locations from backend (Status: ${response.status}):`,
-              rawErrorResponse
-            );
-            reject(new Error(errorMessage));
-          }
-        },
-        onerror: (error) => {
-          console.error("Failed to fetch map locations (XHR onerror):", error);
-          let detail = error.error || error.statusText || "Network request failed";
-          reject(new Error(`Network Error: Could not reach backend to fetch locations. ${detail}`));
-        },
-        ontimeout: () => {
-          console.error("Failed to fetch map locations: Request timed out", apiUrl);
-          reject(new Error("Backend Timeout: Request to fetch locations timed out."));
-        }
-      });
-    });
   }
   const linear = (x) => x;
   function fade(node, { delay = 0, duration = 400, easing = linear } = {}) {
@@ -5454,18 +5509,18 @@ onload: (response) => {
       css: (t) => `opacity: ${t * o}`
     };
   }
-  var root_1$1 = from_html(`<span class="toast-detail svelte-w17ltc"> </span>`);
-  var root$1 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
+  var root_1$2 = from_html(`<span class="toast-detail svelte-w17ltc"> </span>`);
+  var root$2 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
   function ToastNotification($$anchor, $$props) {
     let type = prop($$props, "type", 3, "info");
-    var div = root$1();
+    var div = root$2();
     var div_1 = child(div);
     var span = child(div_1);
     var text = child(span);
     var node = sibling(span, 2);
     {
       var consequent = ($$anchor2) => {
-        var span_1 = root_1$1();
+        var span_1 = root_1$2();
         var text_1 = child(span_1);
         template_effect(() => set_text(text_1, $$props.detail));
         append($$anchor2, span_1);
@@ -5487,17 +5542,27 @@ onload: (response) => {
     append($$anchor, div);
   }
   delegate(["click"]);
-  var root_2 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
-  var root_4 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
+  const API_KEY_STORAGE_NAME = "learnableMeta_apiKey";
+  const URL_TO_GENERATE_TOKEN = "https://learnablemeta.com/profile/token";
+  function getApiKey() {
+    const key = _GM_getValue(API_KEY_STORAGE_NAME, null);
+    return key?.trim() || null;
+  }
+  function saveApiKey(key) {
+    _GM_setValue(API_KEY_STORAGE_NAME, key.trim());
+  }
+  function clearApiKey() {
+    _GM_setValue(API_KEY_STORAGE_NAME, "");
+  }
+  var root_2$1 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
+  var root_4$1 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
           to replace it, or clear the saved key.</p>`);
-  var root_5 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
-  var root_6 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
-  var root_1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
-  var root = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="custom-yellow-button svelte-1plj3lz"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
+  var root_5$1 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
+  var root_6$1 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
+  var root_1$1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
+  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="custom-yellow-button svelte-1plj3lz"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
-    const API_KEY_STORAGE_NAME = "learnableMeta_apiKey";
-    const URL_TO_GENERATE_TOKEN = "https://learnablemeta.com/profile/token";
     let showApiKeyModal = state(false);
     let modalMode = state("upload");
     let apiKeyInput = state("");
@@ -5535,7 +5600,7 @@ onload: (response) => {
     }
     function getApiKeyFromGM() {
       try {
-        return _GM_getValue(API_KEY_STORAGE_NAME, null);
+        return getApiKey();
       } catch (e) {
         console.warn("GM_getValue is not available. API key functionality might be limited.", e);
         showCustomToast("Userscript storage (GM_getValue) is not available. Please ensure Tampermonkey/Violentmonkey is correctly configured.", "error", 0);
@@ -5544,7 +5609,7 @@ onload: (response) => {
     }
     function saveApiKeyToGM(key) {
       try {
-        _GM_setValue(API_KEY_STORAGE_NAME, key);
+        saveApiKey(key);
       } catch (e) {
         console.warn("GM_setValue is not available. API key functionality might be limited.", e);
         showCustomToast("Userscript storage (GM_setValue) is not available. Please ensure Tampermonkey/Violentmonkey is correctly configured.", "error", 0);
@@ -5571,7 +5636,7 @@ onload: (response) => {
       set(showApiKeyModal, true);
     }
     function handleClearApiKey() {
-      saveApiKeyToGM("");
+      clearApiKey();
       set(currentApiKey, null);
       set(showApiKeyModal, false);
       showCustomToast("LearnableMeta API Key cleared.", "success");
@@ -5614,7 +5679,7 @@ onload: (response) => {
       set(showApiKeyModal, false);
       set(apiKeyInput, "");
     }
-    var fragment = root();
+    var fragment = root$1();
     var div = first_child(fragment);
     var button = child(div);
     button.__click = handleUploadClick;
@@ -5624,12 +5689,12 @@ onload: (response) => {
     var node = sibling(div, 2);
     {
       var consequent_3 = ($$anchor2) => {
-        var div_1 = root_1();
+        var div_1 = root_1$1();
         var div_2 = child(div_1);
         var node_1 = sibling(child(div_2), 2);
         {
           var consequent = ($$anchor3) => {
-            var p = root_2();
+            var p = root_2$1();
             append($$anchor3, p);
           };
           var alternate_1 = ($$anchor3) => {
@@ -5637,14 +5702,14 @@ onload: (response) => {
             var node_2 = first_child(fragment_1);
             {
               var consequent_1 = ($$anchor4) => {
-                var p_1 = root_4();
+                var p_1 = root_4$1();
                 var code = sibling(child(p_1));
                 var text_1 = child(code);
                 template_effect(($0) => set_text(text_1, `…${$0 ?? ""}`), [() => get(currentApiKey).slice(-4)]);
                 append($$anchor4, p_1);
               };
               var alternate = ($$anchor4) => {
-                var p_2 = root_5();
+                var p_2 = root_5$1();
                 append($$anchor4, p_2);
               };
               if_block(
@@ -5665,13 +5730,12 @@ onload: (response) => {
         }
         var p_3 = sibling(node_1, 2);
         var a = sibling(child(p_3));
-        set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
         var input = sibling(p_3, 2);
         var div_3 = sibling(input, 2);
         var node_3 = child(div_3);
         {
           var consequent_2 = ($$anchor3) => {
-            var button_2 = root_6();
+            var button_2 = root_6$1();
             button_2.__click = handleClearApiKey;
             append($$anchor3, button_2);
           };
@@ -5684,7 +5748,10 @@ onload: (response) => {
         var text_2 = child(button_3);
         var button_4 = sibling(button_3, 2);
         button_4.__click = handleCancelModal;
-        template_effect(() => set_text(text_2, get(modalMode) === "upload" ? "Save & Upload" : "Save"));
+        template_effect(() => {
+          set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
+          set_text(text_2, get(modalMode) === "upload" ? "Save & Upload" : "Save");
+        });
         bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
         append($$anchor2, div_1);
       };
@@ -5731,7 +5798,7 @@ onload: (response) => {
       addLocationsUploadButtons();
     });
   }
-  const containerId = "geometa-locations-upload";
+  const containerId$1 = "geometa-locations-upload";
   let uploadApp = null;
   let runToken$1 = 0;
   function removeUploadButton() {
@@ -5739,7 +5806,7 @@ onload: (response) => {
       unmount(uploadApp);
       uploadApp = null;
     }
-    document.getElementById(containerId)?.remove();
+    document.getElementById(containerId$1)?.remove();
   }
   async function addLocationsUploadButtons() {
     const token = ++runToken$1;
@@ -5755,7 +5822,7 @@ onload: (response) => {
     const container = document.querySelector(".top-bar-menu_topBarMenu__kd9zX");
     if (container) {
       const target = document.createElement("div");
-      target.id = containerId;
+      target.id = containerId$1;
       container.insertBefore(target, container.lastElementChild);
       uploadApp = mount(UploadLocations, {
         target,
@@ -5814,6 +5881,468 @@ onload: (response) => {
       logInfo("failed to add meta pins on challenge results", e);
     }
   }
+  function canonicalizeMapCoordinates(coordinates) {
+    const tuples = coordinates.map(
+      ({ panoId, lat, lng, heading, pitch, zoom }) => [panoId, lat, lng, heading, pitch, zoom]
+    );
+    tuples.sort((left, right) => {
+      const leftJson = JSON.stringify(left);
+      const rightJson = JSON.stringify(right);
+      return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+    });
+    return JSON.stringify(tuples);
+  }
+  async function fingerprintMapCoordinates(coordinates) {
+    const bytes = new TextEncoder().encode(canonicalizeMapCoordinates(coordinates));
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
+  var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
+  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and scan</button></div></div>`);
+  var root_5 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
+  var root_6 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_9 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
+  var root_8 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
+  var root_7 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
+  var root_11 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
+  var root_12 = from_html(`<div class="summary svelte-axobi4"> </div>`);
+  var root_13 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
+  var root_4 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
+  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4">Update GeoGuessr maps</h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
+  function MapGroupUpdate($$anchor, $$props) {
+    push($$props, true);
+    let phase = state("scanning");
+    let apiToken = state("");
+    let tokenInput = state("");
+    let tokenError = state("");
+    let groupName = state("");
+    let rows = state(proxy([]));
+    let fatalError = state("");
+    let finishedRun = state(false);
+    let selectedCount = user_derived(() => get(rows).filter((row) => row.status === "changed" && row.selected).length);
+    let failureCount = user_derived(() => get(rows).filter((row) => ["scan-error", "update-error", "publish-error"].includes(row.status)).length);
+    let successCount = user_derived(() => get(rows).filter((row) => row.status === "success").length);
+    let changedCount = user_derived(() => get(rows).filter((row) => row.status === "changed").length);
+    onMount(() => {
+      try {
+        const savedToken = getApiKey();
+        if (!savedToken) {
+          set(phase, "token");
+          return;
+        }
+        set(apiToken, savedToken, true);
+        void scanGroup();
+      } catch (error) {
+        set(phase, "token");
+        set(tokenError, errorMessage(error), true);
+      }
+    });
+    function errorMessage(error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+    function replaceRow(geoguessrId, update) {
+      const index2 = get(rows).findIndex((row) => row.geoguessrId === geoguessrId);
+      if (index2 !== -1) get(rows)[index2] = { ...get(rows)[index2], ...update };
+    }
+    async function saveTokenAndScan() {
+      const trimmed = get(tokenInput).trim();
+      if (!trimmed) {
+        set(tokenError, "Paste a valid LearnableMeta API token.");
+        return;
+      }
+      saveApiKey(trimmed);
+      set(apiToken, trimmed, true);
+      set(tokenInput, "");
+      set(tokenError, "");
+      await scanGroup();
+    }
+    function changeToken() {
+      set(tokenInput, "");
+      set(tokenError, "");
+      set(phase, "token");
+    }
+    async function scanGroup() {
+      set(phase, "scanning");
+      set(fatalError, "");
+      set(finishedRun, false);
+      set(groupName, "");
+      set(rows, [], true);
+      try {
+        const manifest = await fetchMapGroupManifest($$props.groupId, get(apiToken));
+        set(groupName, manifest.group.name, true);
+        set(
+          rows,
+          manifest.maps.map((map) => ({
+            ...map,
+            status: map.locationCount === 0 ? "empty" : "scanning",
+            selected: false
+          })),
+          true
+        );
+        let nextIndex = 0;
+        async function worker() {
+          while (nextIndex < get(rows).length) {
+            const row = get(rows)[nextIndex++];
+            if (row.status === "scanning") await scanMap(row);
+          }
+        }
+        await Promise.all(Array.from({ length: Math.min(3, get(rows).length) }, () => worker()));
+        set(phase, "review");
+      } catch (error) {
+        if (error instanceof LearnableMetaApiError && error.status === 401) {
+          clearApiKey();
+          set(apiToken, "");
+          set(tokenError, "Your LearnableMeta API token was rejected. Paste a new token.");
+          set(phase, "token");
+          return;
+        }
+        set(fatalError, errorMessage(error), true);
+        set(phase, "review");
+      }
+    }
+    async function scanMap(row) {
+      replaceRow(row.geoguessrId, { status: "scanning", error: void 0, selected: false });
+      try {
+        const draft = await getGeoguessrDraft(row.geoguessrId);
+        const fingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        const changed = fingerprint !== row.fingerprint;
+        replaceRow(row.geoguessrId, { status: changed ? "changed" : "current", selected: changed });
+      } catch (error) {
+        replaceRow(row.geoguessrId, {
+          status: "scan-error",
+          selected: false,
+          error: errorMessage(error)
+        });
+      }
+    }
+    function selectChanged(selected) {
+      set(rows, get(rows).map((row) => row.status === "changed" ? { ...row, selected } : row), true);
+    }
+    async function updateSelected() {
+      const selectedIds = get(rows).filter((row) => row.status === "changed" && row.selected).map((row) => row.geoguessrId);
+      if (selectedIds.length === 0) return;
+      set(phase, "updating");
+      set(finishedRun, false);
+      for (const geoguessrId of selectedIds) {
+        const row = get(rows).find((candidate) => candidate.geoguessrId === geoguessrId);
+        if (row) await updateMap(row);
+      }
+      set(finishedRun, true);
+      set(phase, "review");
+    }
+    async function updateMap(row) {
+      replaceRow(row.geoguessrId, { status: "updating", error: void 0 });
+      let draft;
+      try {
+        draft = await getGeoguessrDraft(row.geoguessrId);
+        const currentFingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        if (currentFingerprint === row.fingerprint) {
+          replaceRow(row.geoguessrId, { status: "current", selected: false });
+          return;
+        }
+        const coordinates = await fetchSyncedMapLocations(row.geoguessrId, get(apiToken), row.fingerprint);
+        if (coordinates.length === 0) throw new Error("Cannot publish an empty map");
+        await updateGeoguessrDraft(row.geoguessrId, draft, coordinates);
+      } catch (error) {
+        replaceRow(row.geoguessrId, { status: "update-error", error: errorMessage(error) });
+        return;
+      }
+      replaceRow(row.geoguessrId, { status: "publishing" });
+      try {
+        await publishGeoguessrDraft(row.geoguessrId);
+        replaceRow(row.geoguessrId, { status: "success", selected: false });
+      } catch (error) {
+        replaceRow(row.geoguessrId, { status: "publish-error", error: errorMessage(error) });
+      }
+    }
+    async function retryFailures() {
+      set(phase, "updating");
+      set(finishedRun, false);
+      const failedIds = get(rows).filter((row) => ["scan-error", "update-error", "publish-error"].includes(row.status)).map((row) => row.geoguessrId);
+      for (const geoguessrId of failedIds) {
+        const row = get(rows).find((candidate) => candidate.geoguessrId === geoguessrId);
+        if (!row) continue;
+        if (row.status === "scan-error") {
+          await scanMap(row);
+        } else if (row.status === "publish-error") {
+          replaceRow(row.geoguessrId, { status: "publishing", error: void 0 });
+          try {
+            await publishGeoguessrDraft(row.geoguessrId);
+            replaceRow(row.geoguessrId, { status: "success", selected: false });
+          } catch (error) {
+            replaceRow(row.geoguessrId, { status: "publish-error", error: errorMessage(error) });
+          }
+        } else {
+          await updateMap(row);
+        }
+      }
+      set(finishedRun, true);
+      set(phase, "review");
+    }
+    function statusLabel(row) {
+      const labels = {
+        scanning: "Checking…",
+        changed: "Update available",
+        current: "Up to date",
+        empty: "No synchronized locations",
+        "scan-error": "Could not check",
+        updating: "Updating draft…",
+        publishing: "Publishing…",
+        success: "Updated and published",
+        "update-error": "Update failed",
+        "publish-error": "Draft updated; publish failed"
+      };
+      return labels[row.status];
+    }
+    var div = root();
+    var div_1 = child(div);
+    var header = child(div_1);
+    var div_2 = child(header);
+    var node = sibling(child(div_2), 4);
+    {
+      var consequent = ($$anchor2) => {
+        var p = root_1();
+        var text = child(p);
+        template_effect(() => set_text(text, get(groupName)));
+        append($$anchor2, p);
+      };
+      if_block(node, ($$render) => {
+        if (get(groupName)) $$render(consequent);
+      });
+    }
+    var button = sibling(div_2, 2);
+    button.__click = function(...$$args) {
+      $$props.onClose?.apply(this, $$args);
+    };
+    var node_1 = sibling(header, 2);
+    {
+      var consequent_2 = ($$anchor2) => {
+        var div_3 = root_2();
+        var p_1 = sibling(child(div_3), 2);
+        var a = sibling(child(p_1));
+        var input = sibling(p_1, 2);
+        input.__keydown = (event2) => event2.key === "Enter" && void saveTokenAndScan();
+        var node_2 = sibling(input, 2);
+        {
+          var consequent_1 = ($$anchor3) => {
+            var p_2 = root_3();
+            var text_1 = child(p_2);
+            template_effect(() => set_text(text_1, get(tokenError)));
+            append($$anchor3, p_2);
+          };
+          if_block(node_2, ($$render) => {
+            if (get(tokenError)) $$render(consequent_1);
+          });
+        }
+        var div_4 = sibling(node_2, 2);
+        var button_1 = child(div_4);
+        button_1.__click = function(...$$args) {
+          $$props.onClose?.apply(this, $$args);
+        };
+        var button_2 = sibling(button_1, 2);
+        button_2.__click = saveTokenAndScan;
+        template_effect(() => set_attribute(a, "href", URL_TO_GENERATE_TOKEN));
+        bind_value(input, () => get(tokenInput), ($$value) => set(tokenInput, $$value));
+        append($$anchor2, div_3);
+      };
+      var alternate_1 = ($$anchor2) => {
+        var fragment = root_4();
+        var node_3 = first_child(fragment);
+        {
+          var consequent_3 = ($$anchor3) => {
+            var div_5 = root_5();
+            append($$anchor3, div_5);
+          };
+          if_block(node_3, ($$render) => {
+            if (get(phase) === "scanning") $$render(consequent_3);
+          });
+        }
+        var node_4 = sibling(node_3, 2);
+        {
+          var consequent_4 = ($$anchor3) => {
+            var div_6 = root_6();
+            var span = sibling(child(div_6), 2);
+            var text_2 = child(span);
+            var button_3 = sibling(span, 2);
+            button_3.__click = scanGroup;
+            template_effect(() => set_text(text_2, get(fatalError)));
+            append($$anchor3, div_6);
+          };
+          if_block(node_4, ($$render) => {
+            if (get(fatalError)) $$render(consequent_4);
+          });
+        }
+        var node_5 = sibling(node_4, 2);
+        {
+          var consequent_6 = ($$anchor3) => {
+            var fragment_1 = root_7();
+            var div_7 = first_child(fragment_1);
+            var span_1 = child(div_7);
+            var text_3 = child(span_1);
+            var div_8 = sibling(span_1, 2);
+            var button_4 = child(div_8);
+            button_4.__click = () => selectChanged(true);
+            var button_5 = sibling(button_4, 2);
+            button_5.__click = () => selectChanged(false);
+            var div_9 = sibling(div_7, 2);
+            each(div_9, 21, () => get(rows), (row) => row.geoguessrId, ($$anchor4, row, $$index) => {
+              var label = root_8();
+              let classes;
+              var input_1 = child(label);
+              var span_2 = sibling(input_1, 2);
+              var strong = child(span_2);
+              var text_4 = child(strong);
+              var span_3 = sibling(strong, 2);
+              var text_5 = child(span_3);
+              var node_6 = sibling(span_3, 2);
+              {
+                var consequent_5 = ($$anchor5) => {
+                  var span_4 = root_9();
+                  var text_6 = child(span_4);
+                  template_effect(() => set_text(text_6, get(row).error));
+                  append($$anchor5, span_4);
+                };
+                if_block(node_6, ($$render) => {
+                  if (get(row).error) $$render(consequent_5);
+                });
+              }
+              var span_5 = sibling(span_2, 2);
+              let classes_1;
+              var text_7 = child(span_5);
+              template_effect(
+                ($0, $1) => {
+                  classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
+                  input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
+                  set_text(text_4, get(row).name);
+                  set_text(text_5, `${$0 ?? ""} synchronized locations`);
+                  classes_1 = set_class(span_5, 1, "status svelte-axobi4", null, classes_1, {
+                    good: get(row).status === "current" || get(row).status === "success"
+                  });
+                  set_text(text_7, $1);
+                },
+                [
+                  () => get(row).locationCount.toLocaleString(),
+                  () => statusLabel(get(row))
+                ]
+              );
+              bind_checked(input_1, () => get(row).selected, ($$value) => get(row).selected = $$value);
+              append($$anchor4, label);
+            });
+            template_effect(() => set_text(text_3, `${get(rows).length ?? ""} map${get(rows).length === 1 ? "" : "s"}`));
+            append($$anchor3, fragment_1);
+          };
+          var alternate = ($$anchor3) => {
+            var fragment_2 = comment();
+            var node_7 = first_child(fragment_2);
+            {
+              var consequent_7 = ($$anchor4) => {
+                var div_10 = root_11();
+                append($$anchor4, div_10);
+              };
+              if_block(
+                node_7,
+                ($$render) => {
+                  if (get(phase) === "review" && !get(fatalError)) $$render(consequent_7);
+                },
+                true
+              );
+            }
+            append($$anchor3, fragment_2);
+          };
+          if_block(node_5, ($$render) => {
+            if (get(rows).length > 0) $$render(consequent_6);
+            else $$render(alternate, false);
+          });
+        }
+        var node_8 = sibling(node_5, 2);
+        {
+          var consequent_8 = ($$anchor3) => {
+            var div_11 = root_12();
+            var text_8 = child(div_11);
+            template_effect(() => set_text(text_8, `Finished: ${get(successCount) ?? ""} published, ${get(failureCount) ?? ""} failed, ${get(changedCount) ?? ""} still available.`));
+            append($$anchor3, div_11);
+          };
+          if_block(node_8, ($$render) => {
+            if (get(finishedRun)) $$render(consequent_8);
+          });
+        }
+        var footer = sibling(node_8, 2);
+        var button_6 = child(footer);
+        button_6.__click = changeToken;
+        var button_7 = sibling(button_6, 2);
+        button_7.__click = function(...$$args) {
+          $$props.onClose?.apply(this, $$args);
+        };
+        var node_9 = sibling(button_7, 2);
+        {
+          var consequent_9 = ($$anchor3) => {
+            var button_8 = root_13();
+            button_8.__click = retryFailures;
+            var text_9 = child(button_8);
+            template_effect(() => {
+              button_8.disabled = get(phase) === "updating";
+              set_text(text_9, `Retry failed (${get(failureCount) ?? ""})`);
+            });
+            append($$anchor3, button_8);
+          };
+          if_block(node_9, ($$render) => {
+            if (get(failureCount) > 0) $$render(consequent_9);
+          });
+        }
+        var button_9 = sibling(node_9, 2);
+        button_9.__click = updateSelected;
+        var text_10 = child(button_9);
+        template_effect(() => {
+          button_6.disabled = get(phase) === "updating";
+          button_7.disabled = get(phase) === "updating";
+          button_9.disabled = get(phase) !== "review" || get(selectedCount) === 0;
+          set_text(text_10, get(phase) === "updating" ? "Updating…" : `Update and publish (${get(selectedCount)})`);
+        });
+        append($$anchor2, fragment);
+      };
+      if_block(node_1, ($$render) => {
+        if (get(phase) === "token") $$render(consequent_2);
+        else $$render(alternate_1, false);
+      });
+    }
+    template_effect(() => button.disabled = get(phase) === "updating");
+    append($$anchor, div);
+    pop();
+  }
+  delegate(["click", "keydown"]);
+  const queryParameter = "learnableMetaGroupId";
+  const containerId = "learnablemeta-map-group-update";
+  let app = null;
+  function clearHandoffParameter() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(queryParameter);
+    window.history.replaceState(window.history.state, "", url);
+  }
+  function startMapGroupUpdate(groupId) {
+    if (!Number.isSafeInteger(groupId) || groupId <= 0 || app) return;
+    const target = document.createElement("div");
+    target.id = containerId;
+    document.body.appendChild(target);
+    app = mount(MapGroupUpdate, {
+      target,
+      props: {
+        groupId,
+        onClose: () => {
+          if (app) unmount(app);
+          app = null;
+          target.remove();
+          clearHandoffParameter();
+        }
+      }
+    });
+  }
+  function initMapGroupUpdate() {
+    if (!window.location.pathname.startsWith("/creator-hub")) return;
+    const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
+    if (!rawGroupId) return;
+    startMapGroupUpdate(Number(rawGroupId));
+  }
   if (typeof _GM_registerMenuCommand === "function") {
     _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", () => {
       if (confirm("Reset the LearnableMeta window position and size?")) {
@@ -5835,7 +6364,8 @@ onload: (response) => {
       ["liveChallenge", initLiveChallenge],
       ["mapLabel", initMapLabel],
       ["locationsUpload", initLocationsUpload],
-      ["challengeResults", initChallengeResults]
+      ["challengeResults", initChallengeResults],
+      ["mapGroupUpdate", initMapGroupUpdate]
     ];
     for (const [name, init2] of features) {
       try {

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -26,6 +26,7 @@
 ## [0.91]
 
 - Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
+- Added a Creator Hub button for choosing any synchronized map group you can access
 - Added review and selection before updating changed maps
 - Added sequential draft updates, publishing, per-map progress, and retryable failures
 - Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
@@ -176,9 +177,9 @@
 (async function () {
   'use strict';
 
-  const d=new Set;const e = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
+  const d=new Set;const importCSS = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
 
-  e(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.custom-yellow-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-1plj3lz:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-1plj3lz:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
+  importCSS(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.group-list.svelte-axobi4{display:grid;gap:8px;overflow-y:auto;margin:14px 24px 0}.group-row.svelte-axobi4{display:flex;align-items:center;justify-content:space-between;gap:16px;width:100%;border:1px solid #d9dee7;border-radius:9px;padding:13px 15px;background:#fff;color:#172033;text-align:left;cursor:pointer}.group-row.svelte-axobi4:hover{border-color:#d3a300;background:#fffaf0}.group-row.svelte-axobi4 span:where(.svelte-axobi4){flex:none;color:#667085;font-size:12px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
 
   var _GM_getValue = (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = (() => typeof GM_info != "undefined" ? GM_info : void 0)();
@@ -4535,7 +4536,7 @@ context.l
       _unsafeWindow.localStorage.setItem(heightKey, Math.floor(containerHeight).toString());
     }
   }
-  var root_4$2 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
+  var root_4$1 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
   var root_3$2 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
   var root_6$3 = from_html(`<button></button>`);
   var root_5$3 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
@@ -4589,7 +4590,7 @@ context.l
               var node_3 = sibling(img, 2);
               {
                 var consequent = ($$anchor5) => {
-                  var div_2 = root_4$2();
+                  var div_2 = root_4$1();
                   template_effect(() => set_style(div_2, `
                 /* Position the lens so the mouse is in its center */
                 top: ${get(lensY) - lensSize / 2}px;
@@ -4759,11 +4760,11 @@ context.l
   var root_2$2 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
   var root_3$1 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
   var root_6$2 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
-  var root_7$1 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
+  var root_7 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
   var root_5$2 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
-  var root_9$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
+  var root_9 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
   var root_11$1 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
-  var root_10 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
+  var root_10$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
               on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View Map meta list:</strong> Click the list icon to see all the metas included
               in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the Community:</strong> Click the Discord icon to share feedback, suggest
               improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-1j2rmt2">Close</button></div></div>`);
@@ -4952,7 +4953,7 @@ context.l
             var node_9 = sibling(node_7, 2);
             {
               var consequent_3 = ($$anchor4) => {
-                var fragment_3 = root_7$1();
+                var fragment_3 = root_7();
                 var node_10 = sibling(first_child(fragment_3), 2);
                 Carousel(node_10, {
                   get images() {
@@ -4993,7 +4994,7 @@ context.l
     var node_11 = sibling(node_3, 2);
     {
       var consequent_5 = ($$anchor2) => {
-        var div_6 = root_9$1();
+        var div_6 = root_9();
         var div_7 = child(div_6);
         var p_3 = sibling(child(div_7), 2);
         var text_3 = child(p_3);
@@ -5012,7 +5013,7 @@ context.l
     var node_12 = sibling(node_11, 2);
     {
       var consequent_7 = ($$anchor2) => {
-        var div_9 = root_10();
+        var div_9 = root_10$1();
         var div_10 = child(div_9);
         var div_11 = child(div_10);
         var node_13 = child(div_11);
@@ -5381,6 +5382,16 @@ roundNumber: 4,
       apiToken
     );
   }
+  async function fetchAccessibleMapGroups(apiToken) {
+    const data = await requestJson(
+      "https://learnablemeta.com/api/userscript/map-groups",
+      apiToken
+    );
+    if (!Array.isArray(data.groups)) {
+      throw new LearnableMetaApiError(0, "Received invalid map group data");
+    }
+    return data.groups;
+  }
   async function fetchSyncedMapLocations(geoguessrId, apiToken, expectedFingerprint) {
     const query = expectedFingerprint ? `?expectedFingerprint=${encodeURIComponent(expectedFingerprint)}` : "";
     const data = await requestJson(
@@ -5555,12 +5566,12 @@ roundNumber: 4,
     _GM_setValue(API_KEY_STORAGE_NAME, "");
   }
   var root_2$1 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
-  var root_4$1 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
+  var root_4 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
           to replace it, or clear the saved key.</p>`);
   var root_5$1 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
   var root_6$1 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
   var root_1$1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
-  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="custom-yellow-button svelte-1plj3lz"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
+  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="learnablemeta-yellow-button"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
     let showApiKeyModal = state(false);
@@ -5702,7 +5713,7 @@ roundNumber: 4,
             var node_2 = first_child(fragment_1);
             {
               var consequent_1 = ($$anchor4) => {
-                var p_1 = root_4$1();
+                var p_1 = root_4();
                 var code = sibling(child(p_1));
                 var text_1 = child(code);
                 template_effect(($0) => set_text(text_1, `…${$0 ?? ""}`), [() => get(currentApiKey).slice(-4)]);
@@ -5899,24 +5910,35 @@ roundNumber: 4,
   }
   var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
   var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
-  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and scan</button></div></div>`);
-  var root_5 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
-  var root_6 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
-  var root_9 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
-  var root_8 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
-  var root_7 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
-  var root_11 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
-  var root_12 = from_html(`<div class="summary svelte-axobi4"> </div>`);
-  var root_13 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
-  var root_4 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
-  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4">Update GeoGuessr maps</h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
+  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and continue</button></div></div>`);
+  var root_6 = from_html(`<div class="notice svelte-axobi4">Loading your synchronized map groups…</div>`);
+  var root_8 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load your map groups.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_11 = from_html(`<button class="group-row svelte-axobi4"><strong> </strong> <span class="svelte-axobi4"> </span></button>`);
+  var root_10 = from_html(`<div class="notice svelte-axobi4">Select a synchronized LearnableMeta group to compare its maps.</div> <div class="group-list svelte-axobi4"></div>`, 1);
+  var root_12 = from_html(`<div class="notice svelte-axobi4">You have no synchronized map groups containing maps.</div>`);
+  var root_5 = from_html(`<!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button></footer>`, 1);
+  var root_14 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
+  var root_15 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_18 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
+  var root_17 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
+  var root_16 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
+  var root_20 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
+  var root_21 = from_html(`<div class="summary svelte-axobi4"> </div>`);
+  var root_22 = from_html(`<button class="link-button svelte-axobi4">Change group</button>`);
+  var root_23 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
+  var root_13 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <!> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
+  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4"> </h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
   function MapGroupUpdate($$anchor, $$props) {
     push($$props, true);
+    const canChooseGroup = $$props.groupId === void 0;
+    let activeGroupId = state(proxy($$props.groupId ?? null));
     let phase = state("scanning");
     let apiToken = state("");
     let tokenInput = state("");
     let tokenError = state("");
     let groupName = state("");
+    let accessibleGroups = state(proxy([]));
+    let groupsLoading = state(false);
     let rows = state(proxy([]));
     let fatalError = state("");
     let finishedRun = state(false);
@@ -5932,7 +5954,7 @@ roundNumber: 4,
           return;
         }
         set(apiToken, savedToken, true);
-        void scanGroup();
+        void continueWithToken();
       } catch (error) {
         set(phase, "token");
         set(tokenError, errorMessage(error), true);
@@ -5945,7 +5967,7 @@ roundNumber: 4,
       const index2 = get(rows).findIndex((row) => row.geoguessrId === geoguessrId);
       if (index2 !== -1) get(rows)[index2] = { ...get(rows)[index2], ...update };
     }
-    async function saveTokenAndScan() {
+    async function saveTokenAndContinue() {
       const trimmed = get(tokenInput).trim();
       if (!trimmed) {
         set(tokenError, "Paste a valid LearnableMeta API token.");
@@ -5955,21 +5977,63 @@ roundNumber: 4,
       set(apiToken, trimmed, true);
       set(tokenInput, "");
       set(tokenError, "");
-      await scanGroup();
+      await continueWithToken();
     }
     function changeToken() {
       set(tokenInput, "");
       set(tokenError, "");
       set(phase, "token");
     }
+    async function continueWithToken() {
+      if (get(activeGroupId) === null) {
+        await loadAccessibleGroups();
+      } else {
+        await scanGroup();
+      }
+    }
+    async function loadAccessibleGroups() {
+      set(phase, "groups");
+      set(fatalError, "");
+      set(finishedRun, false);
+      set(groupName, "");
+      set(rows, [], true);
+      set(accessibleGroups, [], true);
+      set(groupsLoading, true);
+      try {
+        set(accessibleGroups, await fetchAccessibleMapGroups(get(apiToken)), true);
+      } catch (error) {
+        if (error instanceof LearnableMetaApiError && error.status === 401) {
+          clearApiKey();
+          set(apiToken, "");
+          set(tokenError, "Your LearnableMeta API token was rejected. Paste a new token.");
+          set(phase, "token");
+          return;
+        }
+        set(fatalError, errorMessage(error), true);
+      } finally {
+        set(groupsLoading, false);
+      }
+    }
+    function selectGroup(groupId) {
+      set(activeGroupId, groupId, true);
+      void scanGroup();
+    }
+    function changeGroup() {
+      set(activeGroupId, null);
+      void loadAccessibleGroups();
+    }
     async function scanGroup() {
+      if (get(activeGroupId) === null) {
+        await loadAccessibleGroups();
+        return;
+      }
       set(phase, "scanning");
       set(fatalError, "");
       set(finishedRun, false);
       set(groupName, "");
       set(rows, [], true);
       try {
-        const manifest = await fetchMapGroupManifest($$props.groupId, get(apiToken));
+        const manifest = await fetchMapGroupManifest(get(activeGroupId), get(apiToken));
         set(groupName, manifest.group.name, true);
         set(
           rows,
@@ -6099,12 +6163,14 @@ roundNumber: 4,
     var div_1 = child(div);
     var header = child(div_1);
     var div_2 = child(header);
-    var node = sibling(child(div_2), 4);
+    var h1 = sibling(child(div_2), 2);
+    var text = child(h1);
+    var node = sibling(h1, 2);
     {
       var consequent = ($$anchor2) => {
         var p = root_1();
-        var text = child(p);
-        template_effect(() => set_text(text, get(groupName)));
+        var text_1 = child(p);
+        template_effect(() => set_text(text_1, get(groupName)));
         append($$anchor2, p);
       };
       if_block(node, ($$render) => {
@@ -6122,13 +6188,13 @@ roundNumber: 4,
         var p_1 = sibling(child(div_3), 2);
         var a = sibling(child(p_1));
         var input = sibling(p_1, 2);
-        input.__keydown = (event2) => event2.key === "Enter" && void saveTokenAndScan();
+        input.__keydown = (event2) => event2.key === "Enter" && void saveTokenAndContinue();
         var node_2 = sibling(input, 2);
         {
           var consequent_1 = ($$anchor3) => {
             var p_2 = root_3();
-            var text_1 = child(p_2);
-            template_effect(() => set_text(text_1, get(tokenError)));
+            var text_2 = child(p_2);
+            template_effect(() => set_text(text_2, get(tokenError)));
             append($$anchor3, p_2);
           };
           if_block(node_2, ($$render) => {
@@ -6141,186 +6207,302 @@ roundNumber: 4,
           $$props.onClose?.apply(this, $$args);
         };
         var button_2 = sibling(button_1, 2);
-        button_2.__click = saveTokenAndScan;
+        button_2.__click = saveTokenAndContinue;
         template_effect(() => set_attribute(a, "href", URL_TO_GENERATE_TOKEN));
         bind_value(input, () => get(tokenInput), ($$value) => set(tokenInput, $$value));
         append($$anchor2, div_3);
       };
-      var alternate_1 = ($$anchor2) => {
-        var fragment = root_4();
+      var alternate_5 = ($$anchor2) => {
+        var fragment = comment();
         var node_3 = first_child(fragment);
         {
-          var consequent_3 = ($$anchor3) => {
-            var div_5 = root_5();
-            append($$anchor3, div_5);
-          };
-          if_block(node_3, ($$render) => {
-            if (get(phase) === "scanning") $$render(consequent_3);
-          });
-        }
-        var node_4 = sibling(node_3, 2);
-        {
-          var consequent_4 = ($$anchor3) => {
-            var div_6 = root_6();
-            var span = sibling(child(div_6), 2);
-            var text_2 = child(span);
-            var button_3 = sibling(span, 2);
-            button_3.__click = scanGroup;
-            template_effect(() => set_text(text_2, get(fatalError)));
-            append($$anchor3, div_6);
-          };
-          if_block(node_4, ($$render) => {
-            if (get(fatalError)) $$render(consequent_4);
-          });
-        }
-        var node_5 = sibling(node_4, 2);
-        {
           var consequent_6 = ($$anchor3) => {
-            var fragment_1 = root_7();
-            var div_7 = first_child(fragment_1);
-            var span_1 = child(div_7);
-            var text_3 = child(span_1);
-            var div_8 = sibling(span_1, 2);
-            var button_4 = child(div_8);
-            button_4.__click = () => selectChanged(true);
-            var button_5 = sibling(button_4, 2);
-            button_5.__click = () => selectChanged(false);
-            var div_9 = sibling(div_7, 2);
-            each(div_9, 21, () => get(rows), (row) => row.geoguessrId, ($$anchor4, row, $$index) => {
-              var label = root_8();
-              let classes;
-              var input_1 = child(label);
-              var span_2 = sibling(input_1, 2);
-              var strong = child(span_2);
-              var text_4 = child(strong);
-              var span_3 = sibling(strong, 2);
-              var text_5 = child(span_3);
-              var node_6 = sibling(span_3, 2);
-              {
-                var consequent_5 = ($$anchor5) => {
-                  var span_4 = root_9();
-                  var text_6 = child(span_4);
-                  template_effect(() => set_text(text_6, get(row).error));
-                  append($$anchor5, span_4);
-                };
-                if_block(node_6, ($$render) => {
-                  if (get(row).error) $$render(consequent_5);
-                });
-              }
-              var span_5 = sibling(span_2, 2);
-              let classes_1;
-              var text_7 = child(span_5);
-              template_effect(
-                ($0, $1) => {
-                  classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
-                  input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
-                  set_text(text_4, get(row).name);
-                  set_text(text_5, `${$0 ?? ""} synchronized locations`);
-                  classes_1 = set_class(span_5, 1, "status svelte-axobi4", null, classes_1, {
-                    good: get(row).status === "current" || get(row).status === "success"
-                  });
-                  set_text(text_7, $1);
-                },
-                [
-                  () => get(row).locationCount.toLocaleString(),
-                  () => statusLabel(get(row))
-                ]
-              );
-              bind_checked(input_1, () => get(row).selected, ($$value) => get(row).selected = $$value);
-              append($$anchor4, label);
-            });
-            template_effect(() => set_text(text_3, `${get(rows).length ?? ""} map${get(rows).length === 1 ? "" : "s"}`));
+            var fragment_1 = root_5();
+            var node_4 = first_child(fragment_1);
+            {
+              var consequent_3 = ($$anchor4) => {
+                var div_5 = root_6();
+                append($$anchor4, div_5);
+              };
+              var alternate_2 = ($$anchor4) => {
+                var fragment_2 = comment();
+                var node_5 = first_child(fragment_2);
+                {
+                  var consequent_4 = ($$anchor5) => {
+                    var div_6 = root_8();
+                    var span = sibling(child(div_6), 2);
+                    var text_3 = child(span);
+                    var button_3 = sibling(span, 2);
+                    button_3.__click = loadAccessibleGroups;
+                    template_effect(() => set_text(text_3, get(fatalError)));
+                    append($$anchor5, div_6);
+                  };
+                  var alternate_1 = ($$anchor5) => {
+                    var fragment_3 = comment();
+                    var node_6 = first_child(fragment_3);
+                    {
+                      var consequent_5 = ($$anchor6) => {
+                        var fragment_4 = root_10();
+                        var div_7 = sibling(first_child(fragment_4), 2);
+                        each(div_7, 21, () => get(accessibleGroups), (group) => group.id, ($$anchor7, group) => {
+                          var button_4 = root_11();
+                          button_4.__click = () => selectGroup(get(group).id);
+                          var strong = child(button_4);
+                          var text_4 = child(strong);
+                          var span_1 = sibling(strong, 2);
+                          var text_5 = child(span_1);
+                          template_effect(() => {
+                            set_text(text_4, get(group).name);
+                            set_text(text_5, `${get(group).mapCount ?? ""} map${get(group).mapCount === 1 ? "" : "s"}`);
+                          });
+                          append($$anchor7, button_4);
+                        });
+                        append($$anchor6, fragment_4);
+                      };
+                      var alternate = ($$anchor6) => {
+                        var div_8 = root_12();
+                        append($$anchor6, div_8);
+                      };
+                      if_block(
+                        node_6,
+                        ($$render) => {
+                          if (get(accessibleGroups).length > 0) $$render(consequent_5);
+                          else $$render(alternate, false);
+                        },
+                        true
+                      );
+                    }
+                    append($$anchor5, fragment_3);
+                  };
+                  if_block(
+                    node_5,
+                    ($$render) => {
+                      if (get(fatalError)) $$render(consequent_4);
+                      else $$render(alternate_1, false);
+                    },
+                    true
+                  );
+                }
+                append($$anchor4, fragment_2);
+              };
+              if_block(node_4, ($$render) => {
+                if (get(groupsLoading)) $$render(consequent_3);
+                else $$render(alternate_2, false);
+              });
+            }
+            var footer = sibling(node_4, 2);
+            var button_5 = child(footer);
+            button_5.__click = changeToken;
+            var button_6 = sibling(button_5, 2);
+            button_6.__click = function(...$$args) {
+              $$props.onClose?.apply(this, $$args);
+            };
             append($$anchor3, fragment_1);
           };
-          var alternate = ($$anchor3) => {
-            var fragment_2 = comment();
-            var node_7 = first_child(fragment_2);
+          var alternate_4 = ($$anchor3) => {
+            var fragment_5 = root_13();
+            var node_7 = first_child(fragment_5);
             {
               var consequent_7 = ($$anchor4) => {
-                var div_10 = root_11();
+                var div_9 = root_14();
+                append($$anchor4, div_9);
+              };
+              if_block(node_7, ($$render) => {
+                if (get(phase) === "scanning") $$render(consequent_7);
+              });
+            }
+            var node_8 = sibling(node_7, 2);
+            {
+              var consequent_8 = ($$anchor4) => {
+                var div_10 = root_15();
+                var span_2 = sibling(child(div_10), 2);
+                var text_6 = child(span_2);
+                var button_7 = sibling(span_2, 2);
+                button_7.__click = scanGroup;
+                template_effect(() => set_text(text_6, get(fatalError)));
                 append($$anchor4, div_10);
               };
-              if_block(
-                node_7,
-                ($$render) => {
-                  if (get(phase) === "review" && !get(fatalError)) $$render(consequent_7);
-                },
-                true
-              );
+              if_block(node_8, ($$render) => {
+                if (get(fatalError)) $$render(consequent_8);
+              });
             }
-            append($$anchor3, fragment_2);
-          };
-          if_block(node_5, ($$render) => {
-            if (get(rows).length > 0) $$render(consequent_6);
-            else $$render(alternate, false);
-          });
-        }
-        var node_8 = sibling(node_5, 2);
-        {
-          var consequent_8 = ($$anchor3) => {
-            var div_11 = root_12();
-            var text_8 = child(div_11);
-            template_effect(() => set_text(text_8, `Finished: ${get(successCount) ?? ""} published, ${get(failureCount) ?? ""} failed, ${get(changedCount) ?? ""} still available.`));
-            append($$anchor3, div_11);
-          };
-          if_block(node_8, ($$render) => {
-            if (get(finishedRun)) $$render(consequent_8);
-          });
-        }
-        var footer = sibling(node_8, 2);
-        var button_6 = child(footer);
-        button_6.__click = changeToken;
-        var button_7 = sibling(button_6, 2);
-        button_7.__click = function(...$$args) {
-          $$props.onClose?.apply(this, $$args);
-        };
-        var node_9 = sibling(button_7, 2);
-        {
-          var consequent_9 = ($$anchor3) => {
-            var button_8 = root_13();
-            button_8.__click = retryFailures;
-            var text_9 = child(button_8);
+            var node_9 = sibling(node_8, 2);
+            {
+              var consequent_10 = ($$anchor4) => {
+                var fragment_6 = root_16();
+                var div_11 = first_child(fragment_6);
+                var span_3 = child(div_11);
+                var text_7 = child(span_3);
+                var div_12 = sibling(span_3, 2);
+                var button_8 = child(div_12);
+                button_8.__click = () => selectChanged(true);
+                var button_9 = sibling(button_8, 2);
+                button_9.__click = () => selectChanged(false);
+                var div_13 = sibling(div_11, 2);
+                each(div_13, 21, () => get(rows), (row) => row.geoguessrId, ($$anchor5, row, $$index_1) => {
+                  var label = root_17();
+                  let classes;
+                  var input_1 = child(label);
+                  var span_4 = sibling(input_1, 2);
+                  var strong_1 = child(span_4);
+                  var text_8 = child(strong_1);
+                  var span_5 = sibling(strong_1, 2);
+                  var text_9 = child(span_5);
+                  var node_10 = sibling(span_5, 2);
+                  {
+                    var consequent_9 = ($$anchor6) => {
+                      var span_6 = root_18();
+                      var text_10 = child(span_6);
+                      template_effect(() => set_text(text_10, get(row).error));
+                      append($$anchor6, span_6);
+                    };
+                    if_block(node_10, ($$render) => {
+                      if (get(row).error) $$render(consequent_9);
+                    });
+                  }
+                  var span_7 = sibling(span_4, 2);
+                  let classes_1;
+                  var text_11 = child(span_7);
+                  template_effect(
+                    ($0, $1) => {
+                      classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
+                      input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
+                      set_text(text_8, get(row).name);
+                      set_text(text_9, `${$0 ?? ""} synchronized locations`);
+                      classes_1 = set_class(span_7, 1, "status svelte-axobi4", null, classes_1, {
+                        good: get(row).status === "current" || get(row).status === "success"
+                      });
+                      set_text(text_11, $1);
+                    },
+                    [
+                      () => get(row).locationCount.toLocaleString(),
+                      () => statusLabel(get(row))
+                    ]
+                  );
+                  bind_checked(input_1, () => get(row).selected, ($$value) => get(row).selected = $$value);
+                  append($$anchor5, label);
+                });
+                template_effect(() => set_text(text_7, `${get(rows).length ?? ""} map${get(rows).length === 1 ? "" : "s"}`));
+                append($$anchor4, fragment_6);
+              };
+              var alternate_3 = ($$anchor4) => {
+                var fragment_7 = comment();
+                var node_11 = first_child(fragment_7);
+                {
+                  var consequent_11 = ($$anchor5) => {
+                    var div_14 = root_20();
+                    append($$anchor5, div_14);
+                  };
+                  if_block(
+                    node_11,
+                    ($$render) => {
+                      if (get(phase) === "review" && !get(fatalError)) $$render(consequent_11);
+                    },
+                    true
+                  );
+                }
+                append($$anchor4, fragment_7);
+              };
+              if_block(node_9, ($$render) => {
+                if (get(rows).length > 0) $$render(consequent_10);
+                else $$render(alternate_3, false);
+              });
+            }
+            var node_12 = sibling(node_9, 2);
+            {
+              var consequent_12 = ($$anchor4) => {
+                var div_15 = root_21();
+                var text_12 = child(div_15);
+                template_effect(() => set_text(text_12, `Finished: ${get(successCount) ?? ""} published, ${get(failureCount) ?? ""} failed, ${get(changedCount) ?? ""} still available.`));
+                append($$anchor4, div_15);
+              };
+              if_block(node_12, ($$render) => {
+                if (get(finishedRun)) $$render(consequent_12);
+              });
+            }
+            var footer_1 = sibling(node_12, 2);
+            var button_10 = child(footer_1);
+            button_10.__click = changeToken;
+            var node_13 = sibling(button_10, 2);
+            {
+              var consequent_13 = ($$anchor4) => {
+                var button_11 = root_22();
+                button_11.__click = changeGroup;
+                template_effect(() => button_11.disabled = get(phase) === "updating");
+                append($$anchor4, button_11);
+              };
+              if_block(node_13, ($$render) => {
+                if (canChooseGroup) $$render(consequent_13);
+              });
+            }
+            var button_12 = sibling(node_13, 2);
+            button_12.__click = function(...$$args) {
+              $$props.onClose?.apply(this, $$args);
+            };
+            var node_14 = sibling(button_12, 2);
+            {
+              var consequent_14 = ($$anchor4) => {
+                var button_13 = root_23();
+                button_13.__click = retryFailures;
+                var text_13 = child(button_13);
+                template_effect(() => {
+                  button_13.disabled = get(phase) === "updating";
+                  set_text(text_13, `Retry failed (${get(failureCount) ?? ""})`);
+                });
+                append($$anchor4, button_13);
+              };
+              if_block(node_14, ($$render) => {
+                if (get(failureCount) > 0) $$render(consequent_14);
+              });
+            }
+            var button_14 = sibling(node_14, 2);
+            button_14.__click = updateSelected;
+            var text_14 = child(button_14);
             template_effect(() => {
-              button_8.disabled = get(phase) === "updating";
-              set_text(text_9, `Retry failed (${get(failureCount) ?? ""})`);
+              button_10.disabled = get(phase) === "updating";
+              button_12.disabled = get(phase) === "updating";
+              button_14.disabled = get(phase) !== "review" || get(selectedCount) === 0;
+              set_text(text_14, get(phase) === "updating" ? "Updating…" : `Update and publish (${get(selectedCount)})`);
             });
-            append($$anchor3, button_8);
+            append($$anchor3, fragment_5);
           };
-          if_block(node_9, ($$render) => {
-            if (get(failureCount) > 0) $$render(consequent_9);
-          });
+          if_block(
+            node_3,
+            ($$render) => {
+              if (get(phase) === "groups") $$render(consequent_6);
+              else $$render(alternate_4, false);
+            },
+            true
+          );
         }
-        var button_9 = sibling(node_9, 2);
-        button_9.__click = updateSelected;
-        var text_10 = child(button_9);
-        template_effect(() => {
-          button_6.disabled = get(phase) === "updating";
-          button_7.disabled = get(phase) === "updating";
-          button_9.disabled = get(phase) !== "review" || get(selectedCount) === 0;
-          set_text(text_10, get(phase) === "updating" ? "Updating…" : `Update and publish (${get(selectedCount)})`);
-        });
         append($$anchor2, fragment);
       };
       if_block(node_1, ($$render) => {
         if (get(phase) === "token") $$render(consequent_2);
-        else $$render(alternate_1, false);
+        else $$render(alternate_5, false);
       });
     }
-    template_effect(() => button.disabled = get(phase) === "updating");
+    template_effect(() => {
+      set_text(text, get(phase) === "groups" ? "Choose a map group" : "Update GeoGuessr maps");
+      button.disabled = get(phase) === "updating";
+    });
     append($$anchor, div);
     pop();
   }
   delegate(["click", "keydown"]);
   const queryParameter = "learnableMetaGroupId";
   const containerId = "learnablemeta-map-group-update";
+  const launcherButtonId = "learnablemeta-update-maps-button";
+  const mapActionsClass = "learnablemeta-map-actions";
   let app = null;
+  let launcherObserver = null;
   function clearHandoffParameter() {
     const url = new URL(window.location.href);
     url.searchParams.delete(queryParameter);
     window.history.replaceState(window.history.state, "", url);
   }
   function startMapGroupUpdate(groupId) {
-    if (!Number.isSafeInteger(groupId) || groupId <= 0 || app) return;
+    if (groupId !== void 0 && (!Number.isSafeInteger(groupId) || groupId <= 0) || app) return;
     const target = document.createElement("div");
     target.id = containerId;
     document.body.appendChild(target);
@@ -6337,12 +6519,54 @@ roundNumber: 4,
       }
     });
   }
-  function initMapGroupUpdate() {
-    if (!window.location.pathname.startsWith("/creator-hub")) return;
-    const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
-    if (!rawGroupId) return;
-    startMapGroupUpdate(Number(rawGroupId));
+  function removeLauncherButton() {
+    document.getElementById(launcherButtonId)?.remove();
+    document.querySelectorAll(`.${mapActionsClass}`).forEach((container) => container.classList.remove(mapActionsClass));
   }
+  function ensureLauncherButton() {
+    if (!window.location.pathname.startsWith("/creator-hub")) {
+      removeLauncherButton();
+      return;
+    }
+    const createMapContainer = document.querySelector('[class*="creators-hub_createMapButton"]');
+    const createMapButton = createMapContainer?.querySelector(`button:not(#${launcherButtonId})`);
+    if (!createMapContainer || !createMapButton) return;
+    createMapContainer.classList.add(mapActionsClass);
+    if (document.getElementById(launcherButtonId)) return;
+    const launcher = document.createElement("button");
+    launcher.id = launcherButtonId;
+    launcher.className = "learnablemeta-yellow-button";
+    launcher.type = "button";
+    launcher.setAttribute("aria-label", "Update LearnableMeta maps");
+    launcher.textContent = "Update maps";
+    launcher.addEventListener("click", () => startMapGroupUpdate());
+    createMapContainer.insertBefore(launcher, createMapButton);
+  }
+  function refreshLauncherButton() {
+    if (!window.location.pathname.startsWith("/creator-hub")) {
+      launcherObserver?.disconnect();
+      launcherObserver = null;
+      removeLauncherButton();
+      return;
+    }
+    ensureLauncherButton();
+    if (launcherObserver) return;
+    launcherObserver = new MutationObserver(ensureLauncherButton);
+    launcherObserver.observe(document.body, { childList: true, subtree: true });
+  }
+  function handleCreatorHubNavigation() {
+    if (window.location.pathname.startsWith("/creator-hub")) {
+      const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
+      if (rawGroupId) startMapGroupUpdate(Number(rawGroupId));
+    }
+    refreshLauncherButton();
+  }
+  function initMapGroupUpdate() {
+    handleCreatorHubNavigation();
+    window.addEventListener("urlchange", handleCreatorHubNavigation);
+  }
+  const buttonsCss = ".learnablemeta-yellow-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;appearance:none;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.learnablemeta-yellow-button:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.learnablemeta-yellow-button:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:inset 0 2px 4px #0003;transform:translateY(1px)}.learnablemeta-yellow-button:focus-visible{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.learnablemeta-yellow-button:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.learnablemeta-map-actions{display:flex!important;flex-direction:row!important;align-items:center!important;gap:.75rem!important}";
+  importCSS(buttonsCss);
   if (typeof _GM_registerMenuCommand === "function") {
     _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", () => {
       if (confirm("Reset the LearnableMeta window position and size?")) {

--- a/userscript/CHANGELOG.md
+++ b/userscript/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.91]
 
 - Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
+- Added a Creator Hub button for choosing any synchronized map group you can access
 - Added review and selection before updating changed maps
 - Added sequential draft updates, publishing, per-map progress, and retryable failures
 - Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser

--- a/userscript/CHANGELOG.md
+++ b/userscript/CHANGELOG.md
@@ -2,24 +2,19 @@
 
 ## [0.91]
 
-- Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
-- Added a Creator Hub button for choosing any synchronized map group you can access
-- Added review and selection before updating changed maps
-- Added sequential draft updates, publishing, per-map progress, and retryable failures
-- Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
+- Added map-group updates after syncing and from Creator Hub
+- Detects changed GeoGuessr maps before updating
+- Added map selection, publishing progress, and retries
+- Refreshed dialogs and API token management
 
 ## [0.90]
 
-- Added meta pins on challenge results pages (geoguessr.com/results/...), with support for any round count
-- Fixed memory leaks from meta windows never being unmounted (drag handlers piled up every round)
-- Fixed live challenge windows stacking up instead of replacing each other
-- Fixed the upload button possibly keeping a previous map's id after map-maker navigation
-- Moved the map label to the new GeoGuessr map page layout and darkened its background
-- Restyled the upload button and notifications for the new map-maker top bar
-- Upload errors now show a readable message with the technical error underneath for reports
-- Added an in-page 🔑 button to view, replace or clear the LearnableMeta API key
-- Features now initialize independently, so one failing no longer disables the rest
-- Moved this changelog to CHANGELOG.md
+- Added meta pins to challenge results
+- Fixed meta window leaks and live challenge stacking
+- Fixed stale map IDs after Map Maker navigation
+- Updated the map label and upload UI for new GeoGuessr layouts
+- Added API key management and clearer upload errors
+- Isolated features so one failure does not disable the rest
 
 ## [0.89]
 

--- a/userscript/CHANGELOG.md
+++ b/userscript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.91]
+
+- Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
+- Added review and selection before updating changed maps
+- Added sequential draft updates, publishing, per-map progress, and retryable failures
+- Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
+
 ## [0.90]
 
 - Added meta pins on challenge results pages (geoguessr.com/results/...), with support for any round count

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -25,24 +25,19 @@
 
 ## [0.91]
 
-- Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
-- Added a Creator Hub button for choosing any synchronized map group you can access
-- Added review and selection before updating changed maps
-- Added sequential draft updates, publishing, per-map progress, and retryable failures
-- Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
+- Added map-group updates after syncing and from Creator Hub
+- Detects changed GeoGuessr maps before updating
+- Added map selection, publishing progress, and retries
+- Refreshed dialogs and API token management
 
 ## [0.90]
 
-- Added meta pins on challenge results pages (geoguessr.com/results/...), with support for any round count
-- Fixed memory leaks from meta windows never being unmounted (drag handlers piled up every round)
-- Fixed live challenge windows stacking up instead of replacing each other
-- Fixed the upload button possibly keeping a previous map's id after map-maker navigation
-- Moved the map label to the new GeoGuessr map page layout and darkened its background
-- Restyled the upload button and notifications for the new map-maker top bar
-- Upload errors now show a readable message with the technical error underneath for reports
-- Added an in-page 🔑 button to view, replace or clear the LearnableMeta API key
-- Features now initialize independently, so one failing no longer disables the rest
-- Moved this changelog to CHANGELOG.md
+- Added meta pins to challenge results
+- Fixed meta window leaks and live challenge stacking
+- Fixed stale map IDs after Map Maker navigation
+- Updated the map label and upload UI for new GeoGuessr layouts
+- Added API key management and clearer upload errors
+- Isolated features so one failure does not disable the rest
 
 ## [0.89]
 
@@ -179,7 +174,7 @@
 
   const d=new Set;const importCSS = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
 
-  importCSS(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.group-list.svelte-axobi4{display:grid;gap:8px;overflow-y:auto;margin:14px 24px 0}.group-row.svelte-axobi4{display:flex;align-items:center;justify-content:space-between;gap:16px;width:100%;border:1px solid #d9dee7;border-radius:9px;padding:13px 15px;background:#fff;color:#172033;text-align:left;cursor:pointer}.group-row.svelte-axobi4:hover{border-color:#d3a300;background:#fffaf0}.group-row.svelte-axobi4 span:where(.svelte-axobi4){flex:none;color:#667085;font-size:12px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
+  importCSS(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.help-toggle-button.svelte-1j2rmt2{background:transparent;border:none;padding:0;cursor:pointer}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center;gap:6px}.saved-key.svelte-1plj3lz{border-radius:4px;padding:2px 5px;background:var(--lm-muted);color:var(--lm-foreground);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:12px}.subtitle.svelte-axobi4{margin:6px 0 0;color:var(--lm-muted-foreground);font-size:14px}.map-update-close.svelte-axobi4{width:32px;height:32px;padding:0}.map-update-close.svelte-axobi4 svg:where(.svelte-axobi4){width:18px;height:18px;fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:2}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:13px 15px;border:1px solid var(--lm-border);border-radius:var(--lm-radius);background:var(--lm-muted);color:var(--lm-muted-foreground);font-size:14px;line-height:1.45}.fatal.svelte-axobi4{display:grid;gap:10px;border-color:#dc262659;background:#dc262617;color:var(--lm-destructive)}.fatal.svelte-axobi4 .learnablemeta-button:where(.svelte-axobi4){justify-self:start}.summary.svelte-axobi4{border-color:#16a34a4d;background:#16a34a1a;color:#166534}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;gap:16px;padding:18px 24px 10px;color:var(--lm-muted-foreground);font-size:13px;font-weight:500}.toolbar.svelte-axobi4>div:where(.svelte-axobi4){display:flex;gap:4px}.group-list.svelte-axobi4{display:grid;gap:8px;overflow-y:auto;max-height:390px;margin:14px 24px 0;padding:1px}.group-row.svelte-axobi4{display:flex;align-items:center;justify-content:space-between;gap:16px;width:100%;min-height:62px;border:1px solid var(--lm-border);border-radius:var(--lm-radius);padding:12px 14px;background:var(--lm-card);color:var(--lm-card-foreground);box-shadow:0 1px 2px #0000000d;text-align:left;cursor:pointer;transition:border-color .15s ease,background-color .15s ease,box-shadow .15s ease}.group-row.svelte-axobi4:hover{border-color:var(--lm-ring);background:color-mix(in srgb,var(--lm-primary) 6%,var(--lm-card));box-shadow:0 1px 4px #0000001a}.group-row.svelte-axobi4:focus-visible{outline:none;box-shadow:0 0 0 3px color-mix(in srgb,var(--lm-ring) 30%,transparent)}.group-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.group-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;font-size:14px;font-weight:600;text-overflow:ellipsis;white-space:nowrap}.group-details.svelte-axobi4>span:where(.svelte-axobi4){color:var(--lm-muted-foreground);font-size:12px}.group-count.svelte-axobi4{display:inline-flex;flex:none;align-items:center;gap:6px;color:var(--lm-muted-foreground);font-size:12px;font-weight:500}.group-count.svelte-axobi4 svg:where(.svelte-axobi4){width:16px;height:16px;fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:2}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid var(--lm-border);border-radius:var(--lm-radius);background:var(--lm-card)}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid var(--lm-border);color:var(--lm-card-foreground);transition:background-color .15s ease}.map-row.svelte-axobi4:hover{background:var(--lm-muted)}.map-row.selected.svelte-axobi4{background:color-mix(in srgb,var(--lm-primary) 7%,var(--lm-card))}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:#dc26260f}.map-row.svelte-axobi4 input[type=checkbox]:where(.svelte-axobi4){width:16px;height:16px;accent-color:var(--lm-primary)}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;font-size:14px;font-weight:600;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:var(--lm-muted-foreground);font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:var(--lm-destructive);white-space:normal}.status.svelte-axobi4{padding:3px 8px;border:1px solid transparent;border-radius:calc(var(--lm-radius) - 2px);font-size:12px;font-weight:500;white-space:nowrap}.status.good.svelte-axobi4{border-color:#bbf7d0;background:#dcfce7;color:#166534}.status.warning.svelte-axobi4{border-color:#fde68a;background:#fef3c7;color:#854d0e}.status.bad.svelte-axobi4{border-color:#fecaca;background:#fee2e2;color:#991b1b}.status.working.svelte-axobi4{border-color:#bfdbfe;background:#dbeafe;color:#1e40af}.status.neutral.svelte-axobi4{border-color:var(--lm-border);background:var(--lm-muted);color:var(--lm-muted-foreground)}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px 0}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0;font-size:14px;line-height:1.5}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:var(--lm-muted-foreground);font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:var(--lm-link);text-underline-offset:3px}.token-actions.svelte-axobi4{margin:8px -24px 0}.error-text.svelte-axobi4{margin:0;color:var(--lm-destructive);font-size:13px}@media(prefers-color-scheme:dark){.summary.svelte-axobi4{color:#86efac}.status.good.svelte-axobi4{border-color:#22c55e66;background:#16a34a2e;color:#86efac}.status.warning.svelte-axobi4{border-color:#f59e0b66;background:#b4530933;color:#fde68a}.status.bad.svelte-axobi4{border-color:#ef444466;background:#b91c1c33;color:#fca5a5}.status.working.svelte-axobi4{border-color:#3b82f666;background:#1e40af38;color:#93c5fd}}@media(max-width:620px){.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.group-details.svelte-axobi4>span:where(.svelte-axobi4){display:none}.status.svelte-axobi4{grid-column:2;justify-self:start}} `);
 
   var _GM_getValue = (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = (() => typeof GM_info != "undefined" ? GM_info : void 0)();
@@ -187,186 +182,6 @@
   var _GM_setValue = (() => typeof GM_setValue != "undefined" ? GM_setValue : void 0)();
   var _GM_xmlhttpRequest = (() => typeof GM_xmlhttpRequest != "undefined" ? GM_xmlhttpRequest : void 0)();
   var _unsafeWindow = (() => typeof unsafeWindow != "undefined" ? unsafeWindow : void 0)();
-  function waitForElement(selector) {
-    return new Promise((resolve) => {
-      try {
-        const existingElement = document.querySelector(selector);
-        if (existingElement) {
-          resolve(existingElement);
-          return;
-        }
-      } catch {
-      }
-      const observer = new MutationObserver(() => {
-        try {
-          const element = document.querySelector(selector);
-          if (element) {
-            observer.disconnect();
-            removeUrlChangeListener();
-            resolve(element);
-            return;
-          }
-        } catch {
-        }
-      });
-      const handleUrlChange = () => {
-        observer.disconnect();
-        removeUrlChangeListener();
-        resolve(null);
-      };
-      const removeUrlChangeListener = () => {
-        window.removeEventListener("urlchange", handleUrlChange);
-      };
-      window.addEventListener("urlchange", handleUrlChange);
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ["class"]
-      });
-    });
-  }
-  function localStorageGetInt(name) {
-    const savedValue = _unsafeWindow.localStorage.getItem(name);
-    if (!savedValue) {
-      return null;
-    }
-    const savedInt = parseInt(savedValue, 10);
-    if (isNaN(savedInt)) {
-      return null;
-    }
-    return savedInt;
-  }
-  async function fetchMapInfo(url) {
-    return new Promise((resolve, reject) => {
-      _GM_xmlhttpRequest({
-        method: "GET",
-        url,
-        onload: (response) => {
-          if (response.status === 200 || response.status === 404) {
-            try {
-              const mapInfo = JSON.parse(response.responseText);
-              logInfo("fetched map info", mapInfo);
-              resolve(mapInfo);
-            } catch (e) {
-              logInfo("failed to parse map info response", e);
-              reject("Failed to parse response");
-            }
-          } else {
-            logInfo("failed to fetch map info", response);
-            reject(`HTTP error! status: ${response.status}`);
-          }
-        },
-        onerror: () => {
-          reject("An error occurred while fetching data");
-        }
-      });
-    });
-  }
-  const MAP_FOUND_CACHE_MS = 24 * 60 * 60 * 1e3;
-  const MAP_NOT_FOUND_CACHE_MS = 60 * 60 * 1e3;
-  function getCachedMapInfo(key) {
-    const savedMapInfo = _unsafeWindow.localStorage.getItem(key);
-    if (!savedMapInfo) {
-      return null;
-    }
-    try {
-      const parsed = JSON.parse(savedMapInfo);
-      if (parsed && parsed.mapInfo && typeof parsed.fetchedAt === "number") {
-        return parsed;
-      }
-    } catch {
-    }
-    return null;
-  }
-  async function getMapInfo(geoguessrId, forceUpdate) {
-    const localStorageMapInfoKey = `geometa:map-info:${geoguessrId}`;
-    const cached = getCachedMapInfo(localStorageMapInfoKey);
-    if (!forceUpdate && cached) {
-      const ttl = cached.mapInfo.mapFound ? MAP_FOUND_CACHE_MS : MAP_NOT_FOUND_CACHE_MS;
-      if (Date.now() - cached.fetchedAt < ttl) {
-        logInfo("using saved map info", cached.mapInfo);
-        return cached.mapInfo;
-      }
-    }
-    const url = `https://learnablemeta.com/api/userscript/map/${geoguessrId}`;
-    let mapInfo;
-    try {
-      mapInfo = await fetchMapInfo(url);
-    } catch (e) {
-      if (cached) {
-        logInfo("map info fetch failed - using stale cached map info", e);
-        return cached.mapInfo;
-      }
-      throw e;
-    }
-    const toCache = { mapInfo, fetchedAt: Date.now() };
-    _unsafeWindow.localStorage.setItem(localStorageMapInfoKey, JSON.stringify(toCache));
-    _unsafeWindow.localStorage.setItem("geometa:latest-version", mapInfo.userscriptVersion);
-    return mapInfo;
-  }
-  function getLatestVersionInfo() {
-    return _unsafeWindow.localStorage.getItem("geometa:latest-version");
-  }
-  function isNewerVersion(candidate, current) {
-    const a = candidate.split(".").map(Number);
-    const b = current.split(".").map(Number);
-    for (let i = 0; i < Math.max(a.length, b.length); i++) {
-      const diff = (a[i] || 0) - (b[i] || 0);
-      if (diff) return diff > 0;
-    }
-    return false;
-  }
-  function checkIfOutdated() {
-    const latest = getLatestVersionInfo();
-    if (!latest) {
-      return false;
-    }
-    return isNewerVersion(latest, _GM_info.script.version);
-  }
-  function markHelpMessageAsRead() {
-    _unsafeWindow.localStorage.setItem("geometa:help-message-read", "true");
-  }
-  function wasHelpMessageRead() {
-    return _unsafeWindow.localStorage.getItem("geometa:help-message-read") == "true";
-  }
-  const getChallengeId = () => {
-    const regexp = /.*\/live-challenge\/(.*)/;
-    const matches = location.pathname.match(regexp);
-    if (matches && matches.length > 1) {
-      return matches[1];
-    }
-    return null;
-  };
-  async function getChallengeInfo(id) {
-    const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;
-    const response = await fetch(url, {
-      method: "GET",
-      credentials: "include"
-    });
-    const data = await response.json();
-    const mapId = data.options.mapSlug;
-    const currentRound = data.currentRoundNumber - 1;
-    const rounds = data.rounds;
-    const panorama = rounds[currentRound].question.panoramaQuestionPayload.panorama;
-    const panoIdHex = panorama.panoId;
-    const panoId = decodePanoId(panoIdHex);
-    return { mapId, panoId };
-  }
-  function decodePanoId(encoded) {
-    let panoId = "";
-    for (let i = 0; i + 2 <= encoded.length; i += 2) {
-      panoId += String.fromCharCode(parseInt(encoded.slice(i, i + 2), 16));
-    }
-    return panoId;
-  }
-  function logInfo(name, data) {
-    console.log(`ALM: ${name}`, data);
-  }
-  function extractMapIdFromUrl(url) {
-    const match = url.match(/\/maps\/([^\/]+)/);
-    return match ? match[1] : null;
-  }
   const DEV = false;
   var is_array = Array.isArray;
   var index_of = Array.prototype.indexOf;
@@ -3530,6 +3345,31 @@ get_first_child(node2)
       }
     });
   }
+  function action(dom, action2, get_value) {
+    effect(() => {
+      var payload = untrack(() => action2(dom, get_value?.()) || {});
+      if (get_value && payload?.update) {
+        var inited = false;
+        var prev = (
+{}
+        );
+        render_effect(() => {
+          var value = get_value();
+          deep_read_state(value);
+          if (inited && safe_not_equal(prev, value)) {
+            prev = value;
+            payload.update(value);
+          }
+        });
+        inited = true;
+      }
+      if (payload?.destroy) {
+        return () => (
+payload.destroy()
+        );
+      }
+    });
+  }
   function r(e) {
     var t, f, n = "";
     if ("string" == typeof e || "number" == typeof e) n += e;
@@ -4218,14 +4058,194 @@ context.l
     );
     return l.u ??= { a: [], b: [], m: [] };
   }
+  function waitForElement(selector) {
+    return new Promise((resolve) => {
+      try {
+        const existingElement = document.querySelector(selector);
+        if (existingElement) {
+          resolve(existingElement);
+          return;
+        }
+      } catch {
+      }
+      const observer = new MutationObserver(() => {
+        try {
+          const element = document.querySelector(selector);
+          if (element) {
+            observer.disconnect();
+            removeUrlChangeListener();
+            resolve(element);
+            return;
+          }
+        } catch {
+        }
+      });
+      const handleUrlChange = () => {
+        observer.disconnect();
+        removeUrlChangeListener();
+        resolve(null);
+      };
+      const removeUrlChangeListener = () => {
+        window.removeEventListener("urlchange", handleUrlChange);
+      };
+      window.addEventListener("urlchange", handleUrlChange);
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["class"]
+      });
+    });
+  }
+  function localStorageGetInt(name) {
+    const savedValue = _unsafeWindow.localStorage.getItem(name);
+    if (!savedValue) {
+      return null;
+    }
+    const savedInt = parseInt(savedValue, 10);
+    if (isNaN(savedInt)) {
+      return null;
+    }
+    return savedInt;
+  }
+  async function fetchMapInfo(url) {
+    return new Promise((resolve, reject) => {
+      _GM_xmlhttpRequest({
+        method: "GET",
+        url,
+        onload: (response) => {
+          if (response.status === 200 || response.status === 404) {
+            try {
+              const mapInfo = JSON.parse(response.responseText);
+              logInfo("fetched map info", mapInfo);
+              resolve(mapInfo);
+            } catch (e) {
+              logInfo("failed to parse map info response", e);
+              reject("Failed to parse response");
+            }
+          } else {
+            logInfo("failed to fetch map info", response);
+            reject(`HTTP error! status: ${response.status}`);
+          }
+        },
+        onerror: () => {
+          reject("An error occurred while fetching data");
+        }
+      });
+    });
+  }
+  const MAP_FOUND_CACHE_MS = 24 * 60 * 60 * 1e3;
+  const MAP_NOT_FOUND_CACHE_MS = 60 * 60 * 1e3;
+  function getCachedMapInfo(key) {
+    const savedMapInfo = _unsafeWindow.localStorage.getItem(key);
+    if (!savedMapInfo) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(savedMapInfo);
+      if (parsed && parsed.mapInfo && typeof parsed.fetchedAt === "number") {
+        return parsed;
+      }
+    } catch {
+    }
+    return null;
+  }
+  async function getMapInfo(geoguessrId, forceUpdate) {
+    const localStorageMapInfoKey = `geometa:map-info:${geoguessrId}`;
+    const cached = getCachedMapInfo(localStorageMapInfoKey);
+    if (!forceUpdate && cached) {
+      const ttl = cached.mapInfo.mapFound ? MAP_FOUND_CACHE_MS : MAP_NOT_FOUND_CACHE_MS;
+      if (Date.now() - cached.fetchedAt < ttl) {
+        logInfo("using saved map info", cached.mapInfo);
+        return cached.mapInfo;
+      }
+    }
+    const url = `https://learnablemeta.com/api/userscript/map/${geoguessrId}`;
+    let mapInfo;
+    try {
+      mapInfo = await fetchMapInfo(url);
+    } catch (e) {
+      if (cached) {
+        logInfo("map info fetch failed - using stale cached map info", e);
+        return cached.mapInfo;
+      }
+      throw e;
+    }
+    const toCache = { mapInfo, fetchedAt: Date.now() };
+    _unsafeWindow.localStorage.setItem(localStorageMapInfoKey, JSON.stringify(toCache));
+    _unsafeWindow.localStorage.setItem("geometa:latest-version", mapInfo.userscriptVersion);
+    return mapInfo;
+  }
+  function getLatestVersionInfo() {
+    return _unsafeWindow.localStorage.getItem("geometa:latest-version");
+  }
+  function isNewerVersion(candidate, current) {
+    const a = candidate.split(".").map(Number);
+    const b = current.split(".").map(Number);
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      const diff = (a[i] || 0) - (b[i] || 0);
+      if (diff) return diff > 0;
+    }
+    return false;
+  }
+  function checkIfOutdated() {
+    const latest = getLatestVersionInfo();
+    if (!latest) {
+      return false;
+    }
+    return isNewerVersion(latest, _GM_info.script.version);
+  }
+  function markHelpMessageAsRead() {
+    _unsafeWindow.localStorage.setItem("geometa:help-message-read", "true");
+  }
+  function wasHelpMessageRead() {
+    return _unsafeWindow.localStorage.getItem("geometa:help-message-read") == "true";
+  }
+  const getChallengeId = () => {
+    const regexp = /.*\/live-challenge\/(.*)/;
+    const matches = location.pathname.match(regexp);
+    if (matches && matches.length > 1) {
+      return matches[1];
+    }
+    return null;
+  };
+  async function getChallengeInfo(id) {
+    const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;
+    const response = await fetch(url, {
+      method: "GET",
+      credentials: "include"
+    });
+    const data = await response.json();
+    const mapId = data.options.mapSlug;
+    const currentRound = data.currentRoundNumber - 1;
+    const rounds = data.rounds;
+    const panorama = rounds[currentRound].question.panoramaQuestionPayload.panorama;
+    const panoIdHex = panorama.panoId;
+    const panoId = decodePanoId(panoIdHex);
+    return { mapId, panoId };
+  }
+  function decodePanoId(encoded) {
+    let panoId = "";
+    for (let i = 0; i + 2 <= encoded.length; i += 2) {
+      panoId += String.fromCharCode(parseInt(encoded.slice(i, i + 2), 16));
+    }
+    return panoId;
+  }
+  function logInfo(name, data) {
+    console.log(`ALM: ${name}`, data);
+  }
+  function extractMapIdFromUrl(url) {
+    const match = url.match(/\/maps\/([^\/]+)/);
+    return match ? match[1] : null;
+  }
   const PUBLIC_VERSION = "5";
   if (typeof window !== "undefined") {
     ((window.__svelte ??= {}).v ??= new Set()).add(PUBLIC_VERSION);
   }
   enable_legacy_mode_flag();
-  var root$6 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
+  var root$7 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
   function Spinner($$anchor) {
-    var div = root$6();
+    var div = root$7();
     append($$anchor, div);
   }
   var root_1$3 = from_html(`<img class="fi svelte-tdzec4"/>`);
@@ -4540,7 +4560,7 @@ context.l
   var root_3$2 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
   var root_6$3 = from_html(`<button></button>`);
   var root_5$3 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
-  var root$5 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
+  var root$6 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
   function Carousel($$anchor, $$props) {
     push($$props, false);
     let images = prop($$props, "images", 24, () => []);
@@ -4571,7 +4591,7 @@ context.l
       set(lensY, event2.clientY - rect.top);
     }
     init();
-    var div = root$5();
+    var div = root$6();
     var node = child(div);
     {
       var consequent_2 = ($$anchor2) => {
@@ -4757,18 +4777,81 @@ context.l
       console.warn("LocalStorage Error: Could not save last dismissed announcement timestamp.", e);
     }
   }
+  const focusableSelector = [
+    "a[href]",
+    "button:not(:disabled)",
+    "input:not(:disabled)",
+    "select:not(:disabled)",
+    "textarea:not(:disabled)",
+    '[tabindex]:not([tabindex="-1"])'
+  ].join(",");
+  function focusableElements(node) {
+    return Array.from(node.querySelectorAll(focusableSelector)).filter(
+      (element) => !element.hidden && element.getClientRects().length > 0
+    );
+  }
+  function modalDialog(node, initialOptions) {
+    let options = initialOptions;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    function focusDialog() {
+      if (!node.isConnected || node.contains(document.activeElement)) return;
+      const initialFocus = node.querySelector("[data-modal-initial-focus]") ?? focusableElements(node)[0];
+      if (initialFocus) {
+        initialFocus.focus();
+      } else {
+        node.tabIndex = -1;
+        node.focus();
+      }
+    }
+    function handleKeydown(event2) {
+      if (event2.key === "Escape" && options.closeOnEscape !== false) {
+        event2.preventDefault();
+        event2.stopPropagation();
+        options.onClose();
+        return;
+      }
+      if (event2.key !== "Tab") return;
+      const elements = focusableElements(node);
+      if (elements.length === 0) {
+        event2.preventDefault();
+        node.focus();
+        return;
+      }
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      const activeElement = document.activeElement;
+      if (event2.shiftKey && (activeElement === first || !node.contains(activeElement))) {
+        event2.preventDefault();
+        last.focus();
+      } else if (!event2.shiftKey && (activeElement === last || !node.contains(activeElement))) {
+        event2.preventDefault();
+        first.focus();
+      }
+    }
+    node.addEventListener("keydown", handleKeydown);
+    requestAnimationFrame(focusDialog);
+    return {
+      update(nextOptions) {
+        options = nextOptions;
+      },
+      destroy() {
+        node.removeEventListener("keydown", handleKeydown);
+        if (previouslyFocused?.isConnected) previouslyFocused.focus();
+      }
+    };
+  }
   var root_2$2 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
   var root_3$1 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
   var root_6$2 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
   var root_7 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
   var root_5$2 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
-  var root_9 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
-  var root_11$1 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
-  var root_10$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
-              on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View Map meta list:</strong> Click the list icon to see all the metas included
-              in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the Community:</strong> Click the Discord icon to share feedback, suggest
-              improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-1j2rmt2">Close</button></div></div>`);
-  var root$4 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-1j2rmt2"><span></span></button></div></div> <!> <!> <!></div>`);
+  var root_9 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui svelte-1j2rmt2" role="presentation"><div class="learnablemeta-modal svelte-1j2rmt2" role="dialog" aria-modal="true" aria-labelledby="external-link-title"><div class="learnablemeta-modal-header svelte-1j2rmt2"><p class="learnablemeta-modal-eyebrow svelte-1j2rmt2">LearnableMeta</p> <h2 class="learnablemeta-modal-title svelte-1j2rmt2" id="external-link-title">Open external link?</h2> <p class="learnablemeta-modal-description svelte-1j2rmt2">This link will open in a new browser tab.</p></div> <div class="learnablemeta-modal-body svelte-1j2rmt2"><p class="learnablemeta-modal-code svelte-1j2rmt2"> </p></div> <div class="learnablemeta-modal-actions svelte-1j2rmt2"><button type="button" data-modal-initial-focus="" class="learnablemeta-button learnablemeta-button--outline svelte-1j2rmt2">Cancel</button> <button type="button" class="learnablemeta-button learnablemeta-button--primary svelte-1j2rmt2">Continue</button></div></div></div>`);
+  var root_11$1 = from_html(`<p class="learnablemeta-modal-alert svelte-1j2rmt2"> </p>`);
+  var root_10$1 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui svelte-1j2rmt2" role="presentation"><div class="learnablemeta-modal learnablemeta-modal--wide svelte-1j2rmt2" role="dialog" aria-modal="true" aria-labelledby="learnablemeta-help-title"><div class="learnablemeta-modal-header svelte-1j2rmt2"><p class="learnablemeta-modal-eyebrow svelte-1j2rmt2">LearnableMeta</p> <h2 class="learnablemeta-modal-title svelte-1j2rmt2" id="learnablemeta-help-title">Userscript guide</h2> <p class="learnablemeta-modal-description svelte-1j2rmt2">Quick tips for using LearnableMeta while you play.</p></div> <div class="learnablemeta-modal-body svelte-1j2rmt2"><!> <ul class="learnablemeta-help-list svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to move:</strong> Click and drag the top of the note to reposition it anywhere
+              on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View map meta list:</strong> Click the list icon to see all the metas included
+              in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the community:</strong> Click the Discord icon to share feedback, suggest
+              improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated script:</strong> The question mark icon blinks when an update is available.</li></ul></div> <div class="learnablemeta-modal-actions svelte-1j2rmt2"><button type="button" class="learnablemeta-button learnablemeta-button--primary svelte-1j2rmt2">Close</button></div></div></div>`);
+  var root$5 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button class="help-toggle-button svelte-1j2rmt2" aria-label="More information"><span></span></button></div></div> <!> <!> <!></div>`);
   function App($$anchor, $$props) {
     push($$props, true);
     let geoInfo = state(null);
@@ -4880,7 +4963,7 @@ context.l
       }
     });
     let lastDismissedTimestamp = state(proxy(getLastDismissedAnnouncementTimestamp()));
-    var div = root$4();
+    var div = root$5();
     var node = child(div);
     await_block(node, getAnnouncement, null, ($$anchor2, announcement) => {
       var fragment = comment();
@@ -4996,13 +5079,15 @@ context.l
       var consequent_5 = ($$anchor2) => {
         var div_6 = root_9();
         var div_7 = child(div_6);
-        var p_3 = sibling(child(div_7), 2);
+        var div_8 = sibling(child(div_7), 2);
+        var p_3 = child(div_8);
         var text_3 = child(p_3);
-        var div_8 = sibling(p_3, 2);
-        var button_2 = child(div_8);
-        button_2.__click = proceed;
+        var div_9 = sibling(div_8, 2);
+        var button_2 = child(div_9);
+        button_2.__click = cancel;
         var button_3 = sibling(button_2, 2);
-        button_3.__click = cancel;
+        button_3.__click = proceed;
+        action(div_7, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: cancel }));
         template_effect(() => set_text(text_3, get(currentUrl)));
         append($$anchor2, div_6);
       };
@@ -5013,25 +5098,26 @@ context.l
     var node_12 = sibling(node_11, 2);
     {
       var consequent_7 = ($$anchor2) => {
-        var div_9 = root_10$1();
-        var div_10 = child(div_9);
+        var div_10 = root_10$1();
         var div_11 = child(div_10);
-        var node_13 = child(div_11);
+        var div_12 = sibling(child(div_11), 2);
+        var node_13 = child(div_12);
         {
           var consequent_6 = ($$anchor3) => {
             var p_4 = root_11$1();
-            var strong_1 = child(p_4);
-            var text_4 = child(strong_1);
-            template_effect(($0) => set_text(text_4, `Your script version is out of date - please install the latest version (${$0 ?? ""})!`), [getLatestVersionInfo]);
+            var text_4 = child(p_4);
+            template_effect(($0) => set_text(text_4, `Your userscript is out of date. Install the latest version (${$0 ?? ""}).`), [getLatestVersionInfo]);
             append($$anchor3, p_4);
           };
           if_block(node_13, ($$render) => {
             if (checkIfOutdated()) $$render(consequent_6);
           });
         }
-        var button_4 = sibling(div_11, 2);
+        var div_13 = sibling(div_12, 2);
+        var button_4 = child(div_13);
         button_4.__click = togglePopup;
-        append($$anchor2, div_9);
+        action(div_11, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: togglePopup }));
+        append($$anchor2, div_10);
       };
       if_block(node_12, ($$render) => {
         if (get(showHelpPopup)) $$render(consequent_7);
@@ -5283,9 +5369,9 @@ roundNumber: 4,
       return result;
     };
   }
-  var root$3 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
+  var root$4 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
   function MapLabel($$anchor, $$props) {
-    var div = root$3();
+    var div = root$4();
     var a = sibling(child(div), 2);
     template_effect(() => set_attribute(a, "href", `https://learnablemeta.com/maps/${$$props.mapId}`));
     append($$anchor, div);
@@ -5521,10 +5607,10 @@ roundNumber: 4,
     };
   }
   var root_1$2 = from_html(`<span class="toast-detail svelte-w17ltc"> </span>`);
-  var root$2 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
+  var root$3 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
   function ToastNotification($$anchor, $$props) {
     let type = prop($$props, "type", 3, "info");
-    var div = root$2();
+    var div = root$3();
     var div_1 = child(div);
     var span = child(div_1);
     var text = child(span);
@@ -5565,13 +5651,13 @@ roundNumber: 4,
   function clearApiKey() {
     _GM_setValue(API_KEY_STORAGE_NAME, "");
   }
-  var root_2$1 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
-  var root_4 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
-          to replace it, or clear the saved key.</p>`);
-  var root_5$1 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
-  var root_6$1 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
-  var root_1$1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
-  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="learnablemeta-yellow-button"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
+  var root_2$1 = from_html(`<p>An API token is required before locations can be uploaded.</p>`);
+  var root_4 = from_html(`<p>A token ending in <code class="saved-key svelte-1plj3lz"> </code> is saved. Paste
+            a new token to replace it, or clear the saved token.</p>`);
+  var root_5$1 = from_html(`<p>No API token is saved yet.</p>`);
+  var root_6$1 = from_html(`<button type="button" class="learnablemeta-button learnablemeta-button--destructive learnablemeta-modal-action-leading">Clear token</button>`);
+  var root_1$1 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation"><div class="learnablemeta-modal" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="learnablemeta-modal-header"><p class="learnablemeta-modal-eyebrow">LearnableMeta</p> <h2 class="learnablemeta-modal-title" id="apiKeyModalTitle">API token</h2> <p class="learnablemeta-modal-description">Manage the token used to download synchronized locations.</p></div> <div class="learnablemeta-modal-body"><!> <p>Generate or replace your token on the <a target="_blank" rel="noopener noreferrer">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API token" aria-label="LearnableMeta API token" data-modal-initial-focus="" class="learnablemeta-modal-input"/> <p class="learnablemeta-modal-note">The token is stored only in your browser's userscript storage.</p></div> <div class="learnablemeta-modal-actions"><!> <button type="button" class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button type="button" class="learnablemeta-button learnablemeta-button--primary"> </button></div></div></div>`);
+  var root$2 = from_html(`<div class="upload-label-container learnablemeta-ui svelte-1plj3lz"><button class="learnablemeta-geoguessr-button"> </button> <button class="learnablemeta-geoguessr-button learnablemeta-geoguessr-button--icon" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
     let showApiKeyModal = state(false);
@@ -5690,7 +5776,7 @@ roundNumber: 4,
       set(showApiKeyModal, false);
       set(apiKeyInput, "");
     }
-    var fragment = root$1();
+    var fragment = root$2();
     var div = first_child(fragment);
     var button = child(div);
     button.__click = handleUploadClick;
@@ -5702,7 +5788,8 @@ roundNumber: 4,
       var consequent_3 = ($$anchor2) => {
         var div_1 = root_1$1();
         var div_2 = child(div_1);
-        var node_1 = sibling(child(div_2), 2);
+        var div_3 = sibling(child(div_2), 2);
+        var node_1 = child(div_3);
         {
           var consequent = ($$anchor3) => {
             var p = root_2$1();
@@ -5742,8 +5829,8 @@ roundNumber: 4,
         var p_3 = sibling(node_1, 2);
         var a = sibling(child(p_3));
         var input = sibling(p_3, 2);
-        var div_3 = sibling(input, 2);
-        var node_3 = child(div_3);
+        var div_4 = sibling(div_3, 2);
+        var node_3 = child(div_4);
         {
           var consequent_2 = ($$anchor3) => {
             var button_2 = root_6$1();
@@ -5755,13 +5842,14 @@ roundNumber: 4,
           });
         }
         var button_3 = sibling(node_3, 2);
-        button_3.__click = handleSaveApiKey;
-        var text_2 = child(button_3);
+        button_3.__click = handleCancelModal;
         var button_4 = sibling(button_3, 2);
-        button_4.__click = handleCancelModal;
+        button_4.__click = handleSaveApiKey;
+        var text_2 = child(button_4);
+        action(div_2, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: handleCancelModal }));
         template_effect(() => {
           set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
-          set_text(text_2, get(modalMode) === "upload" ? "Save & Upload" : "Save");
+          set_text(text_2, get(modalMode) === "upload" ? "Save and upload" : "Save");
         });
         bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
         append($$anchor2, div_1);
@@ -5910,24 +5998,24 @@ roundNumber: 4,
   }
   var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
   var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
-  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and continue</button></div></div>`);
+  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="learnablemeta-modal-input" data-modal-initial-focus=""/> <!> <div class="learnablemeta-modal-actions token-actions svelte-axobi4"><button class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button class="learnablemeta-button learnablemeta-button--primary">Save and continue</button></div></div>`);
   var root_6 = from_html(`<div class="notice svelte-axobi4">Loading your synchronized map groups…</div>`);
-  var root_8 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load your map groups.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
-  var root_11 = from_html(`<button class="group-row svelte-axobi4"><strong> </strong> <span class="svelte-axobi4"> </span></button>`);
+  var root_8 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load your map groups.</strong> <span> </span> <button class="learnablemeta-button learnablemeta-button--outline svelte-axobi4">Try again</button></div>`);
+  var root_11 = from_html(`<button class="group-row svelte-axobi4"><span class="group-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4">Synchronized and ready to compare</span></span> <span class="group-count svelte-axobi4"> <svg viewBox="0 0 24 24" aria-hidden="true" class="svelte-axobi4"><path d="m9 18 6-6-6-6"></path></svg></span></button>`);
   var root_10 = from_html(`<div class="notice svelte-axobi4">Select a synchronized LearnableMeta group to compare its maps.</div> <div class="group-list svelte-axobi4"></div>`, 1);
   var root_12 = from_html(`<div class="notice svelte-axobi4">You have no synchronized map groups containing maps.</div>`);
-  var root_5 = from_html(`<!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button></footer>`, 1);
+  var root_5 = from_html(`<!> <footer class="learnablemeta-modal-actions"><button class="learnablemeta-button learnablemeta-button--link learnablemeta-modal-action-leading">Change API token</button> <button class="learnablemeta-button learnablemeta-button--outline">Close</button></footer>`, 1);
   var root_14 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
-  var root_15 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_15 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="learnablemeta-button learnablemeta-button--outline svelte-axobi4">Try again</button></div>`);
   var root_18 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
-  var root_17 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
-  var root_16 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
+  var root_17 = from_html(`<label><input type="checkbox" class="svelte-axobi4"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
+  var root_16 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div class="svelte-axobi4"><button class="learnablemeta-button learnablemeta-button--link">Select changed</button> <button class="learnablemeta-button learnablemeta-button--link">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
   var root_20 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
   var root_21 = from_html(`<div class="summary svelte-axobi4"> </div>`);
-  var root_22 = from_html(`<button class="link-button svelte-axobi4">Change group</button>`);
-  var root_23 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
-  var root_13 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <!> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
-  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4"> </h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
+  var root_22 = from_html(`<button class="learnablemeta-button learnablemeta-button--link">Change group</button>`);
+  var root_23 = from_html(`<button class="learnablemeta-button learnablemeta-button--outline"> </button>`);
+  var root_13 = from_html(`<!> <!> <!> <!> <footer class="learnablemeta-modal-actions"><button class="learnablemeta-button learnablemeta-button--link learnablemeta-modal-action-leading">Change API token</button> <!> <button class="learnablemeta-button learnablemeta-button--outline">Close</button> <!> <button class="learnablemeta-button learnablemeta-button--primary"> </button></footer>`, 1);
+  var root$1 = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation"><div class="learnablemeta-modal learnablemeta-modal--map-update" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="learnablemeta-modal-header learnablemeta-modal-header--row"><div><p class="learnablemeta-modal-eyebrow">LearnableMeta</p> <h1 class="learnablemeta-modal-title learnablemeta-modal-title--large" id="group-update-title"> </h1> <!></div> <button class="learnablemeta-button learnablemeta-button--ghost map-update-close svelte-axobi4" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true" class="svelte-axobi4"><path d="M18 6 6 18M6 6l12 12"></path></svg></button></header> <!></div></div>`);
   function MapGroupUpdate($$anchor, $$props) {
     push($$props, true);
     const canChooseGroup = $$props.groupId === void 0;
@@ -6159,7 +6247,14 @@ roundNumber: 4,
       };
       return labels[row.status];
     }
-    var div = root();
+    function statusTone(row) {
+      if (row.status === "current" || row.status === "success") return "good";
+      if (["scan-error", "update-error", "publish-error"].includes(row.status)) return "bad";
+      if (["scanning", "updating", "publishing"].includes(row.status)) return "working";
+      if (row.status === "empty") return "neutral";
+      return "warning";
+    }
+    var div = root$1();
     var div_1 = child(div);
     var header = child(div_1);
     var div_2 = child(header);
@@ -6247,13 +6342,14 @@ roundNumber: 4,
                         each(div_7, 21, () => get(accessibleGroups), (group) => group.id, ($$anchor7, group) => {
                           var button_4 = root_11();
                           button_4.__click = () => selectGroup(get(group).id);
-                          var strong = child(button_4);
+                          var span_1 = child(button_4);
+                          var strong = child(span_1);
                           var text_4 = child(strong);
-                          var span_1 = sibling(strong, 2);
-                          var text_5 = child(span_1);
+                          var span_2 = sibling(span_1, 2);
+                          var text_5 = child(span_2);
                           template_effect(() => {
                             set_text(text_4, get(group).name);
-                            set_text(text_5, `${get(group).mapCount ?? ""} map${get(group).mapCount === 1 ? "" : "s"}`);
+                            set_text(text_5, `${get(group).mapCount ?? ""} map${get(group).mapCount === 1 ? "" : "s"} `);
                           });
                           append($$anchor7, button_4);
                         });
@@ -6315,9 +6411,9 @@ roundNumber: 4,
             {
               var consequent_8 = ($$anchor4) => {
                 var div_10 = root_15();
-                var span_2 = sibling(child(div_10), 2);
-                var text_6 = child(span_2);
-                var button_7 = sibling(span_2, 2);
+                var span_3 = sibling(child(div_10), 2);
+                var text_6 = child(span_3);
+                var button_7 = sibling(span_3, 2);
                 button_7.__click = scanGroup;
                 template_effect(() => set_text(text_6, get(fatalError)));
                 append($$anchor4, div_10);
@@ -6331,9 +6427,9 @@ roundNumber: 4,
               var consequent_10 = ($$anchor4) => {
                 var fragment_6 = root_16();
                 var div_11 = first_child(fragment_6);
-                var span_3 = child(div_11);
-                var text_7 = child(span_3);
-                var div_12 = sibling(span_3, 2);
+                var span_4 = child(div_11);
+                var text_7 = child(span_4);
+                var div_12 = sibling(span_4, 2);
                 var button_8 = child(div_12);
                 button_8.__click = () => selectChanged(true);
                 var button_9 = sibling(button_8, 2);
@@ -6343,39 +6439,37 @@ roundNumber: 4,
                   var label = root_17();
                   let classes;
                   var input_1 = child(label);
-                  var span_4 = sibling(input_1, 2);
-                  var strong_1 = child(span_4);
+                  var span_5 = sibling(input_1, 2);
+                  var strong_1 = child(span_5);
                   var text_8 = child(strong_1);
-                  var span_5 = sibling(strong_1, 2);
-                  var text_9 = child(span_5);
-                  var node_10 = sibling(span_5, 2);
+                  var span_6 = sibling(strong_1, 2);
+                  var text_9 = child(span_6);
+                  var node_10 = sibling(span_6, 2);
                   {
                     var consequent_9 = ($$anchor6) => {
-                      var span_6 = root_18();
-                      var text_10 = child(span_6);
+                      var span_7 = root_18();
+                      var text_10 = child(span_7);
                       template_effect(() => set_text(text_10, get(row).error));
-                      append($$anchor6, span_6);
+                      append($$anchor6, span_7);
                     };
                     if_block(node_10, ($$render) => {
                       if (get(row).error) $$render(consequent_9);
                     });
                   }
-                  var span_7 = sibling(span_4, 2);
-                  let classes_1;
-                  var text_11 = child(span_7);
+                  var span_8 = sibling(span_5, 2);
+                  var text_11 = child(span_8);
                   template_effect(
-                    ($0, $1) => {
-                      classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
+                    ($0, $1, $2) => {
+                      classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error, selected: get(row).selected });
                       input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
                       set_text(text_8, get(row).name);
                       set_text(text_9, `${$0 ?? ""} synchronized locations`);
-                      classes_1 = set_class(span_7, 1, "status svelte-axobi4", null, classes_1, {
-                        good: get(row).status === "current" || get(row).status === "success"
-                      });
-                      set_text(text_11, $1);
+                      set_class(span_8, 1, `status ${$1 ?? ""}`, "svelte-axobi4");
+                      set_text(text_11, $2);
                     },
                     [
                       () => get(row).locationCount.toLocaleString(),
+                      () => statusTone(get(row)),
                       () => statusLabel(get(row))
                     ]
                   );
@@ -6482,6 +6576,10 @@ roundNumber: 4,
         else $$render(alternate_5, false);
       });
     }
+    action(div_1, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({
+      onClose: $$props.onClose,
+      closeOnEscape: get(phase) !== "updating"
+    }));
     template_effect(() => {
       set_text(text, get(phase) === "groups" ? "Choose a map group" : "Update GeoGuessr maps");
       button.disabled = get(phase) === "updating";
@@ -6535,7 +6633,7 @@ roundNumber: 4,
     if (document.getElementById(launcherButtonId)) return;
     const launcher = document.createElement("button");
     launcher.id = launcherButtonId;
-    launcher.className = "learnablemeta-yellow-button";
+    launcher.className = "learnablemeta-geoguessr-button";
     launcher.type = "button";
     launcher.setAttribute("aria-label", "Update LearnableMeta maps");
     launcher.textContent = "Update maps";
@@ -6565,16 +6663,55 @@ roundNumber: 4,
     handleCreatorHubNavigation();
     window.addEventListener("urlchange", handleCreatorHubNavigation);
   }
-  const buttonsCss = ".learnablemeta-yellow-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;appearance:none;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.learnablemeta-yellow-button:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.learnablemeta-yellow-button:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:inset 0 2px 4px #0003;transform:translateY(1px)}.learnablemeta-yellow-button:focus-visible{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.learnablemeta-yellow-button:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.learnablemeta-map-actions{display:flex!important;flex-direction:row!important;align-items:center!important;gap:.75rem!important}";
+  var root = from_html(`<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation"><div class="learnablemeta-modal" role="dialog" aria-modal="true" aria-labelledby="reset-layout-title"><div class="learnablemeta-modal-header"><p class="learnablemeta-modal-eyebrow">LearnableMeta</p> <h2 class="learnablemeta-modal-title" id="reset-layout-title">Reset window layout?</h2> <p class="learnablemeta-modal-description">The meta window will return to its default position and size.</p></div> <div class="learnablemeta-modal-actions"><button type="button" data-modal-initial-focus="" class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button type="button" class="learnablemeta-button learnablemeta-button--primary">Reset layout</button></div></div></div>`);
+  function ResetLayoutConfirmation($$anchor, $$props) {
+    var div = root();
+    var div_1 = child(div);
+    var div_2 = sibling(child(div_1), 2);
+    var button = child(div_2);
+    button.__click = function(...$$args) {
+      $$props.onCancel?.apply(this, $$args);
+    };
+    var button_1 = sibling(button, 2);
+    button_1.__click = function(...$$args) {
+      $$props.onConfirm?.apply(this, $$args);
+    };
+    action(div_1, ($$node, $$action_arg) => modalDialog?.($$node, $$action_arg), () => ({ onClose: $$props.onCancel }));
+    append($$anchor, div);
+  }
+  delegate(["click"]);
+  const themeCss = ".learnablemeta-ui{--lm-background: hsl(0 0% 100%);--lm-foreground: hsl(240 10% 3.9%);--lm-card: hsl(0 0% 100%);--lm-card-foreground: hsl(240 10% 3.9%);--lm-primary: hsl(161 92% 25%);--lm-primary-hover: hsl(161 92% 22%);--lm-primary-foreground: hsl(355.7 100% 97.3%);--lm-secondary: hsl(240 4.8% 95.9%);--lm-secondary-foreground: hsl(240 5.9% 10%);--lm-muted: hsl(240 4.8% 95.9%);--lm-muted-foreground: hsl(240 3.8% 46.1%);--lm-accent: hsl(240 4.8% 95.9%);--lm-accent-foreground: hsl(240 5.9% 10%);--lm-destructive: hsl(0 72.22% 50.59%);--lm-border: hsl(240 5.9% 90%);--lm-input: hsl(240 5.9% 90%);--lm-ring: hsl(142.1 76.2% 36.3%);--lm-link: hsl(220.3 82.9% 52.7%);--lm-radius: .5rem;color:var(--lm-foreground);font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}@media(prefers-color-scheme:dark){.learnablemeta-ui{--lm-background: hsl(0 0% 10%);--lm-foreground: hsl(0 0% 95%);--lm-card: hsl(24 9.8% 10%);--lm-card-foreground: hsl(0 0% 95%);--lm-primary: hsl(161 92% 25%);--lm-primary-hover: hsl(161 92% 29%);--lm-primary-foreground: hsl(0 0% 98%);--lm-secondary: hsl(240 3.7% 20.9%);--lm-secondary-foreground: hsl(0 0% 98%);--lm-muted: hsl(0 0% 15%);--lm-muted-foreground: hsl(240 5% 64.9%);--lm-accent: hsl(12 6.5% 15.1%);--lm-accent-foreground: hsl(0 0% 98%);--lm-destructive: hsl(0 72% 60%);--lm-border: hsl(240 3.7% 22%);--lm-input: hsl(240 3.7% 25.5%);--lm-ring: hsl(142.4 71.8% 35%);--lm-link: hsl(217.1 92.7% 67.6%);color-scheme:dark}}";
+  importCSS(themeCss);
+  const buttonsCss = ".learnablemeta-button{display:inline-flex;height:36px;flex:none;align-items:center;justify-content:center;gap:8px;padding:8px 16px;appearance:none;font-family:inherit;font-size:14px;font-weight:500;line-height:20px;white-space:nowrap;border:1px solid transparent;border-radius:var(--lm-radius, .5rem);cursor:pointer;transition:background-color .15s ease,border-color .15s ease,color .15s ease,box-shadow .15s ease}.learnablemeta-button--primary{background:var(--lm-primary, hsl(161 92% 25%));color:var(--lm-primary-foreground, #fff);box-shadow:0 1px 2px #0000001f}.learnablemeta-button--primary:hover:not(:disabled){background:var(--lm-primary-hover, hsl(161 92% 22%))}.learnablemeta-button--outline{border-color:var(--lm-border, hsl(240 5.9% 90%));background:var(--lm-background, #fff);color:var(--lm-secondary-foreground, hsl(240 5.9% 10%));box-shadow:0 1px 2px #0000000f}.learnablemeta-button--outline:hover:not(:disabled){background:var(--lm-accent, hsl(240 4.8% 95.9%));color:var(--lm-accent-foreground, hsl(240 5.9% 10%))}.learnablemeta-button--ghost{background:transparent;color:var(--lm-muted-foreground, hsl(240 3.8% 46.1%));box-shadow:none}.learnablemeta-button--ghost:hover:not(:disabled){background:var(--lm-accent, hsl(240 4.8% 95.9%));color:var(--lm-accent-foreground, hsl(240 5.9% 10%))}.learnablemeta-button--link{height:auto;padding:5px 7px;background:transparent;color:var(--lm-link, hsl(220.3 82.9% 52.7%));font-size:13px;box-shadow:none}.learnablemeta-button--link:hover:not(:disabled){text-decoration:underline;text-underline-offset:3px}.learnablemeta-button--destructive{background:var(--lm-destructive, hsl(0 72.22% 50.59%));color:#fff;box-shadow:0 1px 2px #0000001f}.learnablemeta-button--destructive:hover:not(:disabled){background:color-mix(in srgb,var(--lm-destructive, #dc2626) 88%,#000)}.learnablemeta-button--icon{width:36px;padding:0}.learnablemeta-button:active:not(:disabled){box-shadow:inset 0 1px 3px #00000040}.learnablemeta-button--ghost:active:not(:disabled),.learnablemeta-button--link:active:not(:disabled){box-shadow:none}.learnablemeta-button:focus-visible{outline:none;box-shadow:0 0 0 3px color-mix(in srgb,var(--lm-ring, #16a34a) 35%,transparent)}.learnablemeta-button:disabled{opacity:.5;cursor:not-allowed}.learnablemeta-geoguessr-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;appearance:none;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.learnablemeta-geoguessr-button:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.learnablemeta-geoguessr-button:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:inset 0 2px 4px #0003;transform:translateY(1px)}.learnablemeta-geoguessr-button:focus-visible{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.learnablemeta-geoguessr-button:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.learnablemeta-geoguessr-button--icon{width:30px;height:30px;padding:0;border-radius:50%;font-size:14px}.learnablemeta-geoguessr-button--icon:hover:not(:disabled){box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transform:none}.learnablemeta-geoguessr-button--icon:active:not(:disabled){transform:none}.learnablemeta-map-actions{display:flex!important;flex-direction:row!important;align-items:center!important;gap:.75rem!important}";
   importCSS(buttonsCss);
-  if (typeof _GM_registerMenuCommand === "function") {
-    _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", () => {
-      if (confirm("Reset the LearnableMeta window position and size?")) {
-        resetContainerPosition();
-        resetContainerDimensions();
-        window.location.reload();
+  const modalsCss = '.learnablemeta-modal-backdrop{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;box-sizing:border-box;padding:24px;background:#000000c2;-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px)}.learnablemeta-modal,.learnablemeta-modal *{box-sizing:border-box}.learnablemeta-modal{position:relative;width:min(460px,100%);max-height:calc(100vh - 48px);overflow-y:auto;border:1px solid var(--lm-border);border-radius:calc(var(--lm-radius) + 4px);background:var(--lm-background);color:var(--lm-foreground);box-shadow:0 24px 70px #00000080;text-align:left}.learnablemeta-modal--wide{width:min(600px,100%)}.learnablemeta-modal--map-update{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden}.learnablemeta-modal:before{position:absolute;inset:0 0 auto;height:4px;background:linear-gradient(90deg,#057a55,#0b87c1);content:""}.learnablemeta-modal-header{display:grid;gap:6px;padding:26px 24px 0}.learnablemeta-modal-header--row{display:flex;align-items:flex-start;justify-content:space-between;gap:24px;padding:26px 24px 20px;border-bottom:1px solid var(--lm-border);background:var(--lm-card)}.learnablemeta-modal-eyebrow{margin:0;color:var(--lm-primary);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase}.learnablemeta-modal-title{margin:0;color:var(--lm-foreground);font-size:20px;font-weight:650;line-height:1.3;letter-spacing:-.025em}.learnablemeta-modal-title--large{margin-top:4px;color:var(--lm-card-foreground);font-size:22px;line-height:1.25}.learnablemeta-modal-description{margin:0;color:var(--lm-muted-foreground);font-size:14px;line-height:1.5}.learnablemeta-modal-body{display:grid;gap:14px;padding:20px 24px 0;color:var(--lm-foreground);font-size:14px;line-height:1.5}.learnablemeta-modal-body p{margin:0}.learnablemeta-modal-body a{color:var(--lm-link);text-decoration:underline;text-underline-offset:3px}.learnablemeta-modal-input{width:100%;height:38px;border:1px solid var(--lm-input);border-radius:var(--lm-radius);padding:7px 12px;outline:none;background:var(--lm-background);color:var(--lm-foreground);font:inherit;font-size:14px;box-shadow:0 1px 2px #0000000a;transition:border-color .15s ease,box-shadow .15s ease}.learnablemeta-modal-input::placeholder{color:var(--lm-muted-foreground)}.learnablemeta-modal-input:focus-visible{border-color:var(--lm-ring);box-shadow:0 0 0 3px color-mix(in srgb,var(--lm-ring) 25%,transparent)}.learnablemeta-modal-code{overflow-wrap:anywhere;border:1px solid var(--lm-border);border-radius:var(--lm-radius);padding:10px 12px;background:var(--lm-muted);color:var(--lm-link);font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:12px;line-height:1.45;-webkit-user-select:text;user-select:text}.learnablemeta-modal-note{color:var(--lm-muted-foreground);font-size:12px;line-height:1.45}.learnablemeta-modal-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;margin-top:20px;padding:16px 24px;border-top:1px solid var(--lm-border);background:var(--lm-card)}.learnablemeta-modal-action-leading{margin-right:auto}.learnablemeta-modal-alert{border:1px solid rgba(220,38,38,.3);border-radius:var(--lm-radius);padding:12px 14px;background:#dc262617;color:var(--lm-destructive);font-size:13px}.learnablemeta-modal .learnablemeta-modal-body .learnablemeta-help-list{display:grid;gap:10px;margin:0;padding-left:20px;list-style:disc}.learnablemeta-modal .learnablemeta-help-list strong{color:var(--lm-foreground);font-weight:600}@media(max-width:620px){.learnablemeta-modal-backdrop{padding:8px}.learnablemeta-modal{max-height:calc(100vh - 16px)}.learnablemeta-modal-actions{flex-wrap:wrap}.learnablemeta-modal-action-leading{width:100%;margin-right:0}.learnablemeta-modal-actions .learnablemeta-button--primary,.learnablemeta-modal-actions .learnablemeta-button--outline,.learnablemeta-modal-actions .learnablemeta-button--destructive{flex:1}}';
+  importCSS(modalsCss);
+  let resetDialogApp = null;
+  function openResetLayoutDialog() {
+    if (resetDialogApp) return;
+    const target = document.createElement("div");
+    target.id = "learnablemeta-reset-layout-dialog";
+    document.body.appendChild(target);
+    function closeDialog() {
+      if (resetDialogApp) unmount(resetDialogApp);
+      resetDialogApp = null;
+      target.remove();
+    }
+    resetDialogApp = mount(ResetLayoutConfirmation, {
+      target,
+      props: {
+        onCancel: closeDialog,
+        onConfirm: () => {
+          resetContainerPosition();
+          resetContainerDimensions();
+          closeDialog();
+          window.location.reload();
+        }
       }
     });
+  }
+  if (typeof _GM_registerMenuCommand === "function") {
+    _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", openResetLayoutDialog);
   }
   initURLChangeEvent();
   if (document.readyState === "loading") {

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Learnable Meta
 // @namespace    geometa
-// @version      0.90
+// @version      0.91
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
 // @downloadURL  https://github.com/likeon/geometa/raw/main/userscript/dist/geometa.user.js
@@ -22,6 +22,13 @@
 
 /*
 # Changelog
+
+## [0.91]
+
+- Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
+- Added review and selection before updating changed maps
+- Added sequential draft updates, publishing, per-map progress, and retryable failures
+- Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
 
 ## [0.90]
 
@@ -171,7 +178,7 @@
 
   const d=new Set;const e = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
 
-  e(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.custom-yellow-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-1plj3lz:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-1plj3lz:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center} `);
+  e(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.custom-yellow-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-1plj3lz:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-1plj3lz:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
 
   var _GM_getValue = (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = (() => typeof GM_info != "undefined" ? GM_info : void 0)();
@@ -1464,6 +1471,11 @@ current_batch
       }
       next(promise);
     });
+  }
+function user_derived(fn) {
+    const d = derived(fn);
+    push_reaction_value(d);
+    return d;
   }
 function derived_safe_equal(fn) {
     const signal = derived(fn);
@@ -3537,10 +3549,29 @@ get_first_child(node2)
       return value ?? "";
     }
   }
+  const whitespace = [..." 	\n\r\f \v\uFEFF"];
   function to_class(value, hash, directives) {
     var classname = value == null ? "" : "" + value;
     if (hash) {
       classname = classname ? classname + " " + hash : hash;
+    }
+    if (directives) {
+      for (var key in directives) {
+        if (directives[key]) {
+          classname = classname ? classname + " " + key : key;
+        } else if (classname.length) {
+          var len = key.length;
+          var a = 0;
+          while ((a = classname.indexOf(key, a)) >= 0) {
+            var b = a + len;
+            if ((a === 0 || whitespace.includes(classname[a - 1])) && (b === classname.length || whitespace.includes(classname[b]))) {
+              classname = (a === 0 ? "" : classname.substring(0, a)) + classname.substring(b + 1);
+            } else {
+              a = b;
+            }
+          }
+        }
+      }
     }
     return classname === "" ? null : classname;
   }
@@ -3550,7 +3581,7 @@ get_first_child(node2)
   function set_class(dom, is_html, value, hash, prev_classes, next_classes) {
     var prev = dom.__className;
     if (prev !== value || prev === void 0) {
-      var next_class_name = to_class(value, hash);
+      var next_class_name = to_class(value, hash, next_classes);
       {
         if (next_class_name == null) {
           dom.removeAttribute("class");
@@ -3559,6 +3590,13 @@ get_first_child(node2)
         }
       }
       dom.__className = value;
+    } else if (next_classes && prev_classes !== next_classes) {
+      for (var key in next_classes) {
+        var is_present = !!next_classes[key];
+        if (prev_classes == null || is_present !== !!prev_classes[key]) {
+          dom.classList.toggle(key, is_present);
+        }
+      }
     }
     return next_classes;
   }
@@ -3933,6 +3971,23 @@ previous_batch ?? current_batch
       }
     });
   }
+  function bind_checked(input, get2, set2 = get2) {
+    listen_to_event_and_reset_event(input, "change", (is_reset) => {
+      var value = is_reset ? input.defaultChecked : input.checked;
+      set2(value);
+    });
+    if (
+
+
+untrack(get2) == null
+    ) {
+      set2(input.checked);
+    }
+    render_effect(() => {
+      var value = get2();
+      input.checked = Boolean(value);
+    });
+  }
   function is_numberlike_input(input) {
     var type = input.type;
     return type === "number" || type === "range";
@@ -4167,12 +4222,12 @@ context.l
     ((window.__svelte ??= {}).v ??= new Set()).add(PUBLIC_VERSION);
   }
   enable_legacy_mode_flag();
-  var root$5 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
+  var root$6 = from_html(`<div class="loadership_ZOJAQ svelte-f4erjd"><div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div> <div class="svelte-f4erjd"></div></div>`);
   function Spinner($$anchor) {
-    var div = root$5();
+    var div = root$6();
     append($$anchor, div);
   }
-  var root_1$2 = from_html(`<img class="fi svelte-tdzec4"/>`);
+  var root_1$3 = from_html(`<img class="fi svelte-tdzec4"/>`);
   function CountryFlag($$anchor, $$props) {
     const countryCodes = {
       Afghanistan: "af",
@@ -4380,7 +4435,7 @@ context.l
     var node = first_child(fragment);
     {
       var consequent = ($$anchor2) => {
-        var img = root_1$2();
+        var img = root_1$3();
         template_effect(
           ($0) => {
             set_attribute(img, "alt", $$props.countryName);
@@ -4480,11 +4535,11 @@ context.l
       _unsafeWindow.localStorage.setItem(heightKey, Math.floor(containerHeight).toString());
     }
   }
-  var root_4$1 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
-  var root_3$1 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
-  var root_6$2 = from_html(`<button></button>`);
-  var root_5$2 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
-  var root$4 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
+  var root_4$2 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
+  var root_3$2 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
+  var root_6$3 = from_html(`<button></button>`);
+  var root_5$3 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
+  var root$5 = from_html(`<div class="carousel svelte-8ojyxu"><!> <!></div>`);
   function Carousel($$anchor, $$props) {
     push($$props, false);
     let images = prop($$props, "images", 24, () => []);
@@ -4515,7 +4570,7 @@ context.l
       set(lensY, event2.clientY - rect.top);
     }
     init();
-    var div = root$4();
+    var div = root$5();
     var node = child(div);
     {
       var consequent_2 = ($$anchor2) => {
@@ -4526,7 +4581,7 @@ context.l
           var node_2 = first_child(fragment_1);
           {
             var consequent_1 = ($$anchor4) => {
-              var div_1 = root_3$1();
+              var div_1 = root_3$2();
               div_1.__mousemove = handleMouseMove;
               var img = child(div_1);
               set_attribute(img, "alt", `Image ${index2 + 1}`);
@@ -4534,7 +4589,7 @@ context.l
               var node_3 = sibling(img, 2);
               {
                 var consequent = ($$anchor5) => {
-                  var div_2 = root_4$1();
+                  var div_2 = root_4$2();
                   template_effect(() => set_style(div_2, `
                 /* Position the lens so the mouse is in its center */
                 top: ${get(lensY) - lensSize / 2}px;
@@ -4573,7 +4628,7 @@ context.l
     var node_4 = sibling(node, 2);
     {
       var consequent_3 = ($$anchor2) => {
-        var fragment_2 = root_5$2();
+        var fragment_2 = root_5$3();
         var div_3 = first_child(fragment_2);
         var button = child(div_3);
         button.__click = prev;
@@ -4581,7 +4636,7 @@ context.l
         button_1.__click = next;
         var div_4 = sibling(div_3, 2);
         each(div_4, 5, images, index, ($$anchor3, _, index2) => {
-          var button_2 = root_6$2();
+          var button_2 = root_6$3();
           set_attribute(button_2, "aria-label", `Switch to image ${index2 + 1}`);
           button_2.__click = () => set(currentIndex, index2);
           template_effect(() => set_class(button_2, 1, `indicator ${index2 === get(currentIndex) ? "active" : ""}`, "svelte-8ojyxu"));
@@ -4701,18 +4756,18 @@ context.l
       console.warn("LocalStorage Error: Could not save last dismissed announcement timestamp.", e);
     }
   }
-  var root_2$1 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
-  var root_3 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
-  var root_6$1 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
-  var root_7 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
-  var root_5$1 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
-  var root_9 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
-  var root_11 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
+  var root_2$2 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
+  var root_3$1 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
+  var root_6$2 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
+  var root_7$1 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
+  var root_5$2 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
+  var root_9$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
+  var root_11$1 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
   var root_10 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
               on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View Map meta list:</strong> Click the list icon to see all the metas included
               in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the Community:</strong> Click the Discord icon to share feedback, suggest
               improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-1j2rmt2">Close</button></div></div>`);
-  var root$3 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-1j2rmt2"><span></span></button></div></div> <!> <!> <!></div>`);
+  var root$4 = from_html(`<div class="geometa-container svelte-1j2rmt2"><!> <div class="flex header svelte-1j2rmt2"><h2 class="svelte-1j2rmt2">Learnable Meta</h2> <div class="icons svelte-1j2rmt2"><a target="_blank" aria-label="List of map metas" class="svelte-1j2rmt2"><span class="skill-icons--list svelte-1j2rmt2"></span></a> <a href="https://learnablemeta.com/" target="_blank" aria-label="Learnable Meta website" class="svelte-1j2rmt2"><span class="flat-color-icons--globe svelte-1j2rmt2"></span></a> <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord" class="svelte-1j2rmt2"><span class="skill-icons--discord svelte-1j2rmt2"></span></a> <button aria-label="More information" style="background: none; border: none; padding: 0;" class="svelte-1j2rmt2"><span></span></button></div></div> <!> <!> <!></div>`);
   function App($$anchor, $$props) {
     push($$props, true);
     let geoInfo = state(null);
@@ -4824,14 +4879,14 @@ context.l
       }
     });
     let lastDismissedTimestamp = state(proxy(getLastDismissedAnnouncementTimestamp()));
-    var div = root$3();
+    var div = root$4();
     var node = child(div);
     await_block(node, getAnnouncement, null, ($$anchor2, announcement) => {
       var fragment = comment();
       var node_1 = first_child(fragment);
       {
         var consequent = ($$anchor3) => {
-          var div_1 = root_2$1();
+          var div_1 = root_2$2();
           var div_2 = child(div_1);
           var node_2 = child(div_2);
           html(node_2, () => get(announcement).htmlMessage);
@@ -4858,7 +4913,7 @@ context.l
     var node_3 = sibling(div_3, 2);
     {
       var consequent_1 = ($$anchor2) => {
-        var p = root_3();
+        var p = root_3$1();
         var text = child(p);
         template_effect(() => set_text(text, `Error: ${get(error) ?? ""}`));
         append($$anchor2, p);
@@ -4868,7 +4923,7 @@ context.l
         var node_4 = first_child(fragment_1);
         {
           var consequent_4 = ($$anchor3) => {
-            var fragment_2 = root_5$1();
+            var fragment_2 = root_5$2();
             var p_1 = first_child(fragment_2);
             var node_5 = child(p_1);
             CountryFlag(node_5, {
@@ -4885,7 +4940,7 @@ context.l
             var node_7 = sibling(div_5, 2);
             {
               var consequent_2 = ($$anchor4) => {
-                var p_2 = root_6$1();
+                var p_2 = root_6$2();
                 var node_8 = child(p_2);
                 html(node_8, () => get(geoInfo).footer);
                 append($$anchor4, p_2);
@@ -4897,7 +4952,7 @@ context.l
             var node_9 = sibling(node_7, 2);
             {
               var consequent_3 = ($$anchor4) => {
-                var fragment_3 = root_7();
+                var fragment_3 = root_7$1();
                 var node_10 = sibling(first_child(fragment_3), 2);
                 Carousel(node_10, {
                   get images() {
@@ -4938,7 +4993,7 @@ context.l
     var node_11 = sibling(node_3, 2);
     {
       var consequent_5 = ($$anchor2) => {
-        var div_6 = root_9();
+        var div_6 = root_9$1();
         var div_7 = child(div_6);
         var p_3 = sibling(child(div_7), 2);
         var text_3 = child(p_3);
@@ -4963,7 +5018,7 @@ context.l
         var node_13 = child(div_11);
         {
           var consequent_6 = ($$anchor3) => {
-            var p_4 = root_11();
+            var p_4 = root_11$1();
             var strong_1 = child(p_4);
             var text_4 = child(strong_1);
             template_effect(($0) => set_text(text_4, `Your script version is out of date - please install the latest version (${$0 ?? ""})!`), [getLatestVersionInfo]);
@@ -5227,9 +5282,9 @@ roundNumber: 4,
       return result;
     };
   }
-  var root$2 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
+  var root$3 = from_html(`<div class="geometa-map-label-container svelte-1y99qco"><p class="svelte-1y99qco">LearnableMeta Enabled</p> <a target="_blank"><button class="svelte-1y99qco">Meta List</button></a></div>`);
   function MapLabel($$anchor, $$props) {
-    var div = root$2();
+    var div = root$3();
     var a = sibling(child(div), 2);
     template_effect(() => set_attribute(a, "href", `https://learnablemeta.com/maps/${$$props.mapId}`));
     append($$anchor, div);
@@ -5279,6 +5334,64 @@ roundNumber: 4,
       }
     });
   }
+  class LearnableMetaApiError extends Error {
+    constructor(status, message) {
+      super(message);
+      this.status = status;
+      this.name = "LearnableMetaApiError";
+    }
+  }
+  function requestJson(url, apiToken) {
+    return new Promise((resolve, reject) => {
+      _GM_xmlhttpRequest({
+        method: "GET",
+        url,
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json"
+        },
+        timeout: 15e3,
+        onload: (response) => {
+          let body;
+          try {
+            body = response.responseText ? JSON.parse(response.responseText) : null;
+          } catch {
+            body = response.responseText;
+          }
+          if (response.status >= 200 && response.status < 300) {
+            resolve(body);
+            return;
+          }
+          const apiMessage = body && typeof body === "object" && "message" in body ? String(body.message) : response.statusText || "Request failed";
+          reject(
+            new LearnableMetaApiError(
+              response.status,
+              `LearnableMeta API error (${response.status}): ${apiMessage}`
+            )
+          );
+        },
+        onerror: () => reject(new LearnableMetaApiError(0, "Could not reach LearnableMeta")),
+        ontimeout: () => reject(new LearnableMetaApiError(0, "LearnableMeta request timed out"))
+      });
+    });
+  }
+  function fetchMapGroupManifest(groupId, apiToken) {
+    return requestJson(
+      `https://learnablemeta.com/api/userscript/map-group/${groupId}/maps`,
+      apiToken
+    );
+  }
+  async function fetchSyncedMapLocations(geoguessrId, apiToken, expectedFingerprint) {
+    const query = expectedFingerprint ? `?expectedFingerprint=${encodeURIComponent(expectedFingerprint)}` : "";
+    const data = await requestJson(
+      `https://learnablemeta.com/api/userscript/map/${geoguessrId}/locations${query}`,
+      apiToken
+    );
+    if (!Array.isArray(data.customCoordinates)) {
+      throw new LearnableMetaApiError(0, "Received invalid map location data");
+    }
+    return data.customCoordinates;
+  }
   async function geoguessrAPIFetch(url, options = {}) {
     const { method = "GET", headers: initialHeaders, body, ...restOptions } = options;
     const effectiveHeaders = new Headers(initialHeaders);
@@ -5321,21 +5434,45 @@ roundNumber: 4,
     }
     return response;
   }
+  function draftUrl(geoguessrId) {
+    return `https://www.geoguessr.com/api/v4/user-maps/drafts/${geoguessrId}`;
+  }
+  async function getGeoguessrDraft(geoguessrId) {
+    const response = await geoguessrAPIFetch(draftUrl(geoguessrId));
+    return response.json();
+  }
+  async function updateGeoguessrDraft(geoguessrId, draft, customCoordinates) {
+    const { avatar, description, highlighted, name, version } = draft;
+    await geoguessrAPIFetch(draftUrl(geoguessrId), {
+      method: "PUT",
+      body: JSON.stringify({
+        avatar,
+        description,
+        highlighted,
+        name,
+        customCoordinates,
+        version: version + 1
+      })
+    });
+  }
+  async function publishGeoguessrDraft(geoguessrId) {
+    await geoguessrAPIFetch(`${draftUrl(geoguessrId)}/publish`, {
+      method: "PUT",
+      body: JSON.stringify({})
+    });
+  }
   async function uploadLocations(geoguessrId, apiKey) {
-    const geoguessrDraftApiUrl = `https://www.geoguessr.com/api/v4/user-maps/drafts/${geoguessrId}`;
     let geoguessrMapDetails;
     try {
-      const response = await geoguessrAPIFetch(geoguessrDraftApiUrl);
-      geoguessrMapDetails = await response.json();
+      geoguessrMapDetails = await getGeoguessrDraft(geoguessrId);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to fetch Geoguessr map info:", error);
       throw new Error(`Geoguessr Error: Could not fetch map details. ${errorMessage}`);
     }
-    const { avatar, description, highlighted, name, version } = geoguessrMapDetails;
     let locationsToUpload;
     try {
-      locationsToUpload = await fetchMapLocationsGM(geoguessrId, apiKey);
+      locationsToUpload = await fetchSyncedMapLocations(geoguessrId, apiKey);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to fetch map locations from backend:", error);
@@ -5346,19 +5483,8 @@ roundNumber: 4,
       console.warn(errorMessage);
       throw new Error(errorMessage);
     }
-    const mapDataToUpload = {
-      avatar,
-      description,
-      highlighted,
-      name,
-      customCoordinates: locationsToUpload,
-      version: version + 1
-    };
     try {
-      await geoguessrAPIFetch(geoguessrDraftApiUrl, {
-        method: "PUT",
-        body: JSON.stringify(mapDataToUpload)
-      });
+      await updateGeoguessrDraft(geoguessrId, geoguessrMapDetails, locationsToUpload);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to update Geoguessr map draft:", error);
@@ -5366,83 +5492,12 @@ roundNumber: 4,
     }
     try {
       console.log("Publishing Geoguessr map...");
-      await geoguessrAPIFetch(`${geoguessrDraftApiUrl}/publish`, {
-        method: "PUT",
-        body: JSON.stringify({})
-      });
+      await publishGeoguessrDraft(geoguessrId);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to publish Geoguessr map:", error);
       throw new Error(`Geoguessr Error: Could not publish map. ${errorMessage}`);
     }
-  }
-  function fetchMapLocationsGM(geoguessrId, apiToken) {
-    return new Promise((resolve, reject) => {
-      const apiUrl = `https://learnablemeta.com/api/userscript/map/${geoguessrId}/locations`;
-      _GM_xmlhttpRequest({
-        method: "GET",
-        url: apiUrl,
-        headers: {
-          Authorization: `Bearer ${apiToken}`,
-          "Content-Type": "application/json"
-        },
-        timeout: 15e3,
-onload: (response) => {
-          if (response.status >= 200 && response.status < 300) {
-            try {
-              const data = JSON.parse(response.responseText);
-              if (data && Array.isArray(data.customCoordinates)) {
-                resolve(data.customCoordinates);
-              } else {
-                console.error("Unexpected data structure from backend:", data);
-                reject(new Error("Received invalid location data structure from backend."));
-              }
-            } catch (parseError) {
-              console.error(
-                "Error parsing JSON response from backend:",
-                parseError,
-                response.responseText
-              );
-              reject(
-                new Error(
-                  `Backend Error: Failed to parse location data: ${parseError.message.substring(0, 100)}`
-                )
-              );
-            }
-          } else {
-            let errorMessage = `Backend Error (${response.status}): ${response.statusText || "Failed to fetch locations"}`;
-            let rawErrorResponse = response.responseText;
-            try {
-              const parsedJsonError = JSON.parse(response.responseText);
-              if (parsedJsonError && parsedJsonError.message) {
-                errorMessage = `Backend Error (${response.status}): ${parsedJsonError.message}`;
-              } else if (parsedJsonError) {
-                errorMessage = `Backend Error (${response.status}): ${JSON.stringify(parsedJsonError).substring(0, 100)}...`;
-              }
-              rawErrorResponse = parsedJsonError;
-            } catch (e) {
-              if (response.responseText) {
-                errorMessage = `Backend Error (${response.status}): ${response.responseText.substring(0, 100)}...`;
-              }
-            }
-            console.error(
-              `Error fetching map locations from backend (Status: ${response.status}):`,
-              rawErrorResponse
-            );
-            reject(new Error(errorMessage));
-          }
-        },
-        onerror: (error) => {
-          console.error("Failed to fetch map locations (XHR onerror):", error);
-          let detail = error.error || error.statusText || "Network request failed";
-          reject(new Error(`Network Error: Could not reach backend to fetch locations. ${detail}`));
-        },
-        ontimeout: () => {
-          console.error("Failed to fetch map locations: Request timed out", apiUrl);
-          reject(new Error("Backend Timeout: Request to fetch locations timed out."));
-        }
-      });
-    });
   }
   const linear = (x) => x;
   function fade(node, { delay = 0, duration = 400, easing = linear } = {}) {
@@ -5454,18 +5509,18 @@ onload: (response) => {
       css: (t) => `opacity: ${t * o}`
     };
   }
-  var root_1$1 = from_html(`<span class="toast-detail svelte-w17ltc"> </span>`);
-  var root$1 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
+  var root_1$2 = from_html(`<span class="toast-detail svelte-w17ltc"> </span>`);
+  var root$2 = from_html(`<div role="alert"><div class="toast-content svelte-w17ltc"><span class="toast-message"> </span> <!></div> <button class="toast-close-button svelte-w17ltc" aria-label="Close">×</button></div>`);
   function ToastNotification($$anchor, $$props) {
     let type = prop($$props, "type", 3, "info");
-    var div = root$1();
+    var div = root$2();
     var div_1 = child(div);
     var span = child(div_1);
     var text = child(span);
     var node = sibling(span, 2);
     {
       var consequent = ($$anchor2) => {
-        var span_1 = root_1$1();
+        var span_1 = root_1$2();
         var text_1 = child(span_1);
         template_effect(() => set_text(text_1, $$props.detail));
         append($$anchor2, span_1);
@@ -5487,17 +5542,27 @@ onload: (response) => {
     append($$anchor, div);
   }
   delegate(["click"]);
-  var root_2 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
-  var root_4 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
+  const API_KEY_STORAGE_NAME = "learnableMeta_apiKey";
+  const URL_TO_GENERATE_TOKEN = "https://learnablemeta.com/profile/token";
+  function getApiKey() {
+    const key = _GM_getValue(API_KEY_STORAGE_NAME, null);
+    return key?.trim() || null;
+  }
+  function saveApiKey(key) {
+    _GM_setValue(API_KEY_STORAGE_NAME, key.trim());
+  }
+  function clearApiKey() {
+    _GM_setValue(API_KEY_STORAGE_NAME, "");
+  }
+  var root_2$1 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
+  var root_4$1 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
           to replace it, or clear the saved key.</p>`);
-  var root_5 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
-  var root_6 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
-  var root_1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
-  var root = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="custom-yellow-button svelte-1plj3lz"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
+  var root_5$1 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
+  var root_6$1 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
+  var root_1$1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
+  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="custom-yellow-button svelte-1plj3lz"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
-    const API_KEY_STORAGE_NAME = "learnableMeta_apiKey";
-    const URL_TO_GENERATE_TOKEN = "https://learnablemeta.com/profile/token";
     let showApiKeyModal = state(false);
     let modalMode = state("upload");
     let apiKeyInput = state("");
@@ -5535,7 +5600,7 @@ onload: (response) => {
     }
     function getApiKeyFromGM() {
       try {
-        return _GM_getValue(API_KEY_STORAGE_NAME, null);
+        return getApiKey();
       } catch (e) {
         console.warn("GM_getValue is not available. API key functionality might be limited.", e);
         showCustomToast("Userscript storage (GM_getValue) is not available. Please ensure Tampermonkey/Violentmonkey is correctly configured.", "error", 0);
@@ -5544,7 +5609,7 @@ onload: (response) => {
     }
     function saveApiKeyToGM(key) {
       try {
-        _GM_setValue(API_KEY_STORAGE_NAME, key);
+        saveApiKey(key);
       } catch (e) {
         console.warn("GM_setValue is not available. API key functionality might be limited.", e);
         showCustomToast("Userscript storage (GM_setValue) is not available. Please ensure Tampermonkey/Violentmonkey is correctly configured.", "error", 0);
@@ -5571,7 +5636,7 @@ onload: (response) => {
       set(showApiKeyModal, true);
     }
     function handleClearApiKey() {
-      saveApiKeyToGM("");
+      clearApiKey();
       set(currentApiKey, null);
       set(showApiKeyModal, false);
       showCustomToast("LearnableMeta API Key cleared.", "success");
@@ -5614,7 +5679,7 @@ onload: (response) => {
       set(showApiKeyModal, false);
       set(apiKeyInput, "");
     }
-    var fragment = root();
+    var fragment = root$1();
     var div = first_child(fragment);
     var button = child(div);
     button.__click = handleUploadClick;
@@ -5624,12 +5689,12 @@ onload: (response) => {
     var node = sibling(div, 2);
     {
       var consequent_3 = ($$anchor2) => {
-        var div_1 = root_1();
+        var div_1 = root_1$1();
         var div_2 = child(div_1);
         var node_1 = sibling(child(div_2), 2);
         {
           var consequent = ($$anchor3) => {
-            var p = root_2();
+            var p = root_2$1();
             append($$anchor3, p);
           };
           var alternate_1 = ($$anchor3) => {
@@ -5637,14 +5702,14 @@ onload: (response) => {
             var node_2 = first_child(fragment_1);
             {
               var consequent_1 = ($$anchor4) => {
-                var p_1 = root_4();
+                var p_1 = root_4$1();
                 var code = sibling(child(p_1));
                 var text_1 = child(code);
                 template_effect(($0) => set_text(text_1, `…${$0 ?? ""}`), [() => get(currentApiKey).slice(-4)]);
                 append($$anchor4, p_1);
               };
               var alternate = ($$anchor4) => {
-                var p_2 = root_5();
+                var p_2 = root_5$1();
                 append($$anchor4, p_2);
               };
               if_block(
@@ -5665,13 +5730,12 @@ onload: (response) => {
         }
         var p_3 = sibling(node_1, 2);
         var a = sibling(child(p_3));
-        set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
         var input = sibling(p_3, 2);
         var div_3 = sibling(input, 2);
         var node_3 = child(div_3);
         {
           var consequent_2 = ($$anchor3) => {
-            var button_2 = root_6();
+            var button_2 = root_6$1();
             button_2.__click = handleClearApiKey;
             append($$anchor3, button_2);
           };
@@ -5684,7 +5748,10 @@ onload: (response) => {
         var text_2 = child(button_3);
         var button_4 = sibling(button_3, 2);
         button_4.__click = handleCancelModal;
-        template_effect(() => set_text(text_2, get(modalMode) === "upload" ? "Save & Upload" : "Save"));
+        template_effect(() => {
+          set_attribute(a, "href", URL_TO_GENERATE_TOKEN);
+          set_text(text_2, get(modalMode) === "upload" ? "Save & Upload" : "Save");
+        });
         bind_value(input, () => get(apiKeyInput), ($$value) => set(apiKeyInput, $$value));
         append($$anchor2, div_1);
       };
@@ -5731,7 +5798,7 @@ onload: (response) => {
       addLocationsUploadButtons();
     });
   }
-  const containerId = "geometa-locations-upload";
+  const containerId$1 = "geometa-locations-upload";
   let uploadApp = null;
   let runToken$1 = 0;
   function removeUploadButton() {
@@ -5739,7 +5806,7 @@ onload: (response) => {
       unmount(uploadApp);
       uploadApp = null;
     }
-    document.getElementById(containerId)?.remove();
+    document.getElementById(containerId$1)?.remove();
   }
   async function addLocationsUploadButtons() {
     const token = ++runToken$1;
@@ -5755,7 +5822,7 @@ onload: (response) => {
     const container = document.querySelector(".top-bar-menu_topBarMenu__kd9zX");
     if (container) {
       const target = document.createElement("div");
-      target.id = containerId;
+      target.id = containerId$1;
       container.insertBefore(target, container.lastElementChild);
       uploadApp = mount(UploadLocations, {
         target,
@@ -5814,6 +5881,468 @@ onload: (response) => {
       logInfo("failed to add meta pins on challenge results", e);
     }
   }
+  function canonicalizeMapCoordinates(coordinates) {
+    const tuples = coordinates.map(
+      ({ panoId, lat, lng, heading, pitch, zoom }) => [panoId, lat, lng, heading, pitch, zoom]
+    );
+    tuples.sort((left, right) => {
+      const leftJson = JSON.stringify(left);
+      const rightJson = JSON.stringify(right);
+      return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+    });
+    return JSON.stringify(tuples);
+  }
+  async function fingerprintMapCoordinates(coordinates) {
+    const bytes = new TextEncoder().encode(canonicalizeMapCoordinates(coordinates));
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
+  var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
+  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and scan</button></div></div>`);
+  var root_5 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
+  var root_6 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_9 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
+  var root_8 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
+  var root_7 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
+  var root_11 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
+  var root_12 = from_html(`<div class="summary svelte-axobi4"> </div>`);
+  var root_13 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
+  var root_4 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
+  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4">Update GeoGuessr maps</h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
+  function MapGroupUpdate($$anchor, $$props) {
+    push($$props, true);
+    let phase = state("scanning");
+    let apiToken = state("");
+    let tokenInput = state("");
+    let tokenError = state("");
+    let groupName = state("");
+    let rows = state(proxy([]));
+    let fatalError = state("");
+    let finishedRun = state(false);
+    let selectedCount = user_derived(() => get(rows).filter((row) => row.status === "changed" && row.selected).length);
+    let failureCount = user_derived(() => get(rows).filter((row) => ["scan-error", "update-error", "publish-error"].includes(row.status)).length);
+    let successCount = user_derived(() => get(rows).filter((row) => row.status === "success").length);
+    let changedCount = user_derived(() => get(rows).filter((row) => row.status === "changed").length);
+    onMount(() => {
+      try {
+        const savedToken = getApiKey();
+        if (!savedToken) {
+          set(phase, "token");
+          return;
+        }
+        set(apiToken, savedToken, true);
+        void scanGroup();
+      } catch (error) {
+        set(phase, "token");
+        set(tokenError, errorMessage(error), true);
+      }
+    });
+    function errorMessage(error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+    function replaceRow(geoguessrId, update) {
+      const index2 = get(rows).findIndex((row) => row.geoguessrId === geoguessrId);
+      if (index2 !== -1) get(rows)[index2] = { ...get(rows)[index2], ...update };
+    }
+    async function saveTokenAndScan() {
+      const trimmed = get(tokenInput).trim();
+      if (!trimmed) {
+        set(tokenError, "Paste a valid LearnableMeta API token.");
+        return;
+      }
+      saveApiKey(trimmed);
+      set(apiToken, trimmed, true);
+      set(tokenInput, "");
+      set(tokenError, "");
+      await scanGroup();
+    }
+    function changeToken() {
+      set(tokenInput, "");
+      set(tokenError, "");
+      set(phase, "token");
+    }
+    async function scanGroup() {
+      set(phase, "scanning");
+      set(fatalError, "");
+      set(finishedRun, false);
+      set(groupName, "");
+      set(rows, [], true);
+      try {
+        const manifest = await fetchMapGroupManifest($$props.groupId, get(apiToken));
+        set(groupName, manifest.group.name, true);
+        set(
+          rows,
+          manifest.maps.map((map) => ({
+            ...map,
+            status: map.locationCount === 0 ? "empty" : "scanning",
+            selected: false
+          })),
+          true
+        );
+        let nextIndex = 0;
+        async function worker() {
+          while (nextIndex < get(rows).length) {
+            const row = get(rows)[nextIndex++];
+            if (row.status === "scanning") await scanMap(row);
+          }
+        }
+        await Promise.all(Array.from({ length: Math.min(3, get(rows).length) }, () => worker()));
+        set(phase, "review");
+      } catch (error) {
+        if (error instanceof LearnableMetaApiError && error.status === 401) {
+          clearApiKey();
+          set(apiToken, "");
+          set(tokenError, "Your LearnableMeta API token was rejected. Paste a new token.");
+          set(phase, "token");
+          return;
+        }
+        set(fatalError, errorMessage(error), true);
+        set(phase, "review");
+      }
+    }
+    async function scanMap(row) {
+      replaceRow(row.geoguessrId, { status: "scanning", error: void 0, selected: false });
+      try {
+        const draft = await getGeoguessrDraft(row.geoguessrId);
+        const fingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        const changed = fingerprint !== row.fingerprint;
+        replaceRow(row.geoguessrId, { status: changed ? "changed" : "current", selected: changed });
+      } catch (error) {
+        replaceRow(row.geoguessrId, {
+          status: "scan-error",
+          selected: false,
+          error: errorMessage(error)
+        });
+      }
+    }
+    function selectChanged(selected) {
+      set(rows, get(rows).map((row) => row.status === "changed" ? { ...row, selected } : row), true);
+    }
+    async function updateSelected() {
+      const selectedIds = get(rows).filter((row) => row.status === "changed" && row.selected).map((row) => row.geoguessrId);
+      if (selectedIds.length === 0) return;
+      set(phase, "updating");
+      set(finishedRun, false);
+      for (const geoguessrId of selectedIds) {
+        const row = get(rows).find((candidate) => candidate.geoguessrId === geoguessrId);
+        if (row) await updateMap(row);
+      }
+      set(finishedRun, true);
+      set(phase, "review");
+    }
+    async function updateMap(row) {
+      replaceRow(row.geoguessrId, { status: "updating", error: void 0 });
+      let draft;
+      try {
+        draft = await getGeoguessrDraft(row.geoguessrId);
+        const currentFingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        if (currentFingerprint === row.fingerprint) {
+          replaceRow(row.geoguessrId, { status: "current", selected: false });
+          return;
+        }
+        const coordinates = await fetchSyncedMapLocations(row.geoguessrId, get(apiToken), row.fingerprint);
+        if (coordinates.length === 0) throw new Error("Cannot publish an empty map");
+        await updateGeoguessrDraft(row.geoguessrId, draft, coordinates);
+      } catch (error) {
+        replaceRow(row.geoguessrId, { status: "update-error", error: errorMessage(error) });
+        return;
+      }
+      replaceRow(row.geoguessrId, { status: "publishing" });
+      try {
+        await publishGeoguessrDraft(row.geoguessrId);
+        replaceRow(row.geoguessrId, { status: "success", selected: false });
+      } catch (error) {
+        replaceRow(row.geoguessrId, { status: "publish-error", error: errorMessage(error) });
+      }
+    }
+    async function retryFailures() {
+      set(phase, "updating");
+      set(finishedRun, false);
+      const failedIds = get(rows).filter((row) => ["scan-error", "update-error", "publish-error"].includes(row.status)).map((row) => row.geoguessrId);
+      for (const geoguessrId of failedIds) {
+        const row = get(rows).find((candidate) => candidate.geoguessrId === geoguessrId);
+        if (!row) continue;
+        if (row.status === "scan-error") {
+          await scanMap(row);
+        } else if (row.status === "publish-error") {
+          replaceRow(row.geoguessrId, { status: "publishing", error: void 0 });
+          try {
+            await publishGeoguessrDraft(row.geoguessrId);
+            replaceRow(row.geoguessrId, { status: "success", selected: false });
+          } catch (error) {
+            replaceRow(row.geoguessrId, { status: "publish-error", error: errorMessage(error) });
+          }
+        } else {
+          await updateMap(row);
+        }
+      }
+      set(finishedRun, true);
+      set(phase, "review");
+    }
+    function statusLabel(row) {
+      const labels = {
+        scanning: "Checking…",
+        changed: "Update available",
+        current: "Up to date",
+        empty: "No synchronized locations",
+        "scan-error": "Could not check",
+        updating: "Updating draft…",
+        publishing: "Publishing…",
+        success: "Updated and published",
+        "update-error": "Update failed",
+        "publish-error": "Draft updated; publish failed"
+      };
+      return labels[row.status];
+    }
+    var div = root();
+    var div_1 = child(div);
+    var header = child(div_1);
+    var div_2 = child(header);
+    var node = sibling(child(div_2), 4);
+    {
+      var consequent = ($$anchor2) => {
+        var p = root_1();
+        var text = child(p);
+        template_effect(() => set_text(text, get(groupName)));
+        append($$anchor2, p);
+      };
+      if_block(node, ($$render) => {
+        if (get(groupName)) $$render(consequent);
+      });
+    }
+    var button = sibling(div_2, 2);
+    button.__click = function(...$$args) {
+      $$props.onClose?.apply(this, $$args);
+    };
+    var node_1 = sibling(header, 2);
+    {
+      var consequent_2 = ($$anchor2) => {
+        var div_3 = root_2();
+        var p_1 = sibling(child(div_3), 2);
+        var a = sibling(child(p_1));
+        var input = sibling(p_1, 2);
+        input.__keydown = (event2) => event2.key === "Enter" && void saveTokenAndScan();
+        var node_2 = sibling(input, 2);
+        {
+          var consequent_1 = ($$anchor3) => {
+            var p_2 = root_3();
+            var text_1 = child(p_2);
+            template_effect(() => set_text(text_1, get(tokenError)));
+            append($$anchor3, p_2);
+          };
+          if_block(node_2, ($$render) => {
+            if (get(tokenError)) $$render(consequent_1);
+          });
+        }
+        var div_4 = sibling(node_2, 2);
+        var button_1 = child(div_4);
+        button_1.__click = function(...$$args) {
+          $$props.onClose?.apply(this, $$args);
+        };
+        var button_2 = sibling(button_1, 2);
+        button_2.__click = saveTokenAndScan;
+        template_effect(() => set_attribute(a, "href", URL_TO_GENERATE_TOKEN));
+        bind_value(input, () => get(tokenInput), ($$value) => set(tokenInput, $$value));
+        append($$anchor2, div_3);
+      };
+      var alternate_1 = ($$anchor2) => {
+        var fragment = root_4();
+        var node_3 = first_child(fragment);
+        {
+          var consequent_3 = ($$anchor3) => {
+            var div_5 = root_5();
+            append($$anchor3, div_5);
+          };
+          if_block(node_3, ($$render) => {
+            if (get(phase) === "scanning") $$render(consequent_3);
+          });
+        }
+        var node_4 = sibling(node_3, 2);
+        {
+          var consequent_4 = ($$anchor3) => {
+            var div_6 = root_6();
+            var span = sibling(child(div_6), 2);
+            var text_2 = child(span);
+            var button_3 = sibling(span, 2);
+            button_3.__click = scanGroup;
+            template_effect(() => set_text(text_2, get(fatalError)));
+            append($$anchor3, div_6);
+          };
+          if_block(node_4, ($$render) => {
+            if (get(fatalError)) $$render(consequent_4);
+          });
+        }
+        var node_5 = sibling(node_4, 2);
+        {
+          var consequent_6 = ($$anchor3) => {
+            var fragment_1 = root_7();
+            var div_7 = first_child(fragment_1);
+            var span_1 = child(div_7);
+            var text_3 = child(span_1);
+            var div_8 = sibling(span_1, 2);
+            var button_4 = child(div_8);
+            button_4.__click = () => selectChanged(true);
+            var button_5 = sibling(button_4, 2);
+            button_5.__click = () => selectChanged(false);
+            var div_9 = sibling(div_7, 2);
+            each(div_9, 21, () => get(rows), (row) => row.geoguessrId, ($$anchor4, row, $$index) => {
+              var label = root_8();
+              let classes;
+              var input_1 = child(label);
+              var span_2 = sibling(input_1, 2);
+              var strong = child(span_2);
+              var text_4 = child(strong);
+              var span_3 = sibling(strong, 2);
+              var text_5 = child(span_3);
+              var node_6 = sibling(span_3, 2);
+              {
+                var consequent_5 = ($$anchor5) => {
+                  var span_4 = root_9();
+                  var text_6 = child(span_4);
+                  template_effect(() => set_text(text_6, get(row).error));
+                  append($$anchor5, span_4);
+                };
+                if_block(node_6, ($$render) => {
+                  if (get(row).error) $$render(consequent_5);
+                });
+              }
+              var span_5 = sibling(span_2, 2);
+              let classes_1;
+              var text_7 = child(span_5);
+              template_effect(
+                ($0, $1) => {
+                  classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
+                  input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
+                  set_text(text_4, get(row).name);
+                  set_text(text_5, `${$0 ?? ""} synchronized locations`);
+                  classes_1 = set_class(span_5, 1, "status svelte-axobi4", null, classes_1, {
+                    good: get(row).status === "current" || get(row).status === "success"
+                  });
+                  set_text(text_7, $1);
+                },
+                [
+                  () => get(row).locationCount.toLocaleString(),
+                  () => statusLabel(get(row))
+                ]
+              );
+              bind_checked(input_1, () => get(row).selected, ($$value) => get(row).selected = $$value);
+              append($$anchor4, label);
+            });
+            template_effect(() => set_text(text_3, `${get(rows).length ?? ""} map${get(rows).length === 1 ? "" : "s"}`));
+            append($$anchor3, fragment_1);
+          };
+          var alternate = ($$anchor3) => {
+            var fragment_2 = comment();
+            var node_7 = first_child(fragment_2);
+            {
+              var consequent_7 = ($$anchor4) => {
+                var div_10 = root_11();
+                append($$anchor4, div_10);
+              };
+              if_block(
+                node_7,
+                ($$render) => {
+                  if (get(phase) === "review" && !get(fatalError)) $$render(consequent_7);
+                },
+                true
+              );
+            }
+            append($$anchor3, fragment_2);
+          };
+          if_block(node_5, ($$render) => {
+            if (get(rows).length > 0) $$render(consequent_6);
+            else $$render(alternate, false);
+          });
+        }
+        var node_8 = sibling(node_5, 2);
+        {
+          var consequent_8 = ($$anchor3) => {
+            var div_11 = root_12();
+            var text_8 = child(div_11);
+            template_effect(() => set_text(text_8, `Finished: ${get(successCount) ?? ""} published, ${get(failureCount) ?? ""} failed, ${get(changedCount) ?? ""} still available.`));
+            append($$anchor3, div_11);
+          };
+          if_block(node_8, ($$render) => {
+            if (get(finishedRun)) $$render(consequent_8);
+          });
+        }
+        var footer = sibling(node_8, 2);
+        var button_6 = child(footer);
+        button_6.__click = changeToken;
+        var button_7 = sibling(button_6, 2);
+        button_7.__click = function(...$$args) {
+          $$props.onClose?.apply(this, $$args);
+        };
+        var node_9 = sibling(button_7, 2);
+        {
+          var consequent_9 = ($$anchor3) => {
+            var button_8 = root_13();
+            button_8.__click = retryFailures;
+            var text_9 = child(button_8);
+            template_effect(() => {
+              button_8.disabled = get(phase) === "updating";
+              set_text(text_9, `Retry failed (${get(failureCount) ?? ""})`);
+            });
+            append($$anchor3, button_8);
+          };
+          if_block(node_9, ($$render) => {
+            if (get(failureCount) > 0) $$render(consequent_9);
+          });
+        }
+        var button_9 = sibling(node_9, 2);
+        button_9.__click = updateSelected;
+        var text_10 = child(button_9);
+        template_effect(() => {
+          button_6.disabled = get(phase) === "updating";
+          button_7.disabled = get(phase) === "updating";
+          button_9.disabled = get(phase) !== "review" || get(selectedCount) === 0;
+          set_text(text_10, get(phase) === "updating" ? "Updating…" : `Update and publish (${get(selectedCount)})`);
+        });
+        append($$anchor2, fragment);
+      };
+      if_block(node_1, ($$render) => {
+        if (get(phase) === "token") $$render(consequent_2);
+        else $$render(alternate_1, false);
+      });
+    }
+    template_effect(() => button.disabled = get(phase) === "updating");
+    append($$anchor, div);
+    pop();
+  }
+  delegate(["click", "keydown"]);
+  const queryParameter = "learnableMetaGroupId";
+  const containerId = "learnablemeta-map-group-update";
+  let app = null;
+  function clearHandoffParameter() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(queryParameter);
+    window.history.replaceState(window.history.state, "", url);
+  }
+  function startMapGroupUpdate(groupId) {
+    if (!Number.isSafeInteger(groupId) || groupId <= 0 || app) return;
+    const target = document.createElement("div");
+    target.id = containerId;
+    document.body.appendChild(target);
+    app = mount(MapGroupUpdate, {
+      target,
+      props: {
+        groupId,
+        onClose: () => {
+          if (app) unmount(app);
+          app = null;
+          target.remove();
+          clearHandoffParameter();
+        }
+      }
+    });
+  }
+  function initMapGroupUpdate() {
+    if (!window.location.pathname.startsWith("/creator-hub")) return;
+    const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
+    if (!rawGroupId) return;
+    startMapGroupUpdate(Number(rawGroupId));
+  }
   if (typeof _GM_registerMenuCommand === "function") {
     _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", () => {
       if (confirm("Reset the LearnableMeta window position and size?")) {
@@ -5835,7 +6364,8 @@ onload: (response) => {
       ["liveChallenge", initLiveChallenge],
       ["mapLabel", initMapLabel],
       ["locationsUpload", initLocationsUpload],
-      ["challengeResults", initChallengeResults]
+      ["challengeResults", initChallengeResults],
+      ["mapGroupUpdate", initMapGroupUpdate]
     ];
     for (const [name, init2] of features) {
       try {

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -26,6 +26,7 @@
 ## [0.91]
 
 - Added a post-sync group workflow that compares LearnableMeta locations with GeoGuessr drafts
+- Added a Creator Hub button for choosing any synchronized map group you can access
 - Added review and selection before updating changed maps
 - Added sequential draft updates, publishing, per-map progress, and retryable failures
 - Reused the browser-stored LearnableMeta API token so GeoGuessr credentials remain in the browser
@@ -176,9 +177,9 @@
 (async function () {
   'use strict';
 
-  const d=new Set;const e = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
+  const d=new Set;const importCSS = async e=>{d.has(e)||(d.add(e),(t=>{typeof GM_addStyle=="function"?GM_addStyle(t):(document.head||document.documentElement).appendChild(document.createElement("style")).append(t);})(e));};
 
-  e(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.custom-yellow-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.custom-yellow-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.custom-yellow-button.svelte-1plj3lz:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:0 2px 4px #0003 inset;transform:translateY(1px)}.custom-yellow-button.svelte-1plj3lz:focus{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.custom-yellow-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
+  importCSS(` .loadership_ZOJAQ.svelte-f4erjd{display:flex;position:relative;width:72px;height:72px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd){position:absolute;width:8px;height:8px;border-radius:50%;background:#fff;animation:svelte-f4erjd-loadership_ZOJAQ_scale 1.2s infinite,svelte-f4erjd-loadership_ZOJAQ_fade 1.2s infinite;animation-timing-function:linear}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(1){animation-delay:0s;top:62px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(2){animation-delay:-.1s;top:58px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(3){animation-delay:-.2s;top:47px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(4){animation-delay:-.3s;top:32px;left:62px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(5){animation-delay:-.4s;top:17px;left:58px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(6){animation-delay:-.5s;top:6px;left:47px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(7){animation-delay:-.6s;top:2px;left:32px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(8){animation-delay:-.7s;top:6px;left:17px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(9){animation-delay:-.8s;top:17px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(10){animation-delay:-.9s;top:32px;left:2px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(11){animation-delay:-1s;top:47px;left:6px}.loadership_ZOJAQ.svelte-f4erjd div:where(.svelte-f4erjd):nth-child(12){animation-delay:-1.1s;top:58px;left:17px}@keyframes svelte-f4erjd-loadership_ZOJAQ_scale{0%,20%,80%,to{transform:scale(1)}50%{transform:scale(1.5)}}@keyframes svelte-f4erjd-loadership_ZOJAQ_fade{0%,20%,80%,to{opacity:.8}50%{opacity:1}}.fi.svelte-tdzec4{width:1.5em;height:1em;display:inline-block;vertical-align:middle;padding-right:3px}.carousel.svelte-8ojyxu{position:relative;overflow:hidden;margin:0 auto}.image-wrapper.svelte-8ojyxu{width:100%;height:100%;display:flex;justify-content:center;align-items:center;cursor:zoom-in}.responsive-image.svelte-8ojyxu{max-width:100%;height:100%;display:block;object-fit:contain}.lens.svelte-8ojyxu{position:absolute;pointer-events:none;border:2px solid #aaa;border-radius:50%;box-shadow:0 0 8px #00000080}.click-area.svelte-8ojyxu{position:absolute;top:0;bottom:0;width:1.4em;cursor:pointer}.prev-area.svelte-8ojyxu{left:0}.next-area.svelte-8ojyxu{right:0}.prev.svelte-8ojyxu,.next.svelte-8ojyxu{background-color:#00000080;color:#fff;border:none;font-size:1.2em;padding:.2em;cursor:pointer;pointer-events:auto;position:absolute;top:50%;transform:translateY(-50%)}.prev.svelte-8ojyxu{left:0}.next.svelte-8ojyxu{right:0}.indicators.svelte-8ojyxu{position:absolute;bottom:15px;left:50%;transform:translate(-50%);display:flex;justify-content:center;align-items:center;gap:8px}.indicator.svelte-8ojyxu{width:12px;height:12px;background-color:#ffffff80;border-radius:50%;cursor:pointer;border:none;padding:0;flex-shrink:0}.indicator.active.svelte-8ojyxu{background-color:#fff}.geometa-footer a{color:#188bd2;text-decoration:none}.geometa-footer a:hover{text-decoration:underline}.geometa-container.svelte-1j2rmt2{position:absolute;top:13rem;left:1rem;z-index:50;display:flex;flex-direction:column;gap:5px;align-items:flex-start;background:var(--ds-color-purple-100, #1c1836);color:#fff;padding:6px 10px;border-radius:5px;font-size:17px;line-height:1.4;width:min(25%,500px);resize:both;overflow:auto}.geometa-container.svelte-1j2rmt2 h2:where(.svelte-1j2rmt2){margin:0;font-size:1.2rem;font-weight:700}.geometa-container.svelte-1j2rmt2 p{margin:0}.geometa-container.svelte-1j2rmt2 ul,.geometa-container.svelte-1j2rmt2 ol{margin:0;padding:0;list-style:none}.geometa-container.svelte-1j2rmt2>.header:where(.svelte-1j2rmt2){margin-top:0}.geometa-footer.svelte-1j2rmt2{color:#d3d3d3;font-size:small}.announcement.svelte-1j2rmt2{background-color:#e6f7ff;color:#0050b3;padding:8px 12px;border-radius:4px;font-size:14px;display:flex;justify-content:space-between;align-items:center;width:100%;box-sizing:border-box;margin-bottom:8px;border:1px solid #91d5ff}.announcement a{color:#0050b3;font-weight:700;text-decoration:underline}.announcement a:hover{color:#003a8c}.vote-close-btn.svelte-1j2rmt2{background-color:#b3d9ff;border:1px solid #0050b3;color:#0050b3;font-size:12px;cursor:pointer;padding:1px 10px;border-radius:4px;line-height:1;margin-left:5px;text-transform:none;transition:background-color .2s ease,color .2s ease,border-color .2s ease}.vote-close-btn.svelte-1j2rmt2:hover,.vote-close-btn.svelte-1j2rmt2:focus{background-color:#0050b3;color:#fff;border-color:#036;outline:none}a.svelte-1j2rmt2{color:#188bd2}a.svelte-1j2rmt2:hover{text-decoration:underline}.skill-icons--discord.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'%3E%3Cg fill='none'%3E%3Crect width='256' height='256' fill='%235865f2' rx='60'/%3E%3Cg clip-path='url(%23skillIconsDiscord0)'%3E%3Cpath fill='%23ffffff' d='M197.308 64.797a165 165 0 0 0-40.709-12.627a.62.62 0 0 0-.654.31c-1.758 3.126-3.706 7.206-5.069 10.412c-15.373-2.302-30.666-2.302-45.723 0c-1.364-3.278-3.382-7.286-5.148-10.412a.64.64 0 0 0-.655-.31a164.5 164.5 0 0 0-40.709 12.627a.6.6 0 0 0-.268.23c-25.928 38.736-33.03 76.52-29.546 113.836a.7.7 0 0 0 .26.468c17.106 12.563 33.677 20.19 49.94 25.245a.65.65 0 0 0 .702-.23c3.847-5.254 7.276-10.793 10.217-16.618a.633.633 0 0 0-.347-.881c-5.44-2.064-10.619-4.579-15.601-7.436a.642.642 0 0 1-.063-1.064a86 86 0 0 0 3.098-2.428a.62.62 0 0 1 .646-.088c32.732 14.944 68.167 14.944 100.512 0a.62.62 0 0 1 .655.08a80 80 0 0 0 3.106 2.436a.642.642 0 0 1-.055 1.064a102.6 102.6 0 0 1-15.609 7.428a.64.64 0 0 0-.339.889a133 133 0 0 0 10.208 16.61a.64.64 0 0 0 .702.238c16.342-5.055 32.913-12.682 50.02-25.245a.65.65 0 0 0 .26-.46c4.17-43.141-6.985-80.616-29.571-113.836a.5.5 0 0 0-.26-.238M94.834 156.142c-9.855 0-17.975-9.047-17.975-20.158s7.963-20.158 17.975-20.158c10.09 0 18.131 9.127 17.973 20.158c0 11.111-7.962 20.158-17.973 20.158m66.456 0c-9.855 0-17.974-9.047-17.974-20.158s7.962-20.158 17.974-20.158c10.09 0 18.131 9.127 17.974 20.158c0 11.111-7.884 20.158-17.974 20.158'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='skillIconsDiscord0'%3E%3Cpath fill='%23ffffff' d='M28 51h200v154.93H28z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/g%3E%3C/svg%3E")}.flat-color-icons--globe.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Cpath fill='%237cb342' d='M24 4C13 4 4 13 4 24s9 20 20 20s20-9 20-20S35 4 24 4'/%3E%3Cpath fill='%230277bd' d='M45 24c0 11.7-9.5 21-21 21S3 35.7 3 24S12.3 3 24 3s21 9.3 21 21m-21.2 9.7c0-.4-.2-.6-.6-.8c-1.3-.4-2.5-.4-3.6-1.5c-.2-.4-.2-.8-.4-1.3c-.4-.4-1.5-.6-2.1-.8h-4.2c-.6-.2-1.1-1.1-1.5-1.7c0-.2 0-.6-.4-.6c-.4-.2-.8.2-1.3 0c-.2-.2-.2-.4-.2-.6c0-.6.4-1.3.8-1.7c.6-.4 1.3.2 1.9.2c.2 0 .2 0 .4.2c.6.2.8 1 .8 1.7v.4c0 .2.2.2.4.2c.2-1.1.2-2.1.4-3.2c0-1.3 1.3-2.5 2.3-2.9c.4-.2.6.2 1.1 0c1.3-.4 4.4-1.7 3.8-3.4c-.4-1.5-1.7-2.9-3.4-2.7c-.4.2-.6.4-1 .6c-.6.4-1.9 1.7-2.5 1.7c-1.1-.2-1.1-1.7-.8-2.3c.2-.8 2.1-3.6 3.4-3.1l.8.8c.4.2 1.1.2 1.7.2c.2 0 .4 0 .6-.2s.2-.2.2-.4c0-.6-.6-1.3-1-1.7s-1.1-.8-1.7-1.1c-2.1-.6-5.5.2-7.1 1.7s-2.9 4-3.8 6.1c-.4 1.3-.8 2.9-1 4.4c-.2 1-.4 1.9.2 2.9c.6 1.3 1.9 2.5 3.2 3.4c.8.6 2.5.6 3.4 1.7c.6.8.4 1.9.4 2.9c0 1.3.8 2.3 1.3 3.4c.2.6.4 1.5.6 2.1c0 .2.2 1.5.2 1.7c1.3.6 2.3 1.3 3.8 1.7c.2 0 1-1.3 1-1.5c.6-.6 1.1-1.5 1.7-1.9c.4-.2.8-.4 1.3-.8c.4-.4.6-1.3.8-1.9c.1-.5.3-1.3.1-1.9m.4-19.4c.2 0 .4-.2.8-.4c.6-.4 1.3-1.1 1.9-1.5s1.3-1.1 1.7-1.5c.6-.4 1.1-1.3 1.3-1.9c.2-.4.8-1.3.6-1.9c-.2-.4-1.3-.6-1.7-.8c-1.7-.4-3.1-.6-4.8-.6c-.6 0-1.5.2-1.7.8c-.2 1.1.6.8 1.5 1.1c0 0 .2 1.7.2 1.9c.2 1-.4 1.7-.4 2.7c0 .6 0 1.7.4 2.1zM41.8 29c.2-.4.2-1.1.4-1.5c.2-1 .2-2.1.2-3.1c0-2.1-.2-4.2-.8-6.1c-.4-.6-.6-1.3-.8-1.9c-.4-1.1-1-2.1-1.9-2.9c-.8-1.1-1.9-4-3.8-3.1c-.6.2-1 1-1.5 1.5c-.4.6-.8 1.3-1.3 1.9c-.2.2-.4.6-.2.8c0 .2.2.2.4.2c.4.2.6.2 1 .4c.2 0 .4.2.2.4c0 0 0 .2-.2.2c-1 1.1-2.1 1.9-3.1 2.9c-.2.2-.4.6-.4.8s.2.2.2.4s-.2.2-.4.4c-.4.2-.8.4-1.1.6c-.2.4 0 1.1-.2 1.5c-.2 1.1-.8 1.9-1.3 2.9c-.4.6-.6 1.3-1 1.9c0 .8-.2 1.5.2 2.1c1 1.5 2.9.6 4.4 1.3c.4.2.8.2 1.1.6c.6.6.6 1.7.8 2.3c.2.8.4 1.7.8 2.5c.2 1 .6 2.1.8 2.9c1.9-1.5 3.6-3.1 4.8-5.2c1.5-1.3 2.1-3 2.7-4.7'/%3E%3C/svg%3E")}.skill-icons--list.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%235865f2' d='M4 3h13.17c.41 0 .8.16 1.09.44l3.3 3.3c.29.29.44.68.44 1.09V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z'/%3E%3Cpath fill='%23ffffff' d='M14 2v4h4l-4-4zM7 9h10v2H7V9zm0 4h7v2H7v-2z'/%3E%3C/svg%3E")}.question-mark-icon.svelte-1j2rmt2{display:inline-block;width:1.2rem;height:1.2rem;margin-left:2px;background-repeat:no-repeat;background-size:100% 100%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23188bd2' d='M21 2H3c-.55 0-1 .45-1 1v18c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1ZM12 18a1 1 0 1 1 1-1a1 1 0 0 1-1 1Zm2.07-5.25c-.9.52-.98 1.26-.98 1.75h-2c0-1.12.46-2.21 1.78-2.91c.9-.52 1.22-.87 1.22-1.34a1.5 1.5 0 0 0-3 0H9a3.5 3.5 0 0 1 7 0c0 1.63-1.28 2.41-1.93 2.75Z'/%3E%3C/svg%3E");cursor:pointer}.icons.svelte-1j2rmt2{display:inline-block;vertical-align:middle}.flex.svelte-1j2rmt2{display:flex;align-items:center}.icons.svelte-1j2rmt2 a:where(.svelte-1j2rmt2) span:where(.svelte-1j2rmt2){align-items:center;justify-content:center}hr.svelte-1j2rmt2{border:0;border-top:1px solid white;width:100%}.header.svelte-1j2rmt2{cursor:move;border-bottom:1px solid #aaa;width:100%;display:flex;justify-content:space-between;align-items:center;touch-action:none;-webkit-user-select:none;user-select:none}.geometa-note a{color:#188bd2}.geometa-note a:hover{text-decoration:underline}.geometa-note ul li{list-style-type:disc;margin-left:1rem}.geometa-note ol li{list-style-type:decimal;margin-left:1rem}.modal-backdrop.svelte-1j2rmt2{position:fixed;top:0;left:0;width:100vw;height:100vh;background:#1e1e1ecc;display:flex;justify-content:center;align-items:center;z-index:1000}.modal.svelte-1j2rmt2{background:var(--ds-color-purple-100, #1c1836);padding:15px 25px;border-radius:8px;text-align:center;width:90%;max-width:600px;box-shadow:0 4px 6px #0003;color:#d3d3d3}.modal.svelte-1j2rmt2 p:where(.svelte-1j2rmt2){margin:0 0 10px;font-size:17px}.modal-url.svelte-1j2rmt2{font-size:15px;font-weight:700;color:#188bd2;word-break:break-word;margin:10px 0}.modal-buttons.svelte-1j2rmt2{display:flex;justify-content:center;gap:15px;margin-top:20px}.proceed-btn.svelte-1j2rmt2{background:#188bd2;color:#fff;padding:8px 16px;border:none;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out}.proceed-btn.svelte-1j2rmt2:hover{background:#0056b3}.close-btn.svelte-1j2rmt2{background:transparent;color:#d3d3d3;padding:8px 16px;border:1px solid #d3d3d3;border-radius:5px;cursor:pointer;font-size:15px;transition:background-color .2s ease-in-out,color .2s ease-in-out}.close-btn.svelte-1j2rmt2:hover{background:#d3d3d3;color:var(--ds-color-purple-100, #1c1836)}button.svelte-1j2rmt2{cursor:pointer;background:none;border:none;padding:0}.blink.svelte-1j2rmt2{animation:svelte-1j2rmt2-blink-animation 1s infinite}.help-message.svelte-1j2rmt2{padding:12px;font-size:16px;line-height:1.5;text-align:left}.help-message.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:#007bff;font-weight:700}@keyframes svelte-1j2rmt2-blink-animation{0%{filter:brightness(1)}50%{filter:brightness(2);background-color:#004779}to{filter:brightness(1)}}.outdated.svelte-1j2rmt2 strong:where(.svelte-1j2rmt2){color:red!important}.geometa-meta-btn{background:#188bd2;color:#fff;border:none;border-radius:3px;padding:2px 6px;font-size:11px;cursor:pointer;margin-left:10px;transition:background-color .2s ease;font-weight:700;z-index:1000;pointer-events:auto;display:inline-block}.result-list_listItemWrapper___XCGn{display:flex!important;justify-content:space-between!important;align-items:center!important}.geometa-meta-btn:hover{background:#0056b3}.geometa-pin-question{position:absolute;top:-8px;right:-8px;width:16px;height:16px;background:#188bd2;color:#fff;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;z-index:10000;transition:background-color .2s ease;border:1px solid white;box-shadow:0 1px 3px #0000004d}.geometa-pin-question:hover{background:#0056b3;transform:scale(1.1)}.geometa-map-label-container.svelte-1y99qco{background-color:#000000a6;color:#fff;text-align:center;z-index:100;position:absolute;bottom:4px;right:4px;box-sizing:border-box;border-radius:8px;padding:8px;-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);display:flex;align-items:center;gap:8px}p.svelte-1y99qco{font-size:14px;font-weight:700}button.svelte-1y99qco{padding:6px 12px;font-size:12px;color:#fff;background-color:#4caf50;border:none;border-radius:4px;cursor:pointer}.toast-notification.svelte-w17ltc{position:fixed;top:72px;right:16px;z-index:10001;min-width:250px;max-width:400px;padding:14px 22px;border-radius:8px;box-shadow:0 5px 15px #0003;color:#fff;display:flex;align-items:flex-start;justify-content:space-between;font-size:.95em;line-height:1.4}.toast-success.svelte-w17ltc{background-color:#28a745;border-left:5px solid #1e7e34}.toast-error.svelte-w17ltc{background-color:#dc3545;border-left:5px solid #b02a37}.toast-info.svelte-w17ltc{background-color:#17a2b8;border-left:5px solid #117a8b}.toast-warning.svelte-w17ltc{background-color:#ffc107;color:#212529;border-left:5px solid #d39e00}.toast-content.svelte-w17ltc{flex-grow:1;margin-right:10px;display:flex;flex-direction:column;gap:6px}.toast-detail.svelte-w17ltc{font-size:.8em;line-height:1.35;opacity:.85;word-break:break-word;padding-top:6px;border-top:1px solid rgba(255,255,255,.35);-webkit-user-select:text;user-select:text}.toast-close-button.svelte-w17ltc{background:transparent;border:none;color:inherit;font-size:1.6em;font-weight:700;margin-left:10px;cursor:pointer;padding:0;line-height:1;opacity:.7;transition:opacity .2s ease}.toast-close-button.svelte-w17ltc:hover{opacity:1}.upload-label-container.svelte-1plj3lz{display:flex;align-items:center}.api-key-button.svelte-1plj3lz{display:inline-flex;align-items:center;justify-content:center;margin-left:6px;width:30px;height:30px;padding:0;font-size:14px;line-height:1;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;border-radius:50%;cursor:pointer;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;transition:background .2s ease-in-out}.api-key-button.svelte-1plj3lz:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308)}.api-key-button.svelte-1plj3lz:disabled{background:#e0e0e0;border-color:#bbb;cursor:not-allowed}.modal-overlay.svelte-1plj3lz{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#0009;display:flex;justify-content:center;align-items:center;z-index:10000}.modal-content.svelte-1plj3lz{background-color:#fff;padding:25px 30px;border-radius:8px;box-shadow:0 5px 15px #0000004d;width:90%;max-width:450px;color:#333}.modal-content.svelte-1plj3lz h2:where(.svelte-1plj3lz){margin-top:0;margin-bottom:15px;color:#2c3e50}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz){margin-bottom:15px;line-height:1.6}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz){color:#007bff;text-decoration:underline}.modal-content.svelte-1plj3lz p:where(.svelte-1plj3lz) a:where(.svelte-1plj3lz):hover{color:#0056b3}.modal-input.svelte-1plj3lz{width:calc(100% - 20px);padding:10px;margin-bottom:20px;border:1px solid #ccc;border-radius:4px;font-size:1em}.modal-actions.svelte-1plj3lz{display:flex;justify-content:flex-end;gap:10px}.modal-button.svelte-1plj3lz{padding:10px 18px;border:none;border-radius:4px;cursor:pointer;font-weight:700;transition:background-color .2s ease}.modal-button-save.svelte-1plj3lz{background-color:#28a745;color:#fff}.modal-button-save.svelte-1plj3lz:hover{background-color:#218838}.modal-button-cancel.svelte-1plj3lz{background-color:#6c757d;color:#fff}.modal-button-cancel.svelte-1plj3lz:hover{background-color:#5a6268}.modal-button-clear.svelte-1plj3lz{background-color:#dc3545;color:#fff;margin-right:auto}.modal-button-clear.svelte-1plj3lz:hover{background-color:#b02a37}.modal-content.svelte-1plj3lz code:where(.svelte-1plj3lz){background-color:#f1f3f5;padding:1px 5px;border-radius:3px;font-size:.9em}.modal-note.svelte-1plj3lz{font-size:.85em;color:#555;margin-top:15px;text-align:center}.backdrop.svelte-axobi4{position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:#040812c7;font-family:Arial,sans-serif;color:#172033}.panel.svelte-axobi4{width:min(780px,100%);max-height:min(760px,calc(100vh - 48px));display:flex;flex-direction:column;overflow:hidden;border:1px solid #d8dee9;border-radius:14px;background:#fff;box-shadow:0 24px 70px #00000073}header.svelte-axobi4{display:flex;align-items:flex-start;justify-content:space-between;padding:22px 24px 18px;border-bottom:1px solid #e8ebf0}h1.svelte-axobi4{margin:2px 0 0;font-size:24px;color:#101828}.eyebrow.svelte-axobi4{margin:0;color:#936b00;font-size:11px;font-weight:800;letter-spacing:.12em;text-transform:uppercase}.subtitle.svelte-axobi4{margin:5px 0 0;color:#667085}.icon-button.svelte-axobi4{border:0;background:transparent;font-size:28px;color:#667085;cursor:pointer}.notice.svelte-axobi4,.fatal.svelte-axobi4,.summary.svelte-axobi4{margin:18px 24px 0;padding:12px 14px;border-radius:8px;background:#f5f7fa}.fatal.svelte-axobi4{display:grid;gap:8px;background:#fff1f1;color:#8a1c1c}.summary.svelte-axobi4{background:#eef8ee;color:#245b29}.toolbar.svelte-axobi4{display:flex;justify-content:space-between;align-items:center;padding:16px 24px 10px;color:#475467;font-size:13px}.group-list.svelte-axobi4{display:grid;gap:8px;overflow-y:auto;margin:14px 24px 0}.group-row.svelte-axobi4{display:flex;align-items:center;justify-content:space-between;gap:16px;width:100%;border:1px solid #d9dee7;border-radius:9px;padding:13px 15px;background:#fff;color:#172033;text-align:left;cursor:pointer}.group-row.svelte-axobi4:hover{border-color:#d3a300;background:#fffaf0}.group-row.svelte-axobi4 span:where(.svelte-axobi4){flex:none;color:#667085;font-size:12px}.map-list.svelte-axobi4{overflow-y:auto;margin:0 24px;border:1px solid #e4e7ec;border-radius:9px}.map-row.svelte-axobi4{display:grid;grid-template-columns:24px minmax(0,1fr) auto;gap:10px;align-items:center;padding:12px 14px;border-bottom:1px solid #eef0f3}.map-row.svelte-axobi4:last-child{border-bottom:0}.map-row.error-row.svelte-axobi4{background:snow}.map-details.svelte-axobi4{display:grid;min-width:0;gap:3px}.map-details.svelte-axobi4 strong:where(.svelte-axobi4){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.map-details.svelte-axobi4>span:where(.svelte-axobi4){color:#667085;font-size:12px}.map-details.svelte-axobi4 .row-error:where(.svelte-axobi4){color:#a32626;white-space:normal}.status.svelte-axobi4{padding:4px 8px;border-radius:999px;background:#fff2cc;color:#765700;font-size:11px;font-weight:700;white-space:nowrap}.status.good.svelte-axobi4{background:#e9f8ec;color:#24612d}.actions.svelte-axobi4{display:flex;justify-content:flex-end;align-items:center;gap:9px;padding:18px 24px 22px}button.svelte-axobi4{font:inherit}button.svelte-axobi4:disabled{cursor:not-allowed;opacity:.55}.primary.svelte-axobi4,.secondary.svelte-axobi4{border-radius:7px;padding:9px 14px;font-weight:700;cursor:pointer}.primary.svelte-axobi4{border:1px solid #d3a300;background:#f5c542;color:#172033}.secondary.svelte-axobi4{border:1px solid #cfd5df;background:#fff;color:#344054}.link-button.svelte-axobi4{border:0;padding:4px 7px;background:transparent;color:#3458a5;cursor:pointer}.token-button.svelte-axobi4{margin-right:auto}.token-form.svelte-axobi4{display:grid;gap:12px;padding:22px 24px}.token-form.svelte-axobi4 p:where(.svelte-axobi4){margin:0}.token-form.svelte-axobi4 .small:where(.svelte-axobi4){color:#667085;font-size:13px}.token-form.svelte-axobi4 a:where(.svelte-axobi4){color:#3458a5}.token-form.svelte-axobi4 input:where(.svelte-axobi4){border:1px solid #cfd5df;border-radius:7px;padding:10px 12px;font:inherit}.token-form.svelte-axobi4 .actions:where(.svelte-axobi4){padding:4px 0 0}.error-text.svelte-axobi4{color:#a32626;font-size:13px}@media(max-width:620px){.backdrop.svelte-axobi4{padding:8px}.panel.svelte-axobi4{max-height:calc(100vh - 16px)}.map-row.svelte-axobi4{grid-template-columns:22px minmax(0,1fr)}.status.svelte-axobi4{grid-column:2;justify-self:start}footer.actions.svelte-axobi4{flex-wrap:wrap}.token-button.svelte-axobi4{width:100%;text-align:left}} `);
 
   var _GM_getValue = (() => typeof GM_getValue != "undefined" ? GM_getValue : void 0)();
   var _GM_info = (() => typeof GM_info != "undefined" ? GM_info : void 0)();
@@ -4535,7 +4536,7 @@ context.l
       _unsafeWindow.localStorage.setItem(heightKey, Math.floor(containerHeight).toString());
     }
   }
-  var root_4$2 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
+  var root_4$1 = from_html(`<div class="lens svelte-8ojyxu"></div>`);
   var root_3$2 = from_html(`<div class="image-wrapper svelte-8ojyxu" role="img" aria-label="Zoomable image"><img class="responsive-image svelte-8ojyxu"/> <!></div>`);
   var root_6$3 = from_html(`<button></button>`);
   var root_5$3 = from_html(`<div class="controls"><button class="click-area prev-area svelte-8ojyxu" type="button" aria-label="Previous image"><span class="prev svelte-8ojyxu">&#10094;</span></button> <button class="click-area next-area svelte-8ojyxu" type="button" aria-label="Next image"><span class="next svelte-8ojyxu">&#10095;</span></button></div> <div class="indicators svelte-8ojyxu"></div>`, 1);
@@ -4589,7 +4590,7 @@ context.l
               var node_3 = sibling(img, 2);
               {
                 var consequent = ($$anchor5) => {
-                  var div_2 = root_4$2();
+                  var div_2 = root_4$1();
                   template_effect(() => set_style(div_2, `
                 /* Position the lens so the mouse is in its center */
                 top: ${get(lensY) - lensSize / 2}px;
@@ -4759,11 +4760,11 @@ context.l
   var root_2$2 = from_html(`<div class="announcement svelte-1j2rmt2"><div class="svelte-1j2rmt2"><!></div> <button class="vote-close-btn svelte-1j2rmt2" aria-label="Dismiss announcement">Dismiss</button></div>`);
   var root_3$1 = from_html(`<p class="svelte-1j2rmt2"> </p>`);
   var root_6$2 = from_html(`<p class="geometa-footer svelte-1j2rmt2"><!></p>`);
-  var root_7$1 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
+  var root_7 = from_html(`<hr class="svelte-1j2rmt2"/> <!>`, 1);
   var root_5$2 = from_html(`<p class="svelte-1j2rmt2"><!> <strong class="svelte-1j2rmt2"> </strong> </p> <div class="geometa-note svelte-1j2rmt2"><!></div> <!> <!>`, 1);
-  var root_9$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
+  var root_9 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><p class="svelte-1j2rmt2">You are about to open this site in a new tab:</p> <p class="modal-url svelte-1j2rmt2"> </p> <div class="modal-buttons svelte-1j2rmt2"><button class="proceed-btn svelte-1j2rmt2">Continue</button> <button class="close-btn svelte-1j2rmt2">Cancel</button></div></div></div>`);
   var root_11$1 = from_html(`<p class="outdated svelte-1j2rmt2"><strong class="svelte-1j2rmt2"> </strong></p>`);
-  var root_10 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
+  var root_10$1 = from_html(`<div class="modal-backdrop svelte-1j2rmt2"><div class="modal svelte-1j2rmt2"><div class="help-message svelte-1j2rmt2"><!> <p class="svelte-1j2rmt2">Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p> <ul class="svelte-1j2rmt2"><li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
               on your screen.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Resize:</strong> Use the bottom-right corner to resize the note to your liking.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">View Map meta list:</strong> Click the list icon to see all the metas included
               in the map you are currently playing.</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Join the Community:</strong> Click the Discord icon to share feedback, suggest
               improvements, or just say hi!</li> <li class="svelte-1j2rmt2"><strong class="svelte-1j2rmt2">Outdated Script:</strong> The question mark icon will blink if the script is outdated.</li></ul></div> <button class="close-btn svelte-1j2rmt2">Close</button></div></div>`);
@@ -4952,7 +4953,7 @@ context.l
             var node_9 = sibling(node_7, 2);
             {
               var consequent_3 = ($$anchor4) => {
-                var fragment_3 = root_7$1();
+                var fragment_3 = root_7();
                 var node_10 = sibling(first_child(fragment_3), 2);
                 Carousel(node_10, {
                   get images() {
@@ -4993,7 +4994,7 @@ context.l
     var node_11 = sibling(node_3, 2);
     {
       var consequent_5 = ($$anchor2) => {
-        var div_6 = root_9$1();
+        var div_6 = root_9();
         var div_7 = child(div_6);
         var p_3 = sibling(child(div_7), 2);
         var text_3 = child(p_3);
@@ -5012,7 +5013,7 @@ context.l
     var node_12 = sibling(node_11, 2);
     {
       var consequent_7 = ($$anchor2) => {
-        var div_9 = root_10();
+        var div_9 = root_10$1();
         var div_10 = child(div_9);
         var div_11 = child(div_10);
         var node_13 = child(div_11);
@@ -5381,6 +5382,16 @@ roundNumber: 4,
       apiToken
     );
   }
+  async function fetchAccessibleMapGroups(apiToken) {
+    const data = await requestJson(
+      "https://learnablemeta.com/api/userscript/map-groups",
+      apiToken
+    );
+    if (!Array.isArray(data.groups)) {
+      throw new LearnableMetaApiError(0, "Received invalid map group data");
+    }
+    return data.groups;
+  }
   async function fetchSyncedMapLocations(geoguessrId, apiToken, expectedFingerprint) {
     const query = expectedFingerprint ? `?expectedFingerprint=${encodeURIComponent(expectedFingerprint)}` : "";
     const data = await requestJson(
@@ -5555,12 +5566,12 @@ roundNumber: 4,
     _GM_setValue(API_KEY_STORAGE_NAME, "");
   }
   var root_2$1 = from_html(`<p class="svelte-1plj3lz">An API key is required to upload locations. Please paste your key below.</p>`);
-  var root_4$1 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
+  var root_4 = from_html(`<p class="svelte-1plj3lz">A key ending in <code class="svelte-1plj3lz"> </code> is currently saved. Paste a new key
           to replace it, or clear the saved key.</p>`);
   var root_5$1 = from_html(`<p class="svelte-1plj3lz">No API key is saved yet. Paste your key below.</p>`);
   var root_6$1 = from_html(`<button class="modal-button modal-button-clear svelte-1plj3lz">Clear Key</button>`);
   var root_1$1 = from_html(`<div class="modal-overlay svelte-1plj3lz" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle"><div class="modal-content svelte-1plj3lz"><h2 id="apiKeyModalTitle" class="svelte-1plj3lz">LearnableMeta API Key</h2> <!> <p class="svelte-1plj3lz">You can generate your API token on your <a target="_blank" rel="noopener noreferrer" class="svelte-1plj3lz">LearnableMeta profile page</a>.</p> <input type="text" placeholder="Paste your API key here" aria-label="API Key Input" class="modal-input svelte-1plj3lz"/> <div class="modal-actions svelte-1plj3lz"><!> <button class="modal-button modal-button-save svelte-1plj3lz"> </button> <button class="modal-button modal-button-cancel svelte-1plj3lz">Cancel</button></div> <p class="modal-note svelte-1plj3lz">Your API key will be stored securely in your browser's userscript storage for future use.</p></div></div>`);
-  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="custom-yellow-button svelte-1plj3lz"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
+  var root$1 = from_html(`<div class="upload-label-container svelte-1plj3lz"><button class="learnablemeta-yellow-button"> </button> <button class="api-key-button svelte-1plj3lz" title="Manage LearnableMeta API key" aria-label="Manage LearnableMeta API key">🔑</button></div> <!> <!>`, 1);
   function UploadLocations($$anchor, $$props) {
     push($$props, true);
     let showApiKeyModal = state(false);
@@ -5702,7 +5713,7 @@ roundNumber: 4,
             var node_2 = first_child(fragment_1);
             {
               var consequent_1 = ($$anchor4) => {
-                var p_1 = root_4$1();
+                var p_1 = root_4();
                 var code = sibling(child(p_1));
                 var text_1 = child(code);
                 template_effect(($0) => set_text(text_1, `…${$0 ?? ""}`), [() => get(currentApiKey).slice(-4)]);
@@ -5899,24 +5910,35 @@ roundNumber: 4,
   }
   var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
   var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
-  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and scan</button></div></div>`);
-  var root_5 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
-  var root_6 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
-  var root_9 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
-  var root_8 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
-  var root_7 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
-  var root_11 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
-  var root_12 = from_html(`<div class="summary svelte-axobi4"> </div>`);
-  var root_13 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
-  var root_4 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
-  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4">Update GeoGuessr maps</h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
+  var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="svelte-axobi4"/> <!> <div class="actions svelte-axobi4"><button class="secondary svelte-axobi4">Cancel</button> <button class="primary svelte-axobi4">Save and continue</button></div></div>`);
+  var root_6 = from_html(`<div class="notice svelte-axobi4">Loading your synchronized map groups…</div>`);
+  var root_8 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load your map groups.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_11 = from_html(`<button class="group-row svelte-axobi4"><strong> </strong> <span class="svelte-axobi4"> </span></button>`);
+  var root_10 = from_html(`<div class="notice svelte-axobi4">Select a synchronized LearnableMeta group to compare its maps.</div> <div class="group-list svelte-axobi4"></div>`, 1);
+  var root_12 = from_html(`<div class="notice svelte-axobi4">You have no synchronized map groups containing maps.</div>`);
+  var root_5 = from_html(`<!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <button class="secondary svelte-axobi4">Close</button></footer>`, 1);
+  var root_14 = from_html(`<div class="notice svelte-axobi4">Loading synchronized maps and comparing GeoGuessr drafts…</div>`);
+  var root_15 = from_html(`<div class="fatal svelte-axobi4"><strong>Could not load this group.</strong> <span> </span> <button class="secondary svelte-axobi4">Try again</button></div>`);
+  var root_18 = from_html(`<span class="row-error svelte-axobi4"> </span>`);
+  var root_17 = from_html(`<label><input type="checkbox"/> <span class="map-details svelte-axobi4"><strong class="svelte-axobi4"> </strong> <span class="svelte-axobi4"> </span> <!></span> <span> </span></label>`);
+  var root_16 = from_html(`<div class="toolbar svelte-axobi4"><span> </span> <div><button class="link-button svelte-axobi4">Select changed</button> <button class="link-button svelte-axobi4">Deselect all</button></div></div> <div class="map-list svelte-axobi4"></div>`, 1);
+  var root_20 = from_html(`<div class="notice svelte-axobi4">This group has no maps to update.</div>`);
+  var root_21 = from_html(`<div class="summary svelte-axobi4"> </div>`);
+  var root_22 = from_html(`<button class="link-button svelte-axobi4">Change group</button>`);
+  var root_23 = from_html(`<button class="secondary svelte-axobi4"> </button>`);
+  var root_13 = from_html(`<!> <!> <!> <!> <footer class="actions svelte-axobi4"><button class="link-button token-button svelte-axobi4">Change API token</button> <!> <button class="secondary svelte-axobi4">Close</button> <!> <button class="primary svelte-axobi4"> </button></footer>`, 1);
+  var root = from_html(`<div class="backdrop svelte-axobi4" role="presentation"><div class="panel svelte-axobi4" role="dialog" aria-modal="true" aria-labelledby="group-update-title"><header class="svelte-axobi4"><div><p class="eyebrow svelte-axobi4">LearnableMeta</p> <h1 id="group-update-title" class="svelte-axobi4"> </h1> <!></div> <button class="icon-button svelte-axobi4" aria-label="Close">×</button></header> <!></div></div>`);
   function MapGroupUpdate($$anchor, $$props) {
     push($$props, true);
+    const canChooseGroup = $$props.groupId === void 0;
+    let activeGroupId = state(proxy($$props.groupId ?? null));
     let phase = state("scanning");
     let apiToken = state("");
     let tokenInput = state("");
     let tokenError = state("");
     let groupName = state("");
+    let accessibleGroups = state(proxy([]));
+    let groupsLoading = state(false);
     let rows = state(proxy([]));
     let fatalError = state("");
     let finishedRun = state(false);
@@ -5932,7 +5954,7 @@ roundNumber: 4,
           return;
         }
         set(apiToken, savedToken, true);
-        void scanGroup();
+        void continueWithToken();
       } catch (error) {
         set(phase, "token");
         set(tokenError, errorMessage(error), true);
@@ -5945,7 +5967,7 @@ roundNumber: 4,
       const index2 = get(rows).findIndex((row) => row.geoguessrId === geoguessrId);
       if (index2 !== -1) get(rows)[index2] = { ...get(rows)[index2], ...update };
     }
-    async function saveTokenAndScan() {
+    async function saveTokenAndContinue() {
       const trimmed = get(tokenInput).trim();
       if (!trimmed) {
         set(tokenError, "Paste a valid LearnableMeta API token.");
@@ -5955,21 +5977,63 @@ roundNumber: 4,
       set(apiToken, trimmed, true);
       set(tokenInput, "");
       set(tokenError, "");
-      await scanGroup();
+      await continueWithToken();
     }
     function changeToken() {
       set(tokenInput, "");
       set(tokenError, "");
       set(phase, "token");
     }
+    async function continueWithToken() {
+      if (get(activeGroupId) === null) {
+        await loadAccessibleGroups();
+      } else {
+        await scanGroup();
+      }
+    }
+    async function loadAccessibleGroups() {
+      set(phase, "groups");
+      set(fatalError, "");
+      set(finishedRun, false);
+      set(groupName, "");
+      set(rows, [], true);
+      set(accessibleGroups, [], true);
+      set(groupsLoading, true);
+      try {
+        set(accessibleGroups, await fetchAccessibleMapGroups(get(apiToken)), true);
+      } catch (error) {
+        if (error instanceof LearnableMetaApiError && error.status === 401) {
+          clearApiKey();
+          set(apiToken, "");
+          set(tokenError, "Your LearnableMeta API token was rejected. Paste a new token.");
+          set(phase, "token");
+          return;
+        }
+        set(fatalError, errorMessage(error), true);
+      } finally {
+        set(groupsLoading, false);
+      }
+    }
+    function selectGroup(groupId) {
+      set(activeGroupId, groupId, true);
+      void scanGroup();
+    }
+    function changeGroup() {
+      set(activeGroupId, null);
+      void loadAccessibleGroups();
+    }
     async function scanGroup() {
+      if (get(activeGroupId) === null) {
+        await loadAccessibleGroups();
+        return;
+      }
       set(phase, "scanning");
       set(fatalError, "");
       set(finishedRun, false);
       set(groupName, "");
       set(rows, [], true);
       try {
-        const manifest = await fetchMapGroupManifest($$props.groupId, get(apiToken));
+        const manifest = await fetchMapGroupManifest(get(activeGroupId), get(apiToken));
         set(groupName, manifest.group.name, true);
         set(
           rows,
@@ -6099,12 +6163,14 @@ roundNumber: 4,
     var div_1 = child(div);
     var header = child(div_1);
     var div_2 = child(header);
-    var node = sibling(child(div_2), 4);
+    var h1 = sibling(child(div_2), 2);
+    var text = child(h1);
+    var node = sibling(h1, 2);
     {
       var consequent = ($$anchor2) => {
         var p = root_1();
-        var text = child(p);
-        template_effect(() => set_text(text, get(groupName)));
+        var text_1 = child(p);
+        template_effect(() => set_text(text_1, get(groupName)));
         append($$anchor2, p);
       };
       if_block(node, ($$render) => {
@@ -6122,13 +6188,13 @@ roundNumber: 4,
         var p_1 = sibling(child(div_3), 2);
         var a = sibling(child(p_1));
         var input = sibling(p_1, 2);
-        input.__keydown = (event2) => event2.key === "Enter" && void saveTokenAndScan();
+        input.__keydown = (event2) => event2.key === "Enter" && void saveTokenAndContinue();
         var node_2 = sibling(input, 2);
         {
           var consequent_1 = ($$anchor3) => {
             var p_2 = root_3();
-            var text_1 = child(p_2);
-            template_effect(() => set_text(text_1, get(tokenError)));
+            var text_2 = child(p_2);
+            template_effect(() => set_text(text_2, get(tokenError)));
             append($$anchor3, p_2);
           };
           if_block(node_2, ($$render) => {
@@ -6141,186 +6207,302 @@ roundNumber: 4,
           $$props.onClose?.apply(this, $$args);
         };
         var button_2 = sibling(button_1, 2);
-        button_2.__click = saveTokenAndScan;
+        button_2.__click = saveTokenAndContinue;
         template_effect(() => set_attribute(a, "href", URL_TO_GENERATE_TOKEN));
         bind_value(input, () => get(tokenInput), ($$value) => set(tokenInput, $$value));
         append($$anchor2, div_3);
       };
-      var alternate_1 = ($$anchor2) => {
-        var fragment = root_4();
+      var alternate_5 = ($$anchor2) => {
+        var fragment = comment();
         var node_3 = first_child(fragment);
         {
-          var consequent_3 = ($$anchor3) => {
-            var div_5 = root_5();
-            append($$anchor3, div_5);
-          };
-          if_block(node_3, ($$render) => {
-            if (get(phase) === "scanning") $$render(consequent_3);
-          });
-        }
-        var node_4 = sibling(node_3, 2);
-        {
-          var consequent_4 = ($$anchor3) => {
-            var div_6 = root_6();
-            var span = sibling(child(div_6), 2);
-            var text_2 = child(span);
-            var button_3 = sibling(span, 2);
-            button_3.__click = scanGroup;
-            template_effect(() => set_text(text_2, get(fatalError)));
-            append($$anchor3, div_6);
-          };
-          if_block(node_4, ($$render) => {
-            if (get(fatalError)) $$render(consequent_4);
-          });
-        }
-        var node_5 = sibling(node_4, 2);
-        {
           var consequent_6 = ($$anchor3) => {
-            var fragment_1 = root_7();
-            var div_7 = first_child(fragment_1);
-            var span_1 = child(div_7);
-            var text_3 = child(span_1);
-            var div_8 = sibling(span_1, 2);
-            var button_4 = child(div_8);
-            button_4.__click = () => selectChanged(true);
-            var button_5 = sibling(button_4, 2);
-            button_5.__click = () => selectChanged(false);
-            var div_9 = sibling(div_7, 2);
-            each(div_9, 21, () => get(rows), (row) => row.geoguessrId, ($$anchor4, row, $$index) => {
-              var label = root_8();
-              let classes;
-              var input_1 = child(label);
-              var span_2 = sibling(input_1, 2);
-              var strong = child(span_2);
-              var text_4 = child(strong);
-              var span_3 = sibling(strong, 2);
-              var text_5 = child(span_3);
-              var node_6 = sibling(span_3, 2);
-              {
-                var consequent_5 = ($$anchor5) => {
-                  var span_4 = root_9();
-                  var text_6 = child(span_4);
-                  template_effect(() => set_text(text_6, get(row).error));
-                  append($$anchor5, span_4);
-                };
-                if_block(node_6, ($$render) => {
-                  if (get(row).error) $$render(consequent_5);
-                });
-              }
-              var span_5 = sibling(span_2, 2);
-              let classes_1;
-              var text_7 = child(span_5);
-              template_effect(
-                ($0, $1) => {
-                  classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
-                  input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
-                  set_text(text_4, get(row).name);
-                  set_text(text_5, `${$0 ?? ""} synchronized locations`);
-                  classes_1 = set_class(span_5, 1, "status svelte-axobi4", null, classes_1, {
-                    good: get(row).status === "current" || get(row).status === "success"
-                  });
-                  set_text(text_7, $1);
-                },
-                [
-                  () => get(row).locationCount.toLocaleString(),
-                  () => statusLabel(get(row))
-                ]
-              );
-              bind_checked(input_1, () => get(row).selected, ($$value) => get(row).selected = $$value);
-              append($$anchor4, label);
-            });
-            template_effect(() => set_text(text_3, `${get(rows).length ?? ""} map${get(rows).length === 1 ? "" : "s"}`));
+            var fragment_1 = root_5();
+            var node_4 = first_child(fragment_1);
+            {
+              var consequent_3 = ($$anchor4) => {
+                var div_5 = root_6();
+                append($$anchor4, div_5);
+              };
+              var alternate_2 = ($$anchor4) => {
+                var fragment_2 = comment();
+                var node_5 = first_child(fragment_2);
+                {
+                  var consequent_4 = ($$anchor5) => {
+                    var div_6 = root_8();
+                    var span = sibling(child(div_6), 2);
+                    var text_3 = child(span);
+                    var button_3 = sibling(span, 2);
+                    button_3.__click = loadAccessibleGroups;
+                    template_effect(() => set_text(text_3, get(fatalError)));
+                    append($$anchor5, div_6);
+                  };
+                  var alternate_1 = ($$anchor5) => {
+                    var fragment_3 = comment();
+                    var node_6 = first_child(fragment_3);
+                    {
+                      var consequent_5 = ($$anchor6) => {
+                        var fragment_4 = root_10();
+                        var div_7 = sibling(first_child(fragment_4), 2);
+                        each(div_7, 21, () => get(accessibleGroups), (group) => group.id, ($$anchor7, group) => {
+                          var button_4 = root_11();
+                          button_4.__click = () => selectGroup(get(group).id);
+                          var strong = child(button_4);
+                          var text_4 = child(strong);
+                          var span_1 = sibling(strong, 2);
+                          var text_5 = child(span_1);
+                          template_effect(() => {
+                            set_text(text_4, get(group).name);
+                            set_text(text_5, `${get(group).mapCount ?? ""} map${get(group).mapCount === 1 ? "" : "s"}`);
+                          });
+                          append($$anchor7, button_4);
+                        });
+                        append($$anchor6, fragment_4);
+                      };
+                      var alternate = ($$anchor6) => {
+                        var div_8 = root_12();
+                        append($$anchor6, div_8);
+                      };
+                      if_block(
+                        node_6,
+                        ($$render) => {
+                          if (get(accessibleGroups).length > 0) $$render(consequent_5);
+                          else $$render(alternate, false);
+                        },
+                        true
+                      );
+                    }
+                    append($$anchor5, fragment_3);
+                  };
+                  if_block(
+                    node_5,
+                    ($$render) => {
+                      if (get(fatalError)) $$render(consequent_4);
+                      else $$render(alternate_1, false);
+                    },
+                    true
+                  );
+                }
+                append($$anchor4, fragment_2);
+              };
+              if_block(node_4, ($$render) => {
+                if (get(groupsLoading)) $$render(consequent_3);
+                else $$render(alternate_2, false);
+              });
+            }
+            var footer = sibling(node_4, 2);
+            var button_5 = child(footer);
+            button_5.__click = changeToken;
+            var button_6 = sibling(button_5, 2);
+            button_6.__click = function(...$$args) {
+              $$props.onClose?.apply(this, $$args);
+            };
             append($$anchor3, fragment_1);
           };
-          var alternate = ($$anchor3) => {
-            var fragment_2 = comment();
-            var node_7 = first_child(fragment_2);
+          var alternate_4 = ($$anchor3) => {
+            var fragment_5 = root_13();
+            var node_7 = first_child(fragment_5);
             {
               var consequent_7 = ($$anchor4) => {
-                var div_10 = root_11();
+                var div_9 = root_14();
+                append($$anchor4, div_9);
+              };
+              if_block(node_7, ($$render) => {
+                if (get(phase) === "scanning") $$render(consequent_7);
+              });
+            }
+            var node_8 = sibling(node_7, 2);
+            {
+              var consequent_8 = ($$anchor4) => {
+                var div_10 = root_15();
+                var span_2 = sibling(child(div_10), 2);
+                var text_6 = child(span_2);
+                var button_7 = sibling(span_2, 2);
+                button_7.__click = scanGroup;
+                template_effect(() => set_text(text_6, get(fatalError)));
                 append($$anchor4, div_10);
               };
-              if_block(
-                node_7,
-                ($$render) => {
-                  if (get(phase) === "review" && !get(fatalError)) $$render(consequent_7);
-                },
-                true
-              );
+              if_block(node_8, ($$render) => {
+                if (get(fatalError)) $$render(consequent_8);
+              });
             }
-            append($$anchor3, fragment_2);
-          };
-          if_block(node_5, ($$render) => {
-            if (get(rows).length > 0) $$render(consequent_6);
-            else $$render(alternate, false);
-          });
-        }
-        var node_8 = sibling(node_5, 2);
-        {
-          var consequent_8 = ($$anchor3) => {
-            var div_11 = root_12();
-            var text_8 = child(div_11);
-            template_effect(() => set_text(text_8, `Finished: ${get(successCount) ?? ""} published, ${get(failureCount) ?? ""} failed, ${get(changedCount) ?? ""} still available.`));
-            append($$anchor3, div_11);
-          };
-          if_block(node_8, ($$render) => {
-            if (get(finishedRun)) $$render(consequent_8);
-          });
-        }
-        var footer = sibling(node_8, 2);
-        var button_6 = child(footer);
-        button_6.__click = changeToken;
-        var button_7 = sibling(button_6, 2);
-        button_7.__click = function(...$$args) {
-          $$props.onClose?.apply(this, $$args);
-        };
-        var node_9 = sibling(button_7, 2);
-        {
-          var consequent_9 = ($$anchor3) => {
-            var button_8 = root_13();
-            button_8.__click = retryFailures;
-            var text_9 = child(button_8);
+            var node_9 = sibling(node_8, 2);
+            {
+              var consequent_10 = ($$anchor4) => {
+                var fragment_6 = root_16();
+                var div_11 = first_child(fragment_6);
+                var span_3 = child(div_11);
+                var text_7 = child(span_3);
+                var div_12 = sibling(span_3, 2);
+                var button_8 = child(div_12);
+                button_8.__click = () => selectChanged(true);
+                var button_9 = sibling(button_8, 2);
+                button_9.__click = () => selectChanged(false);
+                var div_13 = sibling(div_11, 2);
+                each(div_13, 21, () => get(rows), (row) => row.geoguessrId, ($$anchor5, row, $$index_1) => {
+                  var label = root_17();
+                  let classes;
+                  var input_1 = child(label);
+                  var span_4 = sibling(input_1, 2);
+                  var strong_1 = child(span_4);
+                  var text_8 = child(strong_1);
+                  var span_5 = sibling(strong_1, 2);
+                  var text_9 = child(span_5);
+                  var node_10 = sibling(span_5, 2);
+                  {
+                    var consequent_9 = ($$anchor6) => {
+                      var span_6 = root_18();
+                      var text_10 = child(span_6);
+                      template_effect(() => set_text(text_10, get(row).error));
+                      append($$anchor6, span_6);
+                    };
+                    if_block(node_10, ($$render) => {
+                      if (get(row).error) $$render(consequent_9);
+                    });
+                  }
+                  var span_7 = sibling(span_4, 2);
+                  let classes_1;
+                  var text_11 = child(span_7);
+                  template_effect(
+                    ($0, $1) => {
+                      classes = set_class(label, 1, "map-row svelte-axobi4", null, classes, { "error-row": get(row).error });
+                      input_1.disabled = get(row).status !== "changed" || get(phase) === "updating";
+                      set_text(text_8, get(row).name);
+                      set_text(text_9, `${$0 ?? ""} synchronized locations`);
+                      classes_1 = set_class(span_7, 1, "status svelte-axobi4", null, classes_1, {
+                        good: get(row).status === "current" || get(row).status === "success"
+                      });
+                      set_text(text_11, $1);
+                    },
+                    [
+                      () => get(row).locationCount.toLocaleString(),
+                      () => statusLabel(get(row))
+                    ]
+                  );
+                  bind_checked(input_1, () => get(row).selected, ($$value) => get(row).selected = $$value);
+                  append($$anchor5, label);
+                });
+                template_effect(() => set_text(text_7, `${get(rows).length ?? ""} map${get(rows).length === 1 ? "" : "s"}`));
+                append($$anchor4, fragment_6);
+              };
+              var alternate_3 = ($$anchor4) => {
+                var fragment_7 = comment();
+                var node_11 = first_child(fragment_7);
+                {
+                  var consequent_11 = ($$anchor5) => {
+                    var div_14 = root_20();
+                    append($$anchor5, div_14);
+                  };
+                  if_block(
+                    node_11,
+                    ($$render) => {
+                      if (get(phase) === "review" && !get(fatalError)) $$render(consequent_11);
+                    },
+                    true
+                  );
+                }
+                append($$anchor4, fragment_7);
+              };
+              if_block(node_9, ($$render) => {
+                if (get(rows).length > 0) $$render(consequent_10);
+                else $$render(alternate_3, false);
+              });
+            }
+            var node_12 = sibling(node_9, 2);
+            {
+              var consequent_12 = ($$anchor4) => {
+                var div_15 = root_21();
+                var text_12 = child(div_15);
+                template_effect(() => set_text(text_12, `Finished: ${get(successCount) ?? ""} published, ${get(failureCount) ?? ""} failed, ${get(changedCount) ?? ""} still available.`));
+                append($$anchor4, div_15);
+              };
+              if_block(node_12, ($$render) => {
+                if (get(finishedRun)) $$render(consequent_12);
+              });
+            }
+            var footer_1 = sibling(node_12, 2);
+            var button_10 = child(footer_1);
+            button_10.__click = changeToken;
+            var node_13 = sibling(button_10, 2);
+            {
+              var consequent_13 = ($$anchor4) => {
+                var button_11 = root_22();
+                button_11.__click = changeGroup;
+                template_effect(() => button_11.disabled = get(phase) === "updating");
+                append($$anchor4, button_11);
+              };
+              if_block(node_13, ($$render) => {
+                if (canChooseGroup) $$render(consequent_13);
+              });
+            }
+            var button_12 = sibling(node_13, 2);
+            button_12.__click = function(...$$args) {
+              $$props.onClose?.apply(this, $$args);
+            };
+            var node_14 = sibling(button_12, 2);
+            {
+              var consequent_14 = ($$anchor4) => {
+                var button_13 = root_23();
+                button_13.__click = retryFailures;
+                var text_13 = child(button_13);
+                template_effect(() => {
+                  button_13.disabled = get(phase) === "updating";
+                  set_text(text_13, `Retry failed (${get(failureCount) ?? ""})`);
+                });
+                append($$anchor4, button_13);
+              };
+              if_block(node_14, ($$render) => {
+                if (get(failureCount) > 0) $$render(consequent_14);
+              });
+            }
+            var button_14 = sibling(node_14, 2);
+            button_14.__click = updateSelected;
+            var text_14 = child(button_14);
             template_effect(() => {
-              button_8.disabled = get(phase) === "updating";
-              set_text(text_9, `Retry failed (${get(failureCount) ?? ""})`);
+              button_10.disabled = get(phase) === "updating";
+              button_12.disabled = get(phase) === "updating";
+              button_14.disabled = get(phase) !== "review" || get(selectedCount) === 0;
+              set_text(text_14, get(phase) === "updating" ? "Updating…" : `Update and publish (${get(selectedCount)})`);
             });
-            append($$anchor3, button_8);
+            append($$anchor3, fragment_5);
           };
-          if_block(node_9, ($$render) => {
-            if (get(failureCount) > 0) $$render(consequent_9);
-          });
+          if_block(
+            node_3,
+            ($$render) => {
+              if (get(phase) === "groups") $$render(consequent_6);
+              else $$render(alternate_4, false);
+            },
+            true
+          );
         }
-        var button_9 = sibling(node_9, 2);
-        button_9.__click = updateSelected;
-        var text_10 = child(button_9);
-        template_effect(() => {
-          button_6.disabled = get(phase) === "updating";
-          button_7.disabled = get(phase) === "updating";
-          button_9.disabled = get(phase) !== "review" || get(selectedCount) === 0;
-          set_text(text_10, get(phase) === "updating" ? "Updating…" : `Update and publish (${get(selectedCount)})`);
-        });
         append($$anchor2, fragment);
       };
       if_block(node_1, ($$render) => {
         if (get(phase) === "token") $$render(consequent_2);
-        else $$render(alternate_1, false);
+        else $$render(alternate_5, false);
       });
     }
-    template_effect(() => button.disabled = get(phase) === "updating");
+    template_effect(() => {
+      set_text(text, get(phase) === "groups" ? "Choose a map group" : "Update GeoGuessr maps");
+      button.disabled = get(phase) === "updating";
+    });
     append($$anchor, div);
     pop();
   }
   delegate(["click", "keydown"]);
   const queryParameter = "learnableMetaGroupId";
   const containerId = "learnablemeta-map-group-update";
+  const launcherButtonId = "learnablemeta-update-maps-button";
+  const mapActionsClass = "learnablemeta-map-actions";
   let app = null;
+  let launcherObserver = null;
   function clearHandoffParameter() {
     const url = new URL(window.location.href);
     url.searchParams.delete(queryParameter);
     window.history.replaceState(window.history.state, "", url);
   }
   function startMapGroupUpdate(groupId) {
-    if (!Number.isSafeInteger(groupId) || groupId <= 0 || app) return;
+    if (groupId !== void 0 && (!Number.isSafeInteger(groupId) || groupId <= 0) || app) return;
     const target = document.createElement("div");
     target.id = containerId;
     document.body.appendChild(target);
@@ -6337,12 +6519,54 @@ roundNumber: 4,
       }
     });
   }
-  function initMapGroupUpdate() {
-    if (!window.location.pathname.startsWith("/creator-hub")) return;
-    const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
-    if (!rawGroupId) return;
-    startMapGroupUpdate(Number(rawGroupId));
+  function removeLauncherButton() {
+    document.getElementById(launcherButtonId)?.remove();
+    document.querySelectorAll(`.${mapActionsClass}`).forEach((container) => container.classList.remove(mapActionsClass));
   }
+  function ensureLauncherButton() {
+    if (!window.location.pathname.startsWith("/creator-hub")) {
+      removeLauncherButton();
+      return;
+    }
+    const createMapContainer = document.querySelector('[class*="creators-hub_createMapButton"]');
+    const createMapButton = createMapContainer?.querySelector(`button:not(#${launcherButtonId})`);
+    if (!createMapContainer || !createMapButton) return;
+    createMapContainer.classList.add(mapActionsClass);
+    if (document.getElementById(launcherButtonId)) return;
+    const launcher = document.createElement("button");
+    launcher.id = launcherButtonId;
+    launcher.className = "learnablemeta-yellow-button";
+    launcher.type = "button";
+    launcher.setAttribute("aria-label", "Update LearnableMeta maps");
+    launcher.textContent = "Update maps";
+    launcher.addEventListener("click", () => startMapGroupUpdate());
+    createMapContainer.insertBefore(launcher, createMapButton);
+  }
+  function refreshLauncherButton() {
+    if (!window.location.pathname.startsWith("/creator-hub")) {
+      launcherObserver?.disconnect();
+      launcherObserver = null;
+      removeLauncherButton();
+      return;
+    }
+    ensureLauncherButton();
+    if (launcherObserver) return;
+    launcherObserver = new MutationObserver(ensureLauncherButton);
+    launcherObserver.observe(document.body, { childList: true, subtree: true });
+  }
+  function handleCreatorHubNavigation() {
+    if (window.location.pathname.startsWith("/creator-hub")) {
+      const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
+      if (rawGroupId) startMapGroupUpdate(Number(rawGroupId));
+    }
+    refreshLauncherButton();
+  }
+  function initMapGroupUpdate() {
+    handleCreatorHubNavigation();
+    window.addEventListener("urlchange", handleCreatorHubNavigation);
+  }
+  const buttonsCss = ".learnablemeta-yellow-button{display:inline-flex;align-items:center;justify-content:center;padding:8px 16px;appearance:none;font-family:inherit;font-size:12px;font-weight:700;line-height:1;white-space:nowrap;background:linear-gradient(180deg,#ffeb99,#f5c542);border:1px solid #e0b000;color:#002147;border-radius:3.75rem;box-shadow:0 2px 4px #00000026,inset 0 1px #fff6;cursor:pointer;transition:background .2s ease-in-out,transform .1s ease,box-shadow .2s ease-in-out}.learnablemeta-yellow-button:hover:not(:disabled){background:linear-gradient(180deg,#ffe066,#eab308);box-shadow:0 4px 8px #0003,inset 0 1px #ffffff80;transform:translateY(-1px)}.learnablemeta-yellow-button:active:not(:disabled){background:linear-gradient(180deg,#eab308,#d39e00);box-shadow:inset 0 2px 4px #0003;transform:translateY(1px)}.learnablemeta-yellow-button:focus-visible{outline:none;box-shadow:0 0 0 3px #eab30880,0 2px 4px #00000026}.learnablemeta-yellow-button:disabled{background:#e0e0e0;border-color:#bbb;color:#888;box-shadow:none;cursor:not-allowed;transform:none}.learnablemeta-map-actions{display:flex!important;flex-direction:row!important;align-items:center!important;gap:.75rem!important}";
+  importCSS(buttonsCss);
   if (typeof _GM_registerMenuCommand === "function") {
     _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", () => {
       if (confirm("Reset the LearnableMeta window position and size?")) {

--- a/userscript/src/lib/App.svelte
+++ b/userscript/src/lib/App.svelte
@@ -22,6 +22,7 @@
     getLastDismissedAnnouncementTimestamp,
     markAnnouncementAsDismissed
   } from './utils/announcement';
+  import { modalDialog } from './utils/modalDialog';
 
   interface Props {
     panoId: string;
@@ -208,10 +209,7 @@
       <a href="https://discord.gg/AcXEWznYZe" target="_blank" aria-label="Learnable Meta discord">
         <span class="skill-icons--discord"></span>
       </a>
-      <button
-        onclick={togglePopup}
-        aria-label="More information"
-        style="background: none; border: none; padding: 0;">
+      <button class="help-toggle-button" onclick={togglePopup} aria-label="More information">
         <span class={helpClass}></span>
       </button>
     </div>
@@ -240,52 +238,84 @@
   {/if}
 
   {#if showModal}
-    <div class="modal-backdrop">
-      <div class="modal">
-        <p>You are about to open this site in a new tab:</p>
-        <p class="modal-url">{currentUrl}</p>
-        <div class="modal-buttons">
-          <button onclick={proceed} class="proceed-btn">Continue</button>
-          <button onclick={cancel} class="close-btn">Cancel</button>
+    <div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation">
+      <div
+        class="learnablemeta-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="external-link-title"
+        use:modalDialog={{ onClose: cancel }}>
+        <div class="learnablemeta-modal-header">
+          <p class="learnablemeta-modal-eyebrow">LearnableMeta</p>
+          <h2 class="learnablemeta-modal-title" id="external-link-title">Open external link?</h2>
+          <p class="learnablemeta-modal-description">This link will open in a new browser tab.</p>
+        </div>
+        <div class="learnablemeta-modal-body">
+          <p class="learnablemeta-modal-code">{currentUrl}</p>
+        </div>
+        <div class="learnablemeta-modal-actions">
+          <button
+            type="button"
+            onclick={cancel}
+            data-modal-initial-focus
+            class="learnablemeta-button learnablemeta-button--outline">Cancel</button>
+          <button
+            type="button"
+            onclick={proceed}
+            class="learnablemeta-button learnablemeta-button--primary">Continue</button>
         </div>
       </div>
     </div>
   {/if}
 
   {#if showHelpPopup}
-    <div class="modal-backdrop">
-      <div class="modal">
-        <div class="help-message">
+    <div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation">
+      <div
+        class="learnablemeta-modal learnablemeta-modal--wide"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="learnablemeta-help-title"
+        use:modalDialog={{ onClose: togglePopup }}>
+        <div class="learnablemeta-modal-header">
+          <p class="learnablemeta-modal-eyebrow">LearnableMeta</p>
+          <h2 class="learnablemeta-modal-title" id="learnablemeta-help-title">Userscript guide</h2>
+          <p class="learnablemeta-modal-description">
+            Quick tips for using LearnableMeta while you play.
+          </p>
+        </div>
+        <div class="learnablemeta-modal-body">
           {#if checkIfOutdated()}
-            <p class="outdated">
-              <strong
-                >Your script version is out of date - please install the latest version ({getLatestVersionInfo()})!
-              </strong>
+            <p class="learnablemeta-modal-alert">
+              Your userscript is out of date. Install the latest version ({getLatestVersionInfo()}).
             </p>
           {/if}
-          <p>Welcome to LearnableMeta, we hope you are enjoying it, some quick info:</p>
-          <ul>
+          <ul class="learnablemeta-help-list">
             <li>
-              <strong>Drag to Move:</strong> Click and drag the top of the note to reposition it anywhere
+              <strong>Drag to move:</strong> Click and drag the top of the note to reposition it anywhere
               on your screen.
             </li>
             <li>
               <strong>Resize:</strong> Use the bottom-right corner to resize the note to your liking.
             </li>
             <li>
-              <strong>View Map meta list:</strong> Click the list icon to see all the metas included
+              <strong>View map meta list:</strong> Click the list icon to see all the metas included
               in the map you are currently playing.
             </li>
             <li>
-              <strong>Join the Community:</strong> Click the Discord icon to share feedback, suggest
+              <strong>Join the community:</strong> Click the Discord icon to share feedback, suggest
               improvements, or just say hi!
             </li>
             <li>
-              <strong>Outdated Script:</strong> The question mark icon will blink if the script is outdated.
+              <strong>Outdated script:</strong> The question mark icon blinks when an update is available.
             </li>
           </ul>
         </div>
-        <button class="close-btn" onclick={togglePopup}>Close</button>
+        <div class="learnablemeta-modal-actions">
+          <button
+            type="button"
+            class="learnablemeta-button learnablemeta-button--primary"
+            onclick={togglePopup}>Close</button>
+        </div>
       </div>
     </div>
   {/if}
@@ -499,104 +529,15 @@
     margin-left: 1rem;
   }
 
-  .modal-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background: rgba(30, 30, 30, 0.8);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-  }
-
-  .modal {
-    background: var(--ds-color-purple-100, #1c1836);
-    padding: 15px 25px;
-    border-radius: 8px;
-    text-align: center;
-    width: 90%;
-    max-width: 600px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-    color: #d3d3d3;
-  }
-
-  .modal p {
-    margin: 0 0 10px;
-    font-size: 17px;
-  }
-
-  .modal-url {
-    font-size: 15px;
-    font-weight: bold;
-    color: #188bd2;
-    word-break: break-word;
-    margin: 10px 0;
-  }
-
-  .modal-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 15px;
-    margin-top: 20px;
-  }
-
-  .proceed-btn {
-    background: #188bd2;
-    color: white;
-    padding: 8px 16px;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 15px;
-    transition: background-color 0.2s ease-in-out;
-  }
-
-  .proceed-btn:hover {
-    background: #0056b3;
-  }
-
-  .close-btn {
+  .help-toggle-button {
     background: transparent;
-    color: #d3d3d3;
-    padding: 8px 16px;
-    border: 1px solid #d3d3d3;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 15px;
-    transition:
-      background-color 0.2s ease-in-out,
-      color 0.2s ease-in-out;
-  }
-
-  .close-btn:hover {
-    background: #d3d3d3;
-    color: var(--ds-color-purple-100, #1c1836);
-  }
-
-  button {
-    cursor: pointer;
-    background: none;
     border: none;
     padding: 0;
+    cursor: pointer;
   }
 
   .blink {
     animation: blink-animation 1s infinite;
-  }
-
-  .help-message {
-    padding: 12px;
-    font-size: 16px;
-    line-height: 1.5;
-    text-align: left;
-
-    strong {
-      color: #007bff; /* Slightly darker or brighter blue */
-      font-weight: bold;
-    }
   }
 
   @keyframes blink-animation {
@@ -610,10 +551,6 @@
     100% {
       filter: brightness(1);
     }
-  }
-
-  .outdated strong {
-    color: red !important;
   }
 
   :global(.geometa-meta-btn) {

--- a/userscript/src/lib/components/MapGroupUpdate.svelte
+++ b/userscript/src/lib/components/MapGroupUpdate.svelte
@@ -10,6 +10,7 @@
     type MapGroupManifest
   } from '../utils/learnableMetaApi';
   import { fingerprintMapCoordinates } from '../utils/mapFingerprint';
+  import { modalDialog } from '../utils/modalDialog';
   import { getGeoguessrDraft, publishGeoguessrDraft, updateGeoguessrDraft } from '../utils/upload';
 
   type MapStatus =
@@ -299,24 +300,41 @@
     };
     return labels[row.status];
   }
+
+  function statusTone(row: MapRow): 'good' | 'warning' | 'bad' | 'working' | 'neutral' {
+    if (row.status === 'current' || row.status === 'success') return 'good';
+    if (['scan-error', 'update-error', 'publish-error'].includes(row.status)) return 'bad';
+    if (['scanning', 'updating', 'publishing'].includes(row.status)) return 'working';
+    if (row.status === 'empty') return 'neutral';
+    return 'warning';
+  }
 </script>
 
-<div class="backdrop" role="presentation">
-  <div class="panel" role="dialog" aria-modal="true" aria-labelledby="group-update-title">
-    <header>
+<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation">
+  <div
+    class="learnablemeta-modal learnablemeta-modal--map-update"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="group-update-title"
+    use:modalDialog={{ onClose, closeOnEscape: phase !== 'updating' }}>
+    <header class="learnablemeta-modal-header learnablemeta-modal-header--row">
       <div>
-        <p class="eyebrow">LearnableMeta</p>
-        <h1 id="group-update-title">
+        <p class="learnablemeta-modal-eyebrow">LearnableMeta</p>
+        <h1
+          class="learnablemeta-modal-title learnablemeta-modal-title--large"
+          id="group-update-title">
           {phase === 'groups' ? 'Choose a map group' : 'Update GeoGuessr maps'}
         </h1>
         {#if groupName}<p class="subtitle">{groupName}</p>{/if}
       </div>
       <button
-        class="icon-button"
+        class="learnablemeta-button learnablemeta-button--ghost map-update-close"
         onclick={onClose}
         disabled={phase === 'updating'}
         aria-label="Close">
-        ×
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18 6 6 18M6 6l12 12"></path>
+        </svg>
       </button>
     </header>
 
@@ -332,11 +350,16 @@
           bind:value={tokenInput}
           placeholder="LearnableMeta API token"
           aria-label="LearnableMeta API token"
+          class="learnablemeta-modal-input"
+          data-modal-initial-focus
           onkeydown={(event) => event.key === 'Enter' && void saveTokenAndContinue()} />
         {#if tokenError}<p class="error-text">{tokenError}</p>{/if}
-        <div class="actions">
-          <button class="secondary" onclick={onClose}>Cancel</button>
-          <button class="primary" onclick={saveTokenAndContinue}>Save and continue</button>
+        <div class="learnablemeta-modal-actions token-actions">
+          <button class="learnablemeta-button learnablemeta-button--outline" onclick={onClose}
+            >Cancel</button>
+          <button
+            class="learnablemeta-button learnablemeta-button--primary"
+            onclick={saveTokenAndContinue}>Save and continue</button>
         </div>
       </div>
     {:else if phase === 'groups'}
@@ -346,24 +369,37 @@
         <div class="fatal">
           <strong>Could not load your map groups.</strong>
           <span>{fatalError}</span>
-          <button class="secondary" onclick={loadAccessibleGroups}>Try again</button>
+          <button
+            class="learnablemeta-button learnablemeta-button--outline"
+            onclick={loadAccessibleGroups}>Try again</button>
         </div>
       {:else if accessibleGroups.length > 0}
         <div class="notice">Select a synchronized LearnableMeta group to compare its maps.</div>
         <div class="group-list">
           {#each accessibleGroups as group (group.id)}
             <button class="group-row" onclick={() => selectGroup(group.id)}>
-              <strong>{group.name}</strong>
-              <span>{group.mapCount} map{group.mapCount === 1 ? '' : 's'}</span>
+              <span class="group-details">
+                <strong>{group.name}</strong>
+                <span>Synchronized and ready to compare</span>
+              </span>
+              <span class="group-count">
+                {group.mapCount} map{group.mapCount === 1 ? '' : 's'}
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6"></path>
+                </svg>
+              </span>
             </button>
           {/each}
         </div>
       {:else}
         <div class="notice">You have no synchronized map groups containing maps.</div>
       {/if}
-      <footer class="actions">
-        <button class="link-button token-button" onclick={changeToken}>Change API token</button>
-        <button class="secondary" onclick={onClose}>Close</button>
+      <footer class="learnablemeta-modal-actions">
+        <button
+          class="learnablemeta-button learnablemeta-button--link learnablemeta-modal-action-leading"
+          onclick={changeToken}>Change API token</button>
+        <button class="learnablemeta-button learnablemeta-button--outline" onclick={onClose}
+          >Close</button>
       </footer>
     {:else}
       {#if phase === 'scanning'}
@@ -373,7 +409,8 @@
         <div class="fatal">
           <strong>Could not load this group.</strong>
           <span>{fatalError}</span>
-          <button class="secondary" onclick={scanGroup}>Try again</button>
+          <button class="learnablemeta-button learnablemeta-button--outline" onclick={scanGroup}
+            >Try again</button>
         </div>
       {/if}
 
@@ -381,13 +418,17 @@
         <div class="toolbar">
           <span>{rows.length} map{rows.length === 1 ? '' : 's'}</span>
           <div>
-            <button class="link-button" onclick={() => selectChanged(true)}>Select changed</button>
-            <button class="link-button" onclick={() => selectChanged(false)}>Deselect all</button>
+            <button
+              class="learnablemeta-button learnablemeta-button--link"
+              onclick={() => selectChanged(true)}>Select changed</button>
+            <button
+              class="learnablemeta-button learnablemeta-button--link"
+              onclick={() => selectChanged(false)}>Deselect all</button>
           </div>
         </div>
         <div class="map-list">
           {#each rows as row (row.geoguessrId)}
-            <label class:error-row={row.error} class="map-row">
+            <label class:error-row={row.error} class:selected={row.selected} class="map-row">
               <input
                 type="checkbox"
                 bind:checked={row.selected}
@@ -397,9 +438,7 @@
                 <span>{row.locationCount.toLocaleString()} synchronized locations</span>
                 {#if row.error}<span class="row-error">{row.error}</span>{/if}
               </span>
-              <span
-                class:good={row.status === 'current' || row.status === 'success'}
-                class="status">
+              <span class="status {statusTone(row)}">
                 {statusLabel(row)}
               </span>
             </label>
@@ -415,26 +454,35 @@
         </div>
       {/if}
 
-      <footer class="actions">
+      <footer class="learnablemeta-modal-actions">
         <button
-          class="link-button token-button"
+          class="learnablemeta-button learnablemeta-button--link learnablemeta-modal-action-leading"
           onclick={changeToken}
           disabled={phase === 'updating'}>
           Change API token
         </button>
         {#if canChooseGroup}
-          <button class="link-button" onclick={changeGroup} disabled={phase === 'updating'}>
+          <button
+            class="learnablemeta-button learnablemeta-button--link"
+            onclick={changeGroup}
+            disabled={phase === 'updating'}>
             Change group
           </button>
         {/if}
-        <button class="secondary" onclick={onClose} disabled={phase === 'updating'}>Close</button>
+        <button
+          class="learnablemeta-button learnablemeta-button--outline"
+          onclick={onClose}
+          disabled={phase === 'updating'}>Close</button>
         {#if failureCount > 0}
-          <button class="secondary" onclick={retryFailures} disabled={phase === 'updating'}>
+          <button
+            class="learnablemeta-button learnablemeta-button--outline"
+            onclick={retryFailures}
+            disabled={phase === 'updating'}>
             Retry failed ({failureCount})
           </button>
         {/if}
         <button
-          class="primary"
+          class="learnablemeta-button learnablemeta-button--primary"
           onclick={updateSelected}
           disabled={phase !== 'review' || selectedCount === 0}>
           {phase === 'updating' ? 'Updating…' : `Update and publish (${selectedCount})`}
@@ -445,91 +493,73 @@
 </div>
 
 <style>
-  .backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
-    background: rgba(4, 8, 18, 0.78);
-    font-family: Arial, sans-serif;
-    color: #172033;
-  }
-  .panel {
-    width: min(780px, 100%);
-    max-height: min(760px, calc(100vh - 48px));
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    border: 1px solid #d8dee9;
-    border-radius: 14px;
-    background: #fff;
-    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.45);
-  }
-  header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    padding: 22px 24px 18px;
-    border-bottom: 1px solid #e8ebf0;
-  }
-  h1 {
-    margin: 2px 0 0;
-    font-size: 24px;
-    color: #101828;
-  }
-  .eyebrow {
-    margin: 0;
-    color: #936b00;
-    font-size: 11px;
-    font-weight: 800;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-  }
   .subtitle {
-    margin: 5px 0 0;
-    color: #667085;
+    margin: 6px 0 0;
+    color: var(--lm-muted-foreground);
+    font-size: 14px;
   }
-  .icon-button {
-    border: 0;
-    background: transparent;
-    font-size: 28px;
-    color: #667085;
-    cursor: pointer;
+  .map-update-close {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+  }
+  .map-update-close svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
   }
   .notice,
   .fatal,
   .summary {
     margin: 18px 24px 0;
-    padding: 12px 14px;
-    border-radius: 8px;
-    background: #f5f7fa;
+    padding: 13px 15px;
+    border: 1px solid var(--lm-border);
+    border-radius: var(--lm-radius);
+    background: var(--lm-muted);
+    color: var(--lm-muted-foreground);
+    font-size: 14px;
+    line-height: 1.45;
   }
   .fatal {
     display: grid;
-    gap: 8px;
-    background: #fff1f1;
-    color: #8a1c1c;
+    gap: 10px;
+    border-color: rgba(220, 38, 38, 0.35);
+    background: rgba(220, 38, 38, 0.09);
+    color: var(--lm-destructive);
+  }
+  .fatal .learnablemeta-button {
+    justify-self: start;
   }
   .summary {
-    background: #eef8ee;
-    color: #245b29;
+    border-color: rgba(22, 163, 74, 0.3);
+    background: rgba(22, 163, 74, 0.1);
+    color: #166534;
   }
   .toolbar {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 16px 24px 10px;
-    color: #475467;
+    gap: 16px;
+    padding: 18px 24px 10px;
+    color: var(--lm-muted-foreground);
     font-size: 13px;
+    font-weight: 500;
+  }
+  .toolbar > div {
+    display: flex;
+    gap: 4px;
   }
   .group-list {
     display: grid;
     gap: 8px;
     overflow-y: auto;
+    max-height: 390px;
     margin: 14px 24px 0;
+    padding: 1px;
   }
   .group-row {
     display: flex;
@@ -537,28 +567,69 @@
     justify-content: space-between;
     gap: 16px;
     width: 100%;
-    border: 1px solid #d9dee7;
-    border-radius: 9px;
-    padding: 13px 15px;
-    background: #fff;
-    color: #172033;
+    min-height: 62px;
+    border: 1px solid var(--lm-border);
+    border-radius: var(--lm-radius);
+    padding: 12px 14px;
+    background: var(--lm-card);
+    color: var(--lm-card-foreground);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
     text-align: left;
     cursor: pointer;
+    transition:
+      border-color 0.15s ease,
+      background-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
   .group-row:hover {
-    border-color: #d3a300;
-    background: #fffaf0;
+    border-color: var(--lm-ring);
+    background: color-mix(in srgb, var(--lm-primary) 6%, var(--lm-card));
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   }
-  .group-row span {
-    flex: none;
-    color: #667085;
+  .group-row:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--lm-ring) 30%, transparent);
+  }
+  .group-details {
+    display: grid;
+    min-width: 0;
+    gap: 3px;
+  }
+  .group-details strong {
+    overflow: hidden;
+    font-size: 14px;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .group-details > span {
+    color: var(--lm-muted-foreground);
     font-size: 12px;
+  }
+  .group-count {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    gap: 6px;
+    color: var(--lm-muted-foreground);
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .group-count svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
   }
   .map-list {
     overflow-y: auto;
     margin: 0 24px;
-    border: 1px solid #e4e7ec;
-    border-radius: 9px;
+    border: 1px solid var(--lm-border);
+    border-radius: var(--lm-radius);
+    background: var(--lm-card);
   }
   .map-row {
     display: grid;
@@ -566,13 +637,26 @@
     gap: 10px;
     align-items: center;
     padding: 12px 14px;
-    border-bottom: 1px solid #eef0f3;
+    border-bottom: 1px solid var(--lm-border);
+    color: var(--lm-card-foreground);
+    transition: background-color 0.15s ease;
+  }
+  .map-row:hover {
+    background: var(--lm-muted);
+  }
+  .map-row.selected {
+    background: color-mix(in srgb, var(--lm-primary) 7%, var(--lm-card));
   }
   .map-row:last-child {
     border-bottom: 0;
   }
   .map-row.error-row {
-    background: #fffafa;
+    background: rgba(220, 38, 38, 0.06);
+  }
+  .map-row input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--lm-primary);
   }
   .map-details {
     display: grid;
@@ -581,119 +665,113 @@
   }
   .map-details strong {
     overflow: hidden;
+    font-size: 14px;
+    font-weight: 600;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
   .map-details > span {
-    color: #667085;
+    color: var(--lm-muted-foreground);
     font-size: 12px;
   }
   .map-details .row-error {
-    color: #a32626;
+    color: var(--lm-destructive);
     white-space: normal;
   }
   .status {
-    padding: 4px 8px;
-    border-radius: 999px;
-    background: #fff2cc;
-    color: #765700;
-    font-size: 11px;
-    font-weight: 700;
+    padding: 3px 8px;
+    border: 1px solid transparent;
+    border-radius: calc(var(--lm-radius) - 2px);
+    font-size: 12px;
+    font-weight: 500;
     white-space: nowrap;
   }
   .status.good {
-    background: #e9f8ec;
-    color: #24612d;
+    border-color: #bbf7d0;
+    background: #dcfce7;
+    color: #166534;
   }
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 9px;
-    padding: 18px 24px 22px;
+  .status.warning {
+    border-color: #fde68a;
+    background: #fef3c7;
+    color: #854d0e;
   }
-  button {
-    font: inherit;
+  .status.bad {
+    border-color: #fecaca;
+    background: #fee2e2;
+    color: #991b1b;
   }
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.55;
+  .status.working {
+    border-color: #bfdbfe;
+    background: #dbeafe;
+    color: #1e40af;
   }
-  .primary,
-  .secondary {
-    border-radius: 7px;
-    padding: 9px 14px;
-    font-weight: 700;
-    cursor: pointer;
-  }
-  .primary {
-    border: 1px solid #d3a300;
-    background: #f5c542;
-    color: #172033;
-  }
-  .secondary {
-    border: 1px solid #cfd5df;
-    background: #fff;
-    color: #344054;
-  }
-  .link-button {
-    border: 0;
-    padding: 4px 7px;
-    background: transparent;
-    color: #3458a5;
-    cursor: pointer;
-  }
-  .token-button {
-    margin-right: auto;
+  .status.neutral {
+    border-color: var(--lm-border);
+    background: var(--lm-muted);
+    color: var(--lm-muted-foreground);
   }
   .token-form {
     display: grid;
     gap: 12px;
-    padding: 22px 24px;
+    padding: 22px 24px 0;
   }
   .token-form p {
     margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
   }
   .token-form .small {
-    color: #667085;
+    color: var(--lm-muted-foreground);
     font-size: 13px;
   }
   .token-form a {
-    color: #3458a5;
+    color: var(--lm-link);
+    text-underline-offset: 3px;
   }
-  .token-form input {
-    border: 1px solid #cfd5df;
-    border-radius: 7px;
-    padding: 10px 12px;
-    font: inherit;
-  }
-  .token-form .actions {
-    padding: 4px 0 0;
+  .token-actions {
+    margin: 8px -24px 0;
   }
   .error-text {
-    color: #a32626;
+    margin: 0;
+    color: var(--lm-destructive);
     font-size: 13px;
   }
+  @media (prefers-color-scheme: dark) {
+    .summary {
+      color: #86efac;
+    }
+    .status.good {
+      border-color: rgba(34, 197, 94, 0.4);
+      background: rgba(22, 163, 74, 0.18);
+      color: #86efac;
+    }
+    .status.warning {
+      border-color: rgba(245, 158, 11, 0.4);
+      background: rgba(180, 83, 9, 0.2);
+      color: #fde68a;
+    }
+    .status.bad {
+      border-color: rgba(239, 68, 68, 0.4);
+      background: rgba(185, 28, 28, 0.2);
+      color: #fca5a5;
+    }
+    .status.working {
+      border-color: rgba(59, 130, 246, 0.4);
+      background: rgba(30, 64, 175, 0.22);
+      color: #93c5fd;
+    }
+  }
   @media (max-width: 620px) {
-    .backdrop {
-      padding: 8px;
-    }
-    .panel {
-      max-height: calc(100vh - 16px);
-    }
     .map-row {
       grid-template-columns: 22px minmax(0, 1fr);
+    }
+    .group-details > span {
+      display: none;
     }
     .status {
       grid-column: 2;
       justify-self: start;
-    }
-    footer.actions {
-      flex-wrap: wrap;
-    }
-    .token-button {
-      width: 100%;
-      text-align: left;
     }
   }
 </style>

--- a/userscript/src/lib/components/MapGroupUpdate.svelte
+++ b/userscript/src/lib/components/MapGroupUpdate.svelte
@@ -2,9 +2,11 @@
   import { onMount } from 'svelte';
   import { clearApiKey, getApiKey, saveApiKey, URL_TO_GENERATE_TOKEN } from '../utils/apiKey';
   import {
+    fetchAccessibleMapGroups,
     fetchMapGroupManifest,
     fetchSyncedMapLocations,
     LearnableMetaApiError,
+    type AccessibleMapGroup,
     type MapGroupManifest
   } from '../utils/learnableMetaApi';
   import { fingerprintMapCoordinates } from '../utils/mapFingerprint';
@@ -28,13 +30,17 @@
     error?: string;
   };
 
-  let { groupId, onClose }: { groupId: number; onClose: () => void } = $props();
+  let { groupId: initialGroupId, onClose }: { groupId?: number; onClose: () => void } = $props();
 
-  let phase = $state<'token' | 'scanning' | 'review' | 'updating'>('scanning');
+  const canChooseGroup = initialGroupId === undefined;
+  let activeGroupId = $state<number | null>(initialGroupId ?? null);
+  let phase = $state<'token' | 'groups' | 'scanning' | 'review' | 'updating'>('scanning');
   let apiToken = $state('');
   let tokenInput = $state('');
   let tokenError = $state('');
   let groupName = $state('');
+  let accessibleGroups: AccessibleMapGroup[] = $state([]);
+  let groupsLoading = $state(false);
   let rows: MapRow[] = $state([]);
   let fatalError = $state('');
   let finishedRun = $state(false);
@@ -57,7 +63,7 @@
         return;
       }
       apiToken = savedToken;
-      void scanGroup();
+      void continueWithToken();
     } catch (error) {
       phase = 'token';
       tokenError = errorMessage(error);
@@ -73,7 +79,7 @@
     if (index !== -1) rows[index] = { ...rows[index], ...update };
   }
 
-  async function saveTokenAndScan() {
+  async function saveTokenAndContinue() {
     const trimmed = tokenInput.trim();
     if (!trimmed) {
       tokenError = 'Paste a valid LearnableMeta API token.';
@@ -83,7 +89,7 @@
     apiToken = trimmed;
     tokenInput = '';
     tokenError = '';
-    await scanGroup();
+    await continueWithToken();
   }
 
   function changeToken() {
@@ -92,14 +98,60 @@
     phase = 'token';
   }
 
+  async function continueWithToken() {
+    if (activeGroupId === null) {
+      await loadAccessibleGroups();
+    } else {
+      await scanGroup();
+    }
+  }
+
+  async function loadAccessibleGroups() {
+    phase = 'groups';
+    fatalError = '';
+    finishedRun = false;
+    groupName = '';
+    rows = [];
+    accessibleGroups = [];
+    groupsLoading = true;
+    try {
+      accessibleGroups = await fetchAccessibleMapGroups(apiToken);
+    } catch (error) {
+      if (error instanceof LearnableMetaApiError && error.status === 401) {
+        clearApiKey();
+        apiToken = '';
+        tokenError = 'Your LearnableMeta API token was rejected. Paste a new token.';
+        phase = 'token';
+        return;
+      }
+      fatalError = errorMessage(error);
+    } finally {
+      groupsLoading = false;
+    }
+  }
+
+  function selectGroup(groupId: number) {
+    activeGroupId = groupId;
+    void scanGroup();
+  }
+
+  function changeGroup() {
+    activeGroupId = null;
+    void loadAccessibleGroups();
+  }
+
   async function scanGroup() {
+    if (activeGroupId === null) {
+      await loadAccessibleGroups();
+      return;
+    }
     phase = 'scanning';
     fatalError = '';
     finishedRun = false;
     groupName = '';
     rows = [];
     try {
-      const manifest = await fetchMapGroupManifest(groupId, apiToken);
+      const manifest = await fetchMapGroupManifest(activeGroupId, apiToken);
       groupName = manifest.group.name;
       rows = manifest.maps.map((map) => ({
         ...map,
@@ -254,7 +306,9 @@
     <header>
       <div>
         <p class="eyebrow">LearnableMeta</p>
-        <h1 id="group-update-title">Update GeoGuessr maps</h1>
+        <h1 id="group-update-title">
+          {phase === 'groups' ? 'Choose a map group' : 'Update GeoGuessr maps'}
+        </h1>
         {#if groupName}<p class="subtitle">{groupName}</p>{/if}
       </div>
       <button
@@ -278,13 +332,39 @@
           bind:value={tokenInput}
           placeholder="LearnableMeta API token"
           aria-label="LearnableMeta API token"
-          onkeydown={(event) => event.key === 'Enter' && void saveTokenAndScan()} />
+          onkeydown={(event) => event.key === 'Enter' && void saveTokenAndContinue()} />
         {#if tokenError}<p class="error-text">{tokenError}</p>{/if}
         <div class="actions">
           <button class="secondary" onclick={onClose}>Cancel</button>
-          <button class="primary" onclick={saveTokenAndScan}>Save and scan</button>
+          <button class="primary" onclick={saveTokenAndContinue}>Save and continue</button>
         </div>
       </div>
+    {:else if phase === 'groups'}
+      {#if groupsLoading}
+        <div class="notice">Loading your synchronized map groups…</div>
+      {:else if fatalError}
+        <div class="fatal">
+          <strong>Could not load your map groups.</strong>
+          <span>{fatalError}</span>
+          <button class="secondary" onclick={loadAccessibleGroups}>Try again</button>
+        </div>
+      {:else if accessibleGroups.length > 0}
+        <div class="notice">Select a synchronized LearnableMeta group to compare its maps.</div>
+        <div class="group-list">
+          {#each accessibleGroups as group (group.id)}
+            <button class="group-row" onclick={() => selectGroup(group.id)}>
+              <strong>{group.name}</strong>
+              <span>{group.mapCount} map{group.mapCount === 1 ? '' : 's'}</span>
+            </button>
+          {/each}
+        </div>
+      {:else}
+        <div class="notice">You have no synchronized map groups containing maps.</div>
+      {/if}
+      <footer class="actions">
+        <button class="link-button token-button" onclick={changeToken}>Change API token</button>
+        <button class="secondary" onclick={onClose}>Close</button>
+      </footer>
     {:else}
       {#if phase === 'scanning'}
         <div class="notice">Loading synchronized maps and comparing GeoGuessr drafts…</div>
@@ -342,6 +422,11 @@
           disabled={phase === 'updating'}>
           Change API token
         </button>
+        {#if canChooseGroup}
+          <button class="link-button" onclick={changeGroup} disabled={phase === 'updating'}>
+            Change group
+          </button>
+        {/if}
         <button class="secondary" onclick={onClose} disabled={phase === 'updating'}>Close</button>
         {#if failureCount > 0}
           <button class="secondary" onclick={retryFailures} disabled={phase === 'updating'}>
@@ -439,6 +524,35 @@
     padding: 16px 24px 10px;
     color: #475467;
     font-size: 13px;
+  }
+  .group-list {
+    display: grid;
+    gap: 8px;
+    overflow-y: auto;
+    margin: 14px 24px 0;
+  }
+  .group-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    width: 100%;
+    border: 1px solid #d9dee7;
+    border-radius: 9px;
+    padding: 13px 15px;
+    background: #fff;
+    color: #172033;
+    text-align: left;
+    cursor: pointer;
+  }
+  .group-row:hover {
+    border-color: #d3a300;
+    background: #fffaf0;
+  }
+  .group-row span {
+    flex: none;
+    color: #667085;
+    font-size: 12px;
   }
   .map-list {
     overflow-y: auto;

--- a/userscript/src/lib/components/MapGroupUpdate.svelte
+++ b/userscript/src/lib/components/MapGroupUpdate.svelte
@@ -1,0 +1,585 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { clearApiKey, getApiKey, saveApiKey, URL_TO_GENERATE_TOKEN } from '../utils/apiKey';
+  import {
+    fetchMapGroupManifest,
+    fetchSyncedMapLocations,
+    LearnableMetaApiError,
+    type MapGroupManifest
+  } from '../utils/learnableMetaApi';
+  import { fingerprintMapCoordinates } from '../utils/mapFingerprint';
+  import { getGeoguessrDraft, publishGeoguessrDraft, updateGeoguessrDraft } from '../utils/upload';
+
+  type MapStatus =
+    | 'scanning'
+    | 'changed'
+    | 'current'
+    | 'empty'
+    | 'scan-error'
+    | 'updating'
+    | 'publishing'
+    | 'success'
+    | 'update-error'
+    | 'publish-error';
+
+  type MapRow = MapGroupManifest['maps'][number] & {
+    status: MapStatus;
+    selected: boolean;
+    error?: string;
+  };
+
+  let { groupId, onClose }: { groupId: number; onClose: () => void } = $props();
+
+  let phase = $state<'token' | 'scanning' | 'review' | 'updating'>('scanning');
+  let apiToken = $state('');
+  let tokenInput = $state('');
+  let tokenError = $state('');
+  let groupName = $state('');
+  let rows: MapRow[] = $state([]);
+  let fatalError = $state('');
+  let finishedRun = $state(false);
+
+  let selectedCount = $derived(
+    rows.filter((row) => row.status === 'changed' && row.selected).length
+  );
+  let failureCount = $derived(
+    rows.filter((row) => ['scan-error', 'update-error', 'publish-error'].includes(row.status))
+      .length
+  );
+  let successCount = $derived(rows.filter((row) => row.status === 'success').length);
+  let changedCount = $derived(rows.filter((row) => row.status === 'changed').length);
+
+  onMount(() => {
+    try {
+      const savedToken = getApiKey();
+      if (!savedToken) {
+        phase = 'token';
+        return;
+      }
+      apiToken = savedToken;
+      void scanGroup();
+    } catch (error) {
+      phase = 'token';
+      tokenError = errorMessage(error);
+    }
+  });
+
+  function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  function replaceRow(geoguessrId: string, update: Partial<MapRow>) {
+    const index = rows.findIndex((row) => row.geoguessrId === geoguessrId);
+    if (index !== -1) rows[index] = { ...rows[index], ...update };
+  }
+
+  async function saveTokenAndScan() {
+    const trimmed = tokenInput.trim();
+    if (!trimmed) {
+      tokenError = 'Paste a valid LearnableMeta API token.';
+      return;
+    }
+    saveApiKey(trimmed);
+    apiToken = trimmed;
+    tokenInput = '';
+    tokenError = '';
+    await scanGroup();
+  }
+
+  function changeToken() {
+    tokenInput = '';
+    tokenError = '';
+    phase = 'token';
+  }
+
+  async function scanGroup() {
+    phase = 'scanning';
+    fatalError = '';
+    finishedRun = false;
+    groupName = '';
+    rows = [];
+    try {
+      const manifest = await fetchMapGroupManifest(groupId, apiToken);
+      groupName = manifest.group.name;
+      rows = manifest.maps.map((map) => ({
+        ...map,
+        status: map.locationCount === 0 ? 'empty' : 'scanning',
+        selected: false
+      }));
+
+      let nextIndex = 0;
+      async function worker() {
+        while (nextIndex < rows.length) {
+          const row = rows[nextIndex++];
+          if (row.status === 'scanning') await scanMap(row);
+        }
+      }
+      await Promise.all(Array.from({ length: Math.min(3, rows.length) }, () => worker()));
+      phase = 'review';
+    } catch (error) {
+      if (error instanceof LearnableMetaApiError && error.status === 401) {
+        clearApiKey();
+        apiToken = '';
+        tokenError = 'Your LearnableMeta API token was rejected. Paste a new token.';
+        phase = 'token';
+        return;
+      }
+      fatalError = errorMessage(error);
+      phase = 'review';
+    }
+  }
+
+  async function scanMap(row: MapRow) {
+    replaceRow(row.geoguessrId, { status: 'scanning', error: undefined, selected: false });
+    try {
+      const draft = await getGeoguessrDraft(row.geoguessrId);
+      const fingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+      const changed = fingerprint !== row.fingerprint;
+      replaceRow(row.geoguessrId, {
+        status: changed ? 'changed' : 'current',
+        selected: changed
+      });
+    } catch (error) {
+      replaceRow(row.geoguessrId, {
+        status: 'scan-error',
+        selected: false,
+        error: errorMessage(error)
+      });
+    }
+  }
+
+  function selectChanged(selected: boolean) {
+    rows = rows.map((row) => (row.status === 'changed' ? { ...row, selected } : row));
+  }
+
+  async function updateSelected() {
+    const selectedIds = rows
+      .filter((row) => row.status === 'changed' && row.selected)
+      .map((row) => row.geoguessrId);
+    if (selectedIds.length === 0) return;
+
+    phase = 'updating';
+    finishedRun = false;
+    for (const geoguessrId of selectedIds) {
+      const row = rows.find((candidate) => candidate.geoguessrId === geoguessrId);
+      if (row) await updateMap(row);
+    }
+    finishedRun = true;
+    phase = 'review';
+  }
+
+  async function updateMap(row: MapRow) {
+    replaceRow(row.geoguessrId, { status: 'updating', error: undefined });
+    let draft;
+    try {
+      draft = await getGeoguessrDraft(row.geoguessrId);
+      const currentFingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+      if (currentFingerprint === row.fingerprint) {
+        replaceRow(row.geoguessrId, { status: 'current', selected: false });
+        return;
+      }
+      const coordinates = await fetchSyncedMapLocations(row.geoguessrId, apiToken, row.fingerprint);
+      if (coordinates.length === 0) throw new Error('Cannot publish an empty map');
+      await updateGeoguessrDraft(row.geoguessrId, draft, coordinates);
+    } catch (error) {
+      replaceRow(row.geoguessrId, {
+        status: 'update-error',
+        error: errorMessage(error)
+      });
+      return;
+    }
+
+    replaceRow(row.geoguessrId, { status: 'publishing' });
+    try {
+      await publishGeoguessrDraft(row.geoguessrId);
+      replaceRow(row.geoguessrId, { status: 'success', selected: false });
+    } catch (error) {
+      replaceRow(row.geoguessrId, {
+        status: 'publish-error',
+        error: errorMessage(error)
+      });
+    }
+  }
+
+  async function retryFailures() {
+    phase = 'updating';
+    finishedRun = false;
+    const failedIds = rows
+      .filter((row) => ['scan-error', 'update-error', 'publish-error'].includes(row.status))
+      .map((row) => row.geoguessrId);
+
+    for (const geoguessrId of failedIds) {
+      const row = rows.find((candidate) => candidate.geoguessrId === geoguessrId);
+      if (!row) continue;
+      if (row.status === 'scan-error') {
+        await scanMap(row);
+      } else if (row.status === 'publish-error') {
+        replaceRow(row.geoguessrId, { status: 'publishing', error: undefined });
+        try {
+          await publishGeoguessrDraft(row.geoguessrId);
+          replaceRow(row.geoguessrId, { status: 'success', selected: false });
+        } catch (error) {
+          replaceRow(row.geoguessrId, {
+            status: 'publish-error',
+            error: errorMessage(error)
+          });
+        }
+      } else {
+        await updateMap(row);
+      }
+    }
+    finishedRun = true;
+    phase = 'review';
+  }
+
+  function statusLabel(row: MapRow): string {
+    const labels: Record<MapStatus, string> = {
+      scanning: 'Checking…',
+      changed: 'Update available',
+      current: 'Up to date',
+      empty: 'No synchronized locations',
+      'scan-error': 'Could not check',
+      updating: 'Updating draft…',
+      publishing: 'Publishing…',
+      success: 'Updated and published',
+      'update-error': 'Update failed',
+      'publish-error': 'Draft updated; publish failed'
+    };
+    return labels[row.status];
+  }
+</script>
+
+<div class="backdrop" role="presentation">
+  <div class="panel" role="dialog" aria-modal="true" aria-labelledby="group-update-title">
+    <header>
+      <div>
+        <p class="eyebrow">LearnableMeta</p>
+        <h1 id="group-update-title">Update GeoGuessr maps</h1>
+        {#if groupName}<p class="subtitle">{groupName}</p>{/if}
+      </div>
+      <button
+        class="icon-button"
+        onclick={onClose}
+        disabled={phase === 'updating'}
+        aria-label="Close">
+        ×
+      </button>
+    </header>
+
+    {#if phase === 'token'}
+      <div class="token-form">
+        <p>Paste your LearnableMeta API token to load maps you can manage.</p>
+        <p class="small">
+          Generate or replace it on your
+          <a href={URL_TO_GENERATE_TOKEN} target="_blank" rel="noopener noreferrer">token page</a>.
+        </p>
+        <input
+          type="password"
+          bind:value={tokenInput}
+          placeholder="LearnableMeta API token"
+          aria-label="LearnableMeta API token"
+          onkeydown={(event) => event.key === 'Enter' && void saveTokenAndScan()} />
+        {#if tokenError}<p class="error-text">{tokenError}</p>{/if}
+        <div class="actions">
+          <button class="secondary" onclick={onClose}>Cancel</button>
+          <button class="primary" onclick={saveTokenAndScan}>Save and scan</button>
+        </div>
+      </div>
+    {:else}
+      {#if phase === 'scanning'}
+        <div class="notice">Loading synchronized maps and comparing GeoGuessr drafts…</div>
+      {/if}
+      {#if fatalError}
+        <div class="fatal">
+          <strong>Could not load this group.</strong>
+          <span>{fatalError}</span>
+          <button class="secondary" onclick={scanGroup}>Try again</button>
+        </div>
+      {/if}
+
+      {#if rows.length > 0}
+        <div class="toolbar">
+          <span>{rows.length} map{rows.length === 1 ? '' : 's'}</span>
+          <div>
+            <button class="link-button" onclick={() => selectChanged(true)}>Select changed</button>
+            <button class="link-button" onclick={() => selectChanged(false)}>Deselect all</button>
+          </div>
+        </div>
+        <div class="map-list">
+          {#each rows as row (row.geoguessrId)}
+            <label class:error-row={row.error} class="map-row">
+              <input
+                type="checkbox"
+                bind:checked={row.selected}
+                disabled={row.status !== 'changed' || phase === 'updating'} />
+              <span class="map-details">
+                <strong>{row.name}</strong>
+                <span>{row.locationCount.toLocaleString()} synchronized locations</span>
+                {#if row.error}<span class="row-error">{row.error}</span>{/if}
+              </span>
+              <span
+                class:good={row.status === 'current' || row.status === 'success'}
+                class="status">
+                {statusLabel(row)}
+              </span>
+            </label>
+          {/each}
+        </div>
+      {:else if phase === 'review' && !fatalError}
+        <div class="notice">This group has no maps to update.</div>
+      {/if}
+
+      {#if finishedRun}
+        <div class="summary">
+          Finished: {successCount} published, {failureCount} failed, {changedCount} still available.
+        </div>
+      {/if}
+
+      <footer class="actions">
+        <button
+          class="link-button token-button"
+          onclick={changeToken}
+          disabled={phase === 'updating'}>
+          Change API token
+        </button>
+        <button class="secondary" onclick={onClose} disabled={phase === 'updating'}>Close</button>
+        {#if failureCount > 0}
+          <button class="secondary" onclick={retryFailures} disabled={phase === 'updating'}>
+            Retry failed ({failureCount})
+          </button>
+        {/if}
+        <button
+          class="primary"
+          onclick={updateSelected}
+          disabled={phase !== 'review' || selectedCount === 0}>
+          {phase === 'updating' ? 'Updating…' : `Update and publish (${selectedCount})`}
+        </button>
+      </footer>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(4, 8, 18, 0.78);
+    font-family: Arial, sans-serif;
+    color: #172033;
+  }
+  .panel {
+    width: min(780px, 100%);
+    max-height: min(760px, calc(100vh - 48px));
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid #d8dee9;
+    border-radius: 14px;
+    background: #fff;
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.45);
+  }
+  header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 22px 24px 18px;
+    border-bottom: 1px solid #e8ebf0;
+  }
+  h1 {
+    margin: 2px 0 0;
+    font-size: 24px;
+    color: #101828;
+  }
+  .eyebrow {
+    margin: 0;
+    color: #936b00;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .subtitle {
+    margin: 5px 0 0;
+    color: #667085;
+  }
+  .icon-button {
+    border: 0;
+    background: transparent;
+    font-size: 28px;
+    color: #667085;
+    cursor: pointer;
+  }
+  .notice,
+  .fatal,
+  .summary {
+    margin: 18px 24px 0;
+    padding: 12px 14px;
+    border-radius: 8px;
+    background: #f5f7fa;
+  }
+  .fatal {
+    display: grid;
+    gap: 8px;
+    background: #fff1f1;
+    color: #8a1c1c;
+  }
+  .summary {
+    background: #eef8ee;
+    color: #245b29;
+  }
+  .toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px 10px;
+    color: #475467;
+    font-size: 13px;
+  }
+  .map-list {
+    overflow-y: auto;
+    margin: 0 24px;
+    border: 1px solid #e4e7ec;
+    border-radius: 9px;
+  }
+  .map-row {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    padding: 12px 14px;
+    border-bottom: 1px solid #eef0f3;
+  }
+  .map-row:last-child {
+    border-bottom: 0;
+  }
+  .map-row.error-row {
+    background: #fffafa;
+  }
+  .map-details {
+    display: grid;
+    min-width: 0;
+    gap: 3px;
+  }
+  .map-details strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .map-details > span {
+    color: #667085;
+    font-size: 12px;
+  }
+  .map-details .row-error {
+    color: #a32626;
+    white-space: normal;
+  }
+  .status {
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: #fff2cc;
+    color: #765700;
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  .status.good {
+    background: #e9f8ec;
+    color: #24612d;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 9px;
+    padding: 18px 24px 22px;
+  }
+  button {
+    font: inherit;
+  }
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+  .primary,
+  .secondary {
+    border-radius: 7px;
+    padding: 9px 14px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .primary {
+    border: 1px solid #d3a300;
+    background: #f5c542;
+    color: #172033;
+  }
+  .secondary {
+    border: 1px solid #cfd5df;
+    background: #fff;
+    color: #344054;
+  }
+  .link-button {
+    border: 0;
+    padding: 4px 7px;
+    background: transparent;
+    color: #3458a5;
+    cursor: pointer;
+  }
+  .token-button {
+    margin-right: auto;
+  }
+  .token-form {
+    display: grid;
+    gap: 12px;
+    padding: 22px 24px;
+  }
+  .token-form p {
+    margin: 0;
+  }
+  .token-form .small {
+    color: #667085;
+    font-size: 13px;
+  }
+  .token-form a {
+    color: #3458a5;
+  }
+  .token-form input {
+    border: 1px solid #cfd5df;
+    border-radius: 7px;
+    padding: 10px 12px;
+    font: inherit;
+  }
+  .token-form .actions {
+    padding: 4px 0 0;
+  }
+  .error-text {
+    color: #a32626;
+    font-size: 13px;
+  }
+  @media (max-width: 620px) {
+    .backdrop {
+      padding: 8px;
+    }
+    .panel {
+      max-height: calc(100vh - 16px);
+    }
+    .map-row {
+      grid-template-columns: 22px minmax(0, 1fr);
+    }
+    .status {
+      grid-column: 2;
+      justify-self: start;
+    }
+    footer.actions {
+      flex-wrap: wrap;
+    }
+    .token-button {
+      width: 100%;
+      text-align: left;
+    }
+  }
+</style>

--- a/userscript/src/lib/components/ResetLayoutConfirmation.svelte
+++ b/userscript/src/lib/components/ResetLayoutConfirmation.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { modalDialog } from '../utils/modalDialog';
+
+  let { onCancel, onConfirm }: { onCancel: () => void; onConfirm: () => void } = $props();
+</script>
+
+<div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation">
+  <div
+    class="learnablemeta-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="reset-layout-title"
+    use:modalDialog={{ onClose: onCancel }}>
+    <div class="learnablemeta-modal-header">
+      <p class="learnablemeta-modal-eyebrow">LearnableMeta</p>
+      <h2 class="learnablemeta-modal-title" id="reset-layout-title">Reset window layout?</h2>
+      <p class="learnablemeta-modal-description">
+        The meta window will return to its default position and size.
+      </p>
+    </div>
+    <div class="learnablemeta-modal-actions">
+      <button
+        type="button"
+        onclick={onCancel}
+        data-modal-initial-focus
+        class="learnablemeta-button learnablemeta-button--outline">Cancel</button>
+      <button
+        type="button"
+        onclick={onConfirm}
+        class="learnablemeta-button learnablemeta-button--primary">Reset layout</button>
+    </div>
+  </div>
+</div>

--- a/userscript/src/lib/components/UploadLocations.svelte
+++ b/userscript/src/lib/components/UploadLocations.svelte
@@ -3,6 +3,7 @@
   import { uploadLocations } from '../utils/upload';
   import ToastNotification from './ToastNotification.svelte';
   import { clearApiKey, getApiKey, saveApiKey, URL_TO_GENERATE_TOKEN } from '../utils/apiKey';
+  import { modalDialog } from '../utils/modalDialog';
 
   let { mapId }: { mapId: string } = $props();
 
@@ -154,12 +155,12 @@
   }
 </script>
 
-<div class="upload-label-container">
-  <button class="learnablemeta-yellow-button" onclick={handleUploadClick} disabled={isLoading}>
+<div class="upload-label-container learnablemeta-ui">
+  <button class="learnablemeta-geoguessr-button" onclick={handleUploadClick} disabled={isLoading}>
     {isLoading ? 'Uploading...' : 'LearnableMeta - Upload'}
   </button>
   <button
-    class="api-key-button"
+    class="learnablemeta-geoguessr-button learnablemeta-geoguessr-button--icon"
     onclick={openManageKeyModal}
     disabled={isLoading}
     title="Manage LearnableMeta API key"
@@ -169,43 +170,68 @@
 </div>
 
 {#if showApiKeyModal}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="apiKeyModalTitle">
-    <div class="modal-content">
-      <h2 id="apiKeyModalTitle">LearnableMeta API Key</h2>
-      {#if modalMode === 'upload'}
-        <p>An API key is required to upload locations. Please paste your key below.</p>
-      {:else if currentApiKey}
-        <p>
-          A key ending in <code>…{currentApiKey.slice(-4)}</code> is currently saved. Paste a new key
-          to replace it, or clear the saved key.
+  <div class="learnablemeta-modal-backdrop learnablemeta-ui" role="presentation">
+    <div
+      class="learnablemeta-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="apiKeyModalTitle"
+      use:modalDialog={{ onClose: handleCancelModal }}>
+      <div class="learnablemeta-modal-header">
+        <p class="learnablemeta-modal-eyebrow">LearnableMeta</p>
+        <h2 class="learnablemeta-modal-title" id="apiKeyModalTitle">API token</h2>
+        <p class="learnablemeta-modal-description">
+          Manage the token used to download synchronized locations.
         </p>
-      {:else}
-        <p>No API key is saved yet. Paste your key below.</p>
-      {/if}
-      <p>
-        You can generate your API token on your
-        <a href={URL_TO_GENERATE_TOKEN} target="_blank" rel="noopener noreferrer">
-          LearnableMeta profile page</a
-        >.
-      </p>
-      <input
-        type="text"
-        bind:value={apiKeyInput}
-        placeholder="Paste your API key here"
-        aria-label="API Key Input"
-        class="modal-input" />
-      <div class="modal-actions">
-        {#if modalMode === 'manage' && currentApiKey}
-          <button onclick={handleClearApiKey} class="modal-button modal-button-clear"
-            >Clear Key</button>
-        {/if}
-        <button onclick={handleSaveApiKey} class="modal-button modal-button-save"
-          >{modalMode === 'upload' ? 'Save & Upload' : 'Save'}</button>
-        <button onclick={handleCancelModal} class="modal-button modal-button-cancel">Cancel</button>
       </div>
-      <p class="modal-note">
-        Your API key will be stored securely in your browser's userscript storage for future use.
-      </p>
+      <div class="learnablemeta-modal-body">
+        {#if modalMode === 'upload'}
+          <p>An API token is required before locations can be uploaded.</p>
+        {:else if currentApiKey}
+          <p>
+            A token ending in <code class="saved-key">…{currentApiKey.slice(-4)}</code> is saved. Paste
+            a new token to replace it, or clear the saved token.
+          </p>
+        {:else}
+          <p>No API token is saved yet.</p>
+        {/if}
+        <p>
+          Generate or replace your token on the
+          <a href={URL_TO_GENERATE_TOKEN} target="_blank" rel="noopener noreferrer">
+            LearnableMeta profile page</a
+          >.
+        </p>
+        <input
+          type="text"
+          bind:value={apiKeyInput}
+          placeholder="Paste your API token"
+          aria-label="LearnableMeta API token"
+          data-modal-initial-focus
+          class="learnablemeta-modal-input" />
+        <p class="learnablemeta-modal-note">
+          The token is stored only in your browser's userscript storage.
+        </p>
+      </div>
+      <div class="learnablemeta-modal-actions">
+        {#if modalMode === 'manage' && currentApiKey}
+          <button
+            type="button"
+            onclick={handleClearApiKey}
+            class="learnablemeta-button learnablemeta-button--destructive learnablemeta-modal-action-leading">
+            Clear token
+          </button>
+        {/if}
+        <button
+          type="button"
+          onclick={handleCancelModal}
+          class="learnablemeta-button learnablemeta-button--outline">Cancel</button>
+        <button
+          type="button"
+          onclick={handleSaveApiKey}
+          class="learnablemeta-button learnablemeta-button--primary">
+          {modalMode === 'upload' ? 'Save and upload' : 'Save'}
+        </button>
+      </div>
     </div>
   </div>
 {/if}
@@ -222,144 +248,15 @@
   .upload-label-container {
     display: flex;
     align-items: center;
+    gap: 6px;
   }
 
-  .api-key-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 6px;
-    width: 30px;
-    height: 30px;
-    padding: 0;
-    font-size: 14px;
-    line-height: 1;
-    background: linear-gradient(180deg, #ffeb99 0%, #f5c542 100%);
-    border: 1px solid #e0b000;
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow:
-      0 2px 4px rgba(0, 0, 0, 0.15),
-      inset 0 1px 0 rgba(255, 255, 255, 0.4);
-    transition: background 0.2s ease-in-out;
-  }
-
-  .api-key-button:hover:not(:disabled) {
-    background: linear-gradient(180deg, #ffe066 0%, #eab308 100%);
-  }
-
-  .api-key-button:disabled {
-    background: #e0e0e0;
-    border-color: #bbbbbb;
-    cursor: not-allowed;
-  }
-
-  .modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.6);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 10000;
-  }
-
-  .modal-content {
-    background-color: white;
-    padding: 25px 30px;
-    border-radius: 8px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-    width: 90%;
-    max-width: 450px;
-    color: #333;
-  }
-
-  .modal-content h2 {
-    margin-top: 0;
-    margin-bottom: 15px;
-    color: #2c3e50;
-  }
-
-  .modal-content p {
-    margin-bottom: 15px;
-    line-height: 1.6;
-  }
-
-  .modal-content p a {
-    color: #007bff;
-    text-decoration: underline;
-  }
-
-  .modal-content p a:hover {
-    color: #0056b3;
-  }
-
-  .modal-input {
-    width: calc(100% - 20px);
-    padding: 10px;
-    margin-bottom: 20px;
-    border: 1px solid #ccc;
+  .saved-key {
     border-radius: 4px;
-    font-size: 1em;
-  }
-
-  .modal-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
-  }
-
-  .modal-button {
-    padding: 10px 18px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-weight: bold;
-    transition: background-color 0.2s ease;
-  }
-
-  .modal-button-save {
-    background-color: #28a745;
-    color: white;
-  }
-
-  .modal-button-save:hover {
-    background-color: #218838;
-  }
-
-  .modal-button-cancel {
-    background-color: #6c757d;
-    color: white;
-  }
-
-  .modal-button-cancel:hover {
-    background-color: #5a6268;
-  }
-
-  .modal-button-clear {
-    background-color: #dc3545;
-    color: white;
-    margin-right: auto;
-  }
-
-  .modal-button-clear:hover {
-    background-color: #b02a37;
-  }
-
-  .modal-content code {
-    background-color: #f1f3f5;
-    padding: 1px 5px;
-    border-radius: 3px;
-    font-size: 0.9em;
-  }
-
-  .modal-note {
-    font-size: 0.85em;
-    color: #555;
-    margin-top: 15px;
-    text-align: center;
+    padding: 2px 5px;
+    background: var(--lm-muted);
+    color: var(--lm-foreground);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
   }
 </style>

--- a/userscript/src/lib/components/UploadLocations.svelte
+++ b/userscript/src/lib/components/UploadLocations.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { uploadLocations } from '../utils/upload';
-  import { GM_setValue, GM_getValue } from '$';
   import ToastNotification from './ToastNotification.svelte';
+  import { clearApiKey, getApiKey, saveApiKey, URL_TO_GENERATE_TOKEN } from '../utils/apiKey';
 
   let { mapId }: { mapId: string } = $props();
-
-  const API_KEY_STORAGE_NAME = 'learnableMeta_apiKey';
-  const URL_TO_GENERATE_TOKEN = 'https://learnablemeta.com/profile/token';
 
   let showApiKeyModal = $state(false);
   let modalMode = $state<'upload' | 'manage'>('upload');
@@ -54,7 +51,7 @@
 
   function getApiKeyFromGM(): string | null {
     try {
-      return GM_getValue(API_KEY_STORAGE_NAME, null);
+      return getApiKey();
     } catch (e) {
       console.warn('GM_getValue is not available. API key functionality might be limited.', e);
       showCustomToast(
@@ -68,7 +65,7 @@
 
   function saveApiKeyToGM(key: string): void {
     try {
-      GM_setValue(API_KEY_STORAGE_NAME, key);
+      saveApiKey(key);
     } catch (e) {
       console.warn('GM_setValue is not available. API key functionality might be limited.', e);
       showCustomToast(
@@ -103,7 +100,7 @@
   }
 
   function handleClearApiKey() {
-    saveApiKeyToGM('');
+    clearApiKey();
     currentApiKey = null;
     showApiKeyModal = false;
     showCustomToast('LearnableMeta API Key cleared.', 'success');

--- a/userscript/src/lib/components/UploadLocations.svelte
+++ b/userscript/src/lib/components/UploadLocations.svelte
@@ -155,7 +155,7 @@
 </script>
 
 <div class="upload-label-container">
-  <button class="custom-yellow-button" onclick={handleUploadClick} disabled={isLoading}>
+  <button class="learnablemeta-yellow-button" onclick={handleUploadClick} disabled={isLoading}>
     {isLoading ? 'Uploading...' : 'LearnableMeta - Upload'}
   </button>
   <button
@@ -222,61 +222,6 @@
   .upload-label-container {
     display: flex;
     align-items: center;
-  }
-
-  /* fully self-styled - geoguessr's hashed button classes change between deploys */
-  .custom-yellow-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 8px 16px;
-    font-family: inherit;
-    font-size: 12px;
-    font-weight: 700;
-    line-height: 1;
-    white-space: nowrap;
-    background: linear-gradient(180deg, #ffeb99 0%, #f5c542 100%);
-    border: 1px solid #e0b000;
-    color: #002147;
-    border-radius: 3.75rem;
-    box-shadow:
-      0 2px 4px rgba(0, 0, 0, 0.15),
-      inset 0 1px 0 rgba(255, 255, 255, 0.4);
-    cursor: pointer;
-    transition:
-      background 0.2s ease-in-out,
-      transform 0.1s ease,
-      box-shadow 0.2s ease-in-out;
-  }
-
-  .custom-yellow-button:hover:not(:disabled) {
-    background: linear-gradient(180deg, #ffe066 0%, #eab308 100%);
-    box-shadow:
-      0 4px 8px rgba(0, 0, 0, 0.2),
-      inset 0 1px 0 rgba(255, 255, 255, 0.5);
-    transform: translateY(-1px);
-  }
-
-  .custom-yellow-button:active:not(:disabled) {
-    background: linear-gradient(180deg, #eab308 0%, #d39e00 100%);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) inset;
-    transform: translateY(1px);
-  }
-
-  .custom-yellow-button:focus {
-    outline: none;
-    box-shadow:
-      0 0 0 3px rgba(234, 179, 8, 0.5),
-      0 2px 4px rgba(0, 0, 0, 0.15);
-  }
-
-  .custom-yellow-button:disabled {
-    background: #e0e0e0;
-    border-color: #bbbbbb;
-    color: #888888;
-    box-shadow: none;
-    cursor: not-allowed;
-    transform: none;
   }
 
   .api-key-button {

--- a/userscript/src/lib/mapGroupUpdate.ts
+++ b/userscript/src/lib/mapGroupUpdate.ts
@@ -56,7 +56,7 @@ function ensureLauncherButton() {
 
   const launcher = document.createElement('button');
   launcher.id = launcherButtonId;
-  launcher.className = 'learnablemeta-yellow-button';
+  launcher.className = 'learnablemeta-geoguessr-button';
   launcher.type = 'button';
   launcher.setAttribute('aria-label', 'Update LearnableMeta maps');
   launcher.textContent = 'Update maps';

--- a/userscript/src/lib/mapGroupUpdate.ts
+++ b/userscript/src/lib/mapGroupUpdate.ts
@@ -3,7 +3,10 @@ import MapGroupUpdate from './components/MapGroupUpdate.svelte';
 
 const queryParameter = 'learnableMetaGroupId';
 const containerId = 'learnablemeta-map-group-update';
+const launcherButtonId = 'learnablemeta-update-maps-button';
+const mapActionsClass = 'learnablemeta-map-actions';
 let app: Record<string, any> | null = null;
+let launcherObserver: MutationObserver | null = null;
 
 function clearHandoffParameter() {
   const url = new URL(window.location.href);
@@ -11,8 +14,8 @@ function clearHandoffParameter() {
   window.history.replaceState(window.history.state, '', url);
 }
 
-export function startMapGroupUpdate(groupId: number) {
-  if (!Number.isSafeInteger(groupId) || groupId <= 0 || app) return;
+export function startMapGroupUpdate(groupId?: number) {
+  if ((groupId !== undefined && (!Number.isSafeInteger(groupId) || groupId <= 0)) || app) return;
 
   const target = document.createElement('div');
   target.id = containerId;
@@ -31,9 +34,59 @@ export function startMapGroupUpdate(groupId: number) {
   });
 }
 
+function removeLauncherButton() {
+  document.getElementById(launcherButtonId)?.remove();
+  document
+    .querySelectorAll(`.${mapActionsClass}`)
+    .forEach((container) => container.classList.remove(mapActionsClass));
+}
+
+function ensureLauncherButton() {
+  if (!window.location.pathname.startsWith('/creator-hub')) {
+    removeLauncherButton();
+    return;
+  }
+
+  const createMapContainer = document.querySelector('[class*="creators-hub_createMapButton"]');
+  const createMapButton = createMapContainer?.querySelector(`button:not(#${launcherButtonId})`);
+  if (!createMapContainer || !createMapButton) return;
+
+  createMapContainer.classList.add(mapActionsClass);
+  if (document.getElementById(launcherButtonId)) return;
+
+  const launcher = document.createElement('button');
+  launcher.id = launcherButtonId;
+  launcher.className = 'learnablemeta-yellow-button';
+  launcher.type = 'button';
+  launcher.setAttribute('aria-label', 'Update LearnableMeta maps');
+  launcher.textContent = 'Update maps';
+  launcher.addEventListener('click', () => startMapGroupUpdate());
+  createMapContainer.insertBefore(launcher, createMapButton);
+}
+
+function refreshLauncherButton() {
+  if (!window.location.pathname.startsWith('/creator-hub')) {
+    launcherObserver?.disconnect();
+    launcherObserver = null;
+    removeLauncherButton();
+    return;
+  }
+
+  ensureLauncherButton();
+  if (launcherObserver) return;
+  launcherObserver = new MutationObserver(ensureLauncherButton);
+  launcherObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+function handleCreatorHubNavigation() {
+  if (window.location.pathname.startsWith('/creator-hub')) {
+    const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
+    if (rawGroupId) startMapGroupUpdate(Number(rawGroupId));
+  }
+  refreshLauncherButton();
+}
+
 export function initMapGroupUpdate() {
-  if (!window.location.pathname.startsWith('/creator-hub')) return;
-  const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
-  if (!rawGroupId) return;
-  startMapGroupUpdate(Number(rawGroupId));
+  handleCreatorHubNavigation();
+  window.addEventListener('urlchange', handleCreatorHubNavigation);
 }

--- a/userscript/src/lib/mapGroupUpdate.ts
+++ b/userscript/src/lib/mapGroupUpdate.ts
@@ -1,0 +1,39 @@
+import { mount, unmount } from 'svelte';
+import MapGroupUpdate from './components/MapGroupUpdate.svelte';
+
+const queryParameter = 'learnableMetaGroupId';
+const containerId = 'learnablemeta-map-group-update';
+let app: Record<string, any> | null = null;
+
+function clearHandoffParameter() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete(queryParameter);
+  window.history.replaceState(window.history.state, '', url);
+}
+
+export function startMapGroupUpdate(groupId: number) {
+  if (!Number.isSafeInteger(groupId) || groupId <= 0 || app) return;
+
+  const target = document.createElement('div');
+  target.id = containerId;
+  document.body.appendChild(target);
+  app = mount(MapGroupUpdate, {
+    target,
+    props: {
+      groupId,
+      onClose: () => {
+        if (app) unmount(app);
+        app = null;
+        target.remove();
+        clearHandoffParameter();
+      }
+    }
+  });
+}
+
+export function initMapGroupUpdate() {
+  if (!window.location.pathname.startsWith('/creator-hub')) return;
+  const rawGroupId = new URL(window.location.href).searchParams.get(queryParameter);
+  if (!rawGroupId) return;
+  startMapGroupUpdate(Number(rawGroupId));
+}

--- a/userscript/src/lib/styles/buttons.css
+++ b/userscript/src/lib/styles/buttons.css
@@ -1,0 +1,62 @@
+/* Self-styled because GeoGuessr's hashed button classes change between deploys. */
+.learnablemeta-yellow-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  appearance: none;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  background: linear-gradient(180deg, #ffeb99 0%, #f5c542 100%);
+  border: 1px solid #e0b000;
+  color: #002147;
+  border-radius: 3.75rem;
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  transition:
+    background 0.2s ease-in-out,
+    transform 0.1s ease,
+    box-shadow 0.2s ease-in-out;
+}
+
+.learnablemeta-yellow-button:hover:not(:disabled) {
+  background: linear-gradient(180deg, #ffe066 0%, #eab308 100%);
+  box-shadow:
+    0 4px 8px rgba(0, 0, 0, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  transform: translateY(-1px);
+}
+
+.learnablemeta-yellow-button:active:not(:disabled) {
+  background: linear-gradient(180deg, #eab308 0%, #d39e00 100%);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+  transform: translateY(1px);
+}
+
+.learnablemeta-yellow-button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(234, 179, 8, 0.5),
+    0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.learnablemeta-yellow-button:disabled {
+  background: #e0e0e0;
+  border-color: #bbbbbb;
+  color: #888888;
+  box-shadow: none;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.learnablemeta-map-actions {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  gap: 0.75rem !important;
+}

--- a/userscript/src/lib/styles/buttons.css
+++ b/userscript/src/lib/styles/buttons.css
@@ -1,5 +1,110 @@
 /* Self-styled because GeoGuessr's hashed button classes change between deploys. */
-.learnablemeta-yellow-button {
+.learnablemeta-button {
+  display: inline-flex;
+  height: 36px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  appearance: none;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  border-radius: var(--lm-radius, 0.5rem);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.learnablemeta-button--primary {
+  background: var(--lm-primary, hsl(161 92% 25%));
+  color: var(--lm-primary-foreground, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.learnablemeta-button--primary:hover:not(:disabled) {
+  background: var(--lm-primary-hover, hsl(161 92% 22%));
+}
+
+.learnablemeta-button--outline {
+  border-color: var(--lm-border, hsl(240 5.9% 90%));
+  background: var(--lm-background, #fff);
+  color: var(--lm-secondary-foreground, hsl(240 5.9% 10%));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.learnablemeta-button--outline:hover:not(:disabled) {
+  background: var(--lm-accent, hsl(240 4.8% 95.9%));
+  color: var(--lm-accent-foreground, hsl(240 5.9% 10%));
+}
+
+.learnablemeta-button--ghost {
+  background: transparent;
+  color: var(--lm-muted-foreground, hsl(240 3.8% 46.1%));
+  box-shadow: none;
+}
+
+.learnablemeta-button--ghost:hover:not(:disabled) {
+  background: var(--lm-accent, hsl(240 4.8% 95.9%));
+  color: var(--lm-accent-foreground, hsl(240 5.9% 10%));
+}
+
+.learnablemeta-button--link {
+  height: auto;
+  padding: 5px 7px;
+  background: transparent;
+  color: var(--lm-link, hsl(220.3 82.9% 52.7%));
+  font-size: 13px;
+  box-shadow: none;
+}
+
+.learnablemeta-button--link:hover:not(:disabled) {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.learnablemeta-button--destructive {
+  background: var(--lm-destructive, hsl(0 72.22% 50.59%));
+  color: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.learnablemeta-button--destructive:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--lm-destructive, #dc2626) 88%, #000);
+}
+
+.learnablemeta-button--icon {
+  width: 36px;
+  padding: 0;
+}
+
+.learnablemeta-button:active:not(:disabled) {
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.learnablemeta-button--ghost:active:not(:disabled),
+.learnablemeta-button--link:active:not(:disabled) {
+  box-shadow: none;
+}
+
+.learnablemeta-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--lm-ring, #16a34a) 35%, transparent);
+}
+
+.learnablemeta-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.learnablemeta-geoguessr-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -24,7 +129,7 @@
     box-shadow 0.2s ease-in-out;
 }
 
-.learnablemeta-yellow-button:hover:not(:disabled) {
+.learnablemeta-geoguessr-button:hover:not(:disabled) {
   background: linear-gradient(180deg, #ffe066 0%, #eab308 100%);
   box-shadow:
     0 4px 8px rgba(0, 0, 0, 0.2),
@@ -32,25 +137,44 @@
   transform: translateY(-1px);
 }
 
-.learnablemeta-yellow-button:active:not(:disabled) {
+.learnablemeta-geoguessr-button:active:not(:disabled) {
   background: linear-gradient(180deg, #eab308 0%, #d39e00 100%);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
   transform: translateY(1px);
 }
 
-.learnablemeta-yellow-button:focus-visible {
+.learnablemeta-geoguessr-button:focus-visible {
   outline: none;
   box-shadow:
     0 0 0 3px rgba(234, 179, 8, 0.5),
     0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
-.learnablemeta-yellow-button:disabled {
+.learnablemeta-geoguessr-button:disabled {
   background: #e0e0e0;
   border-color: #bbbbbb;
   color: #888888;
   box-shadow: none;
   cursor: not-allowed;
+  transform: none;
+}
+
+.learnablemeta-geoguessr-button--icon {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 14px;
+}
+
+.learnablemeta-geoguessr-button--icon:hover:not(:disabled) {
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transform: none;
+}
+
+.learnablemeta-geoguessr-button--icon:active:not(:disabled) {
   transform: none;
 }
 

--- a/userscript/src/lib/styles/modals.css
+++ b/userscript/src/lib/styles/modals.css
@@ -1,0 +1,224 @@
+.learnablemeta-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.76);
+  backdrop-filter: blur(4px);
+}
+
+.learnablemeta-modal,
+.learnablemeta-modal * {
+  box-sizing: border-box;
+}
+
+.learnablemeta-modal {
+  position: relative;
+  width: min(460px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  border: 1px solid var(--lm-border);
+  border-radius: calc(var(--lm-radius) + 4px);
+  background: var(--lm-background);
+  color: var(--lm-foreground);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5);
+  text-align: left;
+}
+
+.learnablemeta-modal--wide {
+  width: min(600px, 100%);
+}
+
+.learnablemeta-modal--map-update {
+  width: min(780px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.learnablemeta-modal::before {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 4px;
+  background: linear-gradient(90deg, hsl(161 92% 25%), hsl(199 89% 40%));
+  content: '';
+}
+
+.learnablemeta-modal-header {
+  display: grid;
+  gap: 6px;
+  padding: 26px 24px 0;
+}
+
+.learnablemeta-modal-header--row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 26px 24px 20px;
+  border-bottom: 1px solid var(--lm-border);
+  background: var(--lm-card);
+}
+
+.learnablemeta-modal-eyebrow {
+  margin: 0;
+  color: var(--lm-primary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.learnablemeta-modal-title {
+  margin: 0;
+  color: var(--lm-foreground);
+  font-size: 20px;
+  font-weight: 650;
+  line-height: 1.3;
+  letter-spacing: -0.025em;
+}
+
+.learnablemeta-modal-title--large {
+  margin-top: 4px;
+  color: var(--lm-card-foreground);
+  font-size: 22px;
+  line-height: 1.25;
+}
+
+.learnablemeta-modal-description {
+  margin: 0;
+  color: var(--lm-muted-foreground);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.learnablemeta-modal-body {
+  display: grid;
+  gap: 14px;
+  padding: 20px 24px 0;
+  color: var(--lm-foreground);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.learnablemeta-modal-body p {
+  margin: 0;
+}
+
+.learnablemeta-modal-body a {
+  color: var(--lm-link);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.learnablemeta-modal-input {
+  width: 100%;
+  height: 38px;
+  border: 1px solid var(--lm-input);
+  border-radius: var(--lm-radius);
+  padding: 7px 12px;
+  outline: none;
+  background: var(--lm-background);
+  color: var(--lm-foreground);
+  font: inherit;
+  font-size: 14px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.learnablemeta-modal-input::placeholder {
+  color: var(--lm-muted-foreground);
+}
+
+.learnablemeta-modal-input:focus-visible {
+  border-color: var(--lm-ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--lm-ring) 25%, transparent);
+}
+
+.learnablemeta-modal-code {
+  overflow-wrap: anywhere;
+  border: 1px solid var(--lm-border);
+  border-radius: var(--lm-radius);
+  padding: 10px 12px;
+  background: var(--lm-muted);
+  color: var(--lm-link);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  user-select: text;
+}
+
+.learnablemeta-modal-note {
+  color: var(--lm-muted-foreground);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.learnablemeta-modal-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--lm-border);
+  background: var(--lm-card);
+}
+
+.learnablemeta-modal-action-leading {
+  margin-right: auto;
+}
+
+.learnablemeta-modal-alert {
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  border-radius: var(--lm-radius);
+  padding: 12px 14px;
+  background: rgba(220, 38, 38, 0.09);
+  color: var(--lm-destructive);
+  font-size: 13px;
+}
+
+.learnablemeta-modal .learnablemeta-modal-body .learnablemeta-help-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 20px;
+  list-style: disc;
+}
+
+.learnablemeta-modal .learnablemeta-help-list strong {
+  color: var(--lm-foreground);
+  font-weight: 600;
+}
+
+@media (max-width: 620px) {
+  .learnablemeta-modal-backdrop {
+    padding: 8px;
+  }
+
+  .learnablemeta-modal {
+    max-height: calc(100vh - 16px);
+  }
+
+  .learnablemeta-modal-actions {
+    flex-wrap: wrap;
+  }
+
+  .learnablemeta-modal-action-leading {
+    width: 100%;
+    margin-right: 0;
+  }
+
+  .learnablemeta-modal-actions .learnablemeta-button--primary,
+  .learnablemeta-modal-actions .learnablemeta-button--outline,
+  .learnablemeta-modal-actions .learnablemeta-button--destructive {
+    flex: 1;
+  }
+}

--- a/userscript/src/lib/styles/theme.css
+++ b/userscript/src/lib/styles/theme.css
@@ -1,0 +1,53 @@
+.learnablemeta-ui {
+  --lm-background: hsl(0 0% 100%);
+  --lm-foreground: hsl(240 10% 3.9%);
+  --lm-card: hsl(0 0% 100%);
+  --lm-card-foreground: hsl(240 10% 3.9%);
+  --lm-primary: hsl(161 92% 25%);
+  --lm-primary-hover: hsl(161 92% 22%);
+  --lm-primary-foreground: hsl(355.7 100% 97.3%);
+  --lm-secondary: hsl(240 4.8% 95.9%);
+  --lm-secondary-foreground: hsl(240 5.9% 10%);
+  --lm-muted: hsl(240 4.8% 95.9%);
+  --lm-muted-foreground: hsl(240 3.8% 46.1%);
+  --lm-accent: hsl(240 4.8% 95.9%);
+  --lm-accent-foreground: hsl(240 5.9% 10%);
+  --lm-destructive: hsl(0 72.22% 50.59%);
+  --lm-border: hsl(240 5.9% 90%);
+  --lm-input: hsl(240 5.9% 90%);
+  --lm-ring: hsl(142.1 76.2% 36.3%);
+  --lm-link: hsl(220.3 82.9% 52.7%);
+  --lm-radius: 0.5rem;
+  color: var(--lm-foreground);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  .learnablemeta-ui {
+    --lm-background: hsl(0 0% 10%);
+    --lm-foreground: hsl(0 0% 95%);
+    --lm-card: hsl(24 9.8% 10%);
+    --lm-card-foreground: hsl(0 0% 95%);
+    --lm-primary: hsl(161 92% 25%);
+    --lm-primary-hover: hsl(161 92% 29%);
+    --lm-primary-foreground: hsl(0 0% 98%);
+    --lm-secondary: hsl(240 3.7% 20.9%);
+    --lm-secondary-foreground: hsl(0 0% 98%);
+    --lm-muted: hsl(0 0% 15%);
+    --lm-muted-foreground: hsl(240 5% 64.9%);
+    --lm-accent: hsl(12 6.5% 15.1%);
+    --lm-accent-foreground: hsl(0 0% 98%);
+    --lm-destructive: hsl(0 72% 60%);
+    --lm-border: hsl(240 3.7% 22%);
+    --lm-input: hsl(240 3.7% 25.5%);
+    --lm-ring: hsl(142.4 71.8% 35%);
+    --lm-link: hsl(217.1 92.7% 67.6%);
+    color-scheme: dark;
+  }
+}

--- a/userscript/src/lib/utils/apiKey.ts
+++ b/userscript/src/lib/utils/apiKey.ts
@@ -1,0 +1,17 @@
+import { GM_getValue, GM_setValue } from '$';
+
+export const API_KEY_STORAGE_NAME = 'learnableMeta_apiKey';
+export const URL_TO_GENERATE_TOKEN = 'https://learnablemeta.com/profile/token';
+
+export function getApiKey(): string | null {
+  const key = GM_getValue<string | null>(API_KEY_STORAGE_NAME, null);
+  return key?.trim() || null;
+}
+
+export function saveApiKey(key: string): void {
+  GM_setValue(API_KEY_STORAGE_NAME, key.trim());
+}
+
+export function clearApiKey(): void {
+  GM_setValue(API_KEY_STORAGE_NAME, '');
+}

--- a/userscript/src/lib/utils/learnableMetaApi.ts
+++ b/userscript/src/lib/utils/learnableMetaApi.ts
@@ -1,0 +1,99 @@
+import { GM_xmlhttpRequest } from '$';
+import type { ManagedMapCoordinate } from './mapFingerprint';
+
+export class LearnableMetaApiError extends Error {
+  constructor(
+    public status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'LearnableMetaApiError';
+  }
+}
+
+export type MapGroupManifest = {
+  group: {
+    id: number;
+    name: string;
+    syncedAt: number;
+  };
+  maps: {
+    name: string;
+    geoguessrId: string;
+    locationCount: number;
+    fingerprint: string;
+  }[];
+};
+
+export type SyncedMapCoordinate = ManagedMapCoordinate & {
+  countryCode: null;
+  stateCode: null;
+};
+
+function requestJson<T>(url: string, apiToken: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    GM_xmlhttpRequest({
+      method: 'GET',
+      url,
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json'
+      },
+      timeout: 15000,
+      onload: (response) => {
+        let body: unknown;
+        try {
+          body = response.responseText ? JSON.parse(response.responseText) : null;
+        } catch {
+          body = response.responseText;
+        }
+
+        if (response.status >= 200 && response.status < 300) {
+          resolve(body as T);
+          return;
+        }
+
+        const apiMessage =
+          body && typeof body === 'object' && 'message' in body
+            ? String((body as { message: unknown }).message)
+            : response.statusText || 'Request failed';
+        reject(
+          new LearnableMetaApiError(
+            response.status,
+            `LearnableMeta API error (${response.status}): ${apiMessage}`
+          )
+        );
+      },
+      onerror: () => reject(new LearnableMetaApiError(0, 'Could not reach LearnableMeta')),
+      ontimeout: () => reject(new LearnableMetaApiError(0, 'LearnableMeta request timed out'))
+    });
+  });
+}
+
+export function fetchMapGroupManifest(
+  groupId: number,
+  apiToken: string
+): Promise<MapGroupManifest> {
+  return requestJson(
+    `https://learnablemeta.com/api/userscript/map-group/${groupId}/maps`,
+    apiToken
+  );
+}
+
+export async function fetchSyncedMapLocations(
+  geoguessrId: string,
+  apiToken: string,
+  expectedFingerprint?: string
+): Promise<SyncedMapCoordinate[]> {
+  const query = expectedFingerprint
+    ? `?expectedFingerprint=${encodeURIComponent(expectedFingerprint)}`
+    : '';
+  const data = await requestJson<{ customCoordinates: SyncedMapCoordinate[] }>(
+    `https://learnablemeta.com/api/userscript/map/${geoguessrId}/locations${query}`,
+    apiToken
+  );
+  if (!Array.isArray(data.customCoordinates)) {
+    throw new LearnableMetaApiError(0, 'Received invalid map location data');
+  }
+  return data.customCoordinates;
+}

--- a/userscript/src/lib/utils/learnableMetaApi.ts
+++ b/userscript/src/lib/utils/learnableMetaApi.ts
@@ -25,6 +25,13 @@ export type MapGroupManifest = {
   }[];
 };
 
+export type AccessibleMapGroup = {
+  id: number;
+  name: string;
+  syncedAt: number;
+  mapCount: number;
+};
+
 export type SyncedMapCoordinate = ManagedMapCoordinate & {
   countryCode: null;
   stateCode: null;
@@ -78,6 +85,17 @@ export function fetchMapGroupManifest(
     `https://learnablemeta.com/api/userscript/map-group/${groupId}/maps`,
     apiToken
   );
+}
+
+export async function fetchAccessibleMapGroups(apiToken: string): Promise<AccessibleMapGroup[]> {
+  const data = await requestJson<{ groups: AccessibleMapGroup[] }>(
+    'https://learnablemeta.com/api/userscript/map-groups',
+    apiToken
+  );
+  if (!Array.isArray(data.groups)) {
+    throw new LearnableMetaApiError(0, 'Received invalid map group data');
+  }
+  return data.groups;
 }
 
 export async function fetchSyncedMapLocations(

--- a/userscript/src/lib/utils/mapFingerprint.ts
+++ b/userscript/src/lib/utils/mapFingerprint.ts
@@ -1,0 +1,29 @@
+export type ManagedMapCoordinate = {
+  panoId: string | null;
+  lat: number;
+  lng: number;
+  heading: number;
+  pitch: number;
+  zoom: number;
+};
+
+export function canonicalizeMapCoordinates(coordinates: ManagedMapCoordinate[]): string {
+  const tuples = coordinates.map(
+    ({ panoId, lat, lng, heading, pitch, zoom }) =>
+      [panoId, lat, lng, heading, pitch, zoom] as const
+  );
+  tuples.sort((left, right) => {
+    const leftJson = JSON.stringify(left);
+    const rightJson = JSON.stringify(right);
+    return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+  });
+  return JSON.stringify(tuples);
+}
+
+export async function fingerprintMapCoordinates(
+  coordinates: ManagedMapCoordinate[]
+): Promise<string> {
+  const bytes = new TextEncoder().encode(canonicalizeMapCoordinates(coordinates));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/userscript/src/lib/utils/modalDialog.ts
+++ b/userscript/src/lib/utils/modalDialog.ts
@@ -1,0 +1,78 @@
+export type ModalDialogOptions = {
+  onClose: () => void;
+  closeOnEscape?: boolean;
+};
+
+const focusableSelector = [
+  'a[href]',
+  'button:not(:disabled)',
+  'input:not(:disabled)',
+  'select:not(:disabled)',
+  'textarea:not(:disabled)',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+function focusableElements(node: HTMLElement) {
+  return Array.from(node.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+    (element) => !element.hidden && element.getClientRects().length > 0
+  );
+}
+
+export function modalDialog(node: HTMLElement, initialOptions: ModalDialogOptions) {
+  let options = initialOptions;
+  const previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  function focusDialog() {
+    if (!node.isConnected || node.contains(document.activeElement)) return;
+    const initialFocus =
+      node.querySelector<HTMLElement>('[data-modal-initial-focus]') ?? focusableElements(node)[0];
+    if (initialFocus) {
+      initialFocus.focus();
+    } else {
+      node.tabIndex = -1;
+      node.focus();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && options.closeOnEscape !== false) {
+      event.preventDefault();
+      event.stopPropagation();
+      options.onClose();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const elements = focusableElements(node);
+    if (elements.length === 0) {
+      event.preventDefault();
+      node.focus();
+      return;
+    }
+
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    const activeElement = document.activeElement;
+    if (event.shiftKey && (activeElement === first || !node.contains(activeElement))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && (activeElement === last || !node.contains(activeElement))) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  node.addEventListener('keydown', handleKeydown);
+  requestAnimationFrame(focusDialog);
+
+  return {
+    update(nextOptions: ModalDialogOptions) {
+      options = nextOptions;
+    },
+    destroy() {
+      node.removeEventListener('keydown', handleKeydown);
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    }
+  };
+}

--- a/userscript/src/lib/utils/upload.ts
+++ b/userscript/src/lib/utils/upload.ts
@@ -1,6 +1,7 @@
-import { GM_xmlhttpRequest } from '$'; // Keep this if used in other parts of the file, not directly here
+import { fetchSyncedMapLocations, type SyncedMapCoordinate } from './learnableMetaApi';
+import type { ManagedMapCoordinate } from './mapFingerprint';
 
-async function geoguessrAPIFetch(url: string, options: RequestInit = {}): Promise<Response> {
+export async function geoguessrAPIFetch(url: string, options: RequestInit = {}): Promise<Response> {
   const { method = 'GET', headers: initialHeaders, body, ...restOptions } = options;
 
   const effectiveHeaders = new Headers(initialHeaders);
@@ -48,24 +49,65 @@ async function geoguessrAPIFetch(url: string, options: RequestInit = {}): Promis
   return response;
 }
 
+export type GeoGuessrDraft = {
+  avatar: unknown;
+  description: string;
+  highlighted: boolean;
+  name: string;
+  version: number;
+  customCoordinates: ManagedMapCoordinate[];
+};
+
+function draftUrl(geoguessrId: string) {
+  return `https://www.geoguessr.com/api/v4/user-maps/drafts/${geoguessrId}`;
+}
+
+export async function getGeoguessrDraft(geoguessrId: string): Promise<GeoGuessrDraft> {
+  const response = await geoguessrAPIFetch(draftUrl(geoguessrId));
+  return response.json();
+}
+
+export async function updateGeoguessrDraft(
+  geoguessrId: string,
+  draft: GeoGuessrDraft,
+  customCoordinates: SyncedMapCoordinate[]
+): Promise<void> {
+  const { avatar, description, highlighted, name, version } = draft;
+  await geoguessrAPIFetch(draftUrl(geoguessrId), {
+    method: 'PUT',
+    body: JSON.stringify({
+      avatar,
+      description,
+      highlighted,
+      name,
+      customCoordinates,
+      version: version + 1
+    })
+  });
+}
+
+export async function publishGeoguessrDraft(geoguessrId: string): Promise<void> {
+  await geoguessrAPIFetch(`${draftUrl(geoguessrId)}/publish`, {
+    method: 'PUT',
+    body: JSON.stringify({})
+  });
+}
+
 export async function uploadLocations(geoguessrId: string, apiKey: string): Promise<void> {
-  const geoguessrDraftApiUrl = `https://www.geoguessr.com/api/v4/user-maps/drafts/${geoguessrId}`;
   let geoguessrMapDetails;
 
   try {
-    const response = await geoguessrAPIFetch(geoguessrDraftApiUrl);
-    geoguessrMapDetails = await response.json();
+    geoguessrMapDetails = await getGeoguessrDraft(geoguessrId);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Failed to fetch Geoguessr map info:', error);
     throw new Error(`Geoguessr Error: Could not fetch map details. ${errorMessage}`);
   }
 
-  const { avatar, description, highlighted, name, version } = geoguessrMapDetails;
   let locationsToUpload;
 
   try {
-    locationsToUpload = await fetchMapLocationsGM(geoguessrId, apiKey);
+    locationsToUpload = await fetchSyncedMapLocations(geoguessrId, apiKey);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Failed to fetch map locations from backend:', error);
@@ -79,20 +121,8 @@ export async function uploadLocations(geoguessrId: string, apiKey: string): Prom
     throw new Error(errorMessage);
   }
 
-  const mapDataToUpload = {
-    avatar,
-    description,
-    highlighted,
-    name,
-    customCoordinates: locationsToUpload,
-    version: version + 1
-  };
-
   try {
-    await geoguessrAPIFetch(geoguessrDraftApiUrl, {
-      method: 'PUT',
-      body: JSON.stringify(mapDataToUpload)
-    });
+    await updateGeoguessrDraft(geoguessrId, geoguessrMapDetails, locationsToUpload);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Failed to update Geoguessr map draft:', error);
@@ -101,83 +131,10 @@ export async function uploadLocations(geoguessrId: string, apiKey: string): Prom
 
   try {
     console.log('Publishing Geoguessr map...');
-    await geoguessrAPIFetch(`${geoguessrDraftApiUrl}/publish`, {
-      method: 'PUT',
-      body: JSON.stringify({})
-    });
+    await publishGeoguessrDraft(geoguessrId);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Failed to publish Geoguessr map:', error);
     throw new Error(`Geoguessr Error: Could not publish map. ${errorMessage}`);
   }
-}
-
-function fetchMapLocationsGM(geoguessrId: string, apiToken: string): Promise<[]> {
-  return new Promise((resolve, reject) => {
-    const apiUrl = `https://learnablemeta.com/api/userscript/map/${geoguessrId}/locations`;
-
-    GM_xmlhttpRequest({
-      method: 'GET',
-      url: apiUrl,
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        'Content-Type': 'application/json'
-      },
-      timeout: 15000, // Add a timeout (e.g., 15 seconds)
-      onload: (response) => {
-        if (response.status >= 200 && response.status < 300) {
-          try {
-            const data = JSON.parse(response.responseText);
-            if (data && Array.isArray(data.customCoordinates)) {
-              resolve(data.customCoordinates);
-            } else {
-              console.error('Unexpected data structure from backend:', data);
-              reject(new Error('Received invalid location data structure from backend.'));
-            }
-          } catch (parseError: any) {
-            console.error(
-              'Error parsing JSON response from backend:',
-              parseError,
-              response.responseText
-            );
-            reject(
-              new Error(
-                `Backend Error: Failed to parse location data: ${parseError.message.substring(0, 100)}`
-              )
-            );
-          }
-        } else {
-          let errorMessage = `Backend Error (${response.status}): ${response.statusText || 'Failed to fetch locations'}`;
-          let rawErrorResponse = response.responseText;
-          try {
-            const parsedJsonError = JSON.parse(response.responseText);
-            if (parsedJsonError && parsedJsonError.message) {
-              errorMessage = `Backend Error (${response.status}): ${parsedJsonError.message}`;
-            } else if (parsedJsonError) {
-              errorMessage = `Backend Error (${response.status}): ${JSON.stringify(parsedJsonError).substring(0, 100)}...`;
-            }
-            rawErrorResponse = parsedJsonError;
-          } catch (e) {
-            if (response.responseText) {
-              errorMessage = `Backend Error (${response.status}): ${response.responseText.substring(0, 100)}...`;
-            }
-          }
-          console.error(
-            `Error fetching map locations from backend (Status: ${response.status}):`,
-            rawErrorResponse
-          );
-          reject(new Error(errorMessage));
-        }
-      },
-      onerror: (error) => {
-        console.error('Failed to fetch map locations (XHR onerror):', error);
-        let detail = (error as any).error || (error as any).statusText || 'Network request failed';
-        reject(new Error(`Network Error: Could not reach backend to fetch locations. ${detail}`));
-      },
-      ontimeout: () => {
-        console.error('Failed to fetch map locations: Request timed out', apiUrl);
-        reject(new Error('Backend Timeout: Request to fetch locations timed out.'));
-      }
-    });
-  });
 }

--- a/userscript/src/main.ts
+++ b/userscript/src/main.ts
@@ -7,6 +7,7 @@ import { initLocationsUpload } from './lib/locationsUpload';
 import { initChallengeResults } from './lib/challengeResults';
 import { resetContainerPosition } from './lib/utils/dragging';
 import { resetContainerDimensions } from './lib/utils/resizing';
+import { initMapGroupUpdate } from './lib/mapGroupUpdate';
 
 if (typeof GM_registerMenuCommand === 'function') {
   GM_registerMenuCommand('LearnableMeta - Reset Meta Window Layout', () => {
@@ -32,7 +33,8 @@ async function setupLearnableMetaFeatures() {
     ['liveChallenge', initLiveChallenge],
     ['mapLabel', initMapLabel],
     ['locationsUpload', initLocationsUpload],
-    ['challengeResults', initChallengeResults]
+    ['challengeResults', initChallengeResults],
+    ['mapGroupUpdate', initMapGroupUpdate]
   ];
   for (const [name, init] of features) {
     try {

--- a/userscript/src/main.ts
+++ b/userscript/src/main.ts
@@ -8,6 +8,7 @@ import { initChallengeResults } from './lib/challengeResults';
 import { resetContainerPosition } from './lib/utils/dragging';
 import { resetContainerDimensions } from './lib/utils/resizing';
 import { initMapGroupUpdate } from './lib/mapGroupUpdate';
+import './lib/styles/buttons.css';
 
 if (typeof GM_registerMenuCommand === 'function') {
   GM_registerMenuCommand('LearnableMeta - Reset Meta Window Layout', () => {

--- a/userscript/src/main.ts
+++ b/userscript/src/main.ts
@@ -1,4 +1,5 @@
 import { GM_registerMenuCommand } from '$';
+import { mount, unmount } from 'svelte';
 import { initSinglePlayer } from './lib/singlePlayer';
 import { initLiveChallenge } from './lib/liveChallenge';
 import { initURLChangeEvent } from './lib/utils/url';
@@ -8,16 +9,42 @@ import { initChallengeResults } from './lib/challengeResults';
 import { resetContainerPosition } from './lib/utils/dragging';
 import { resetContainerDimensions } from './lib/utils/resizing';
 import { initMapGroupUpdate } from './lib/mapGroupUpdate';
+import ResetLayoutConfirmation from './lib/components/ResetLayoutConfirmation.svelte';
+import './lib/styles/theme.css';
 import './lib/styles/buttons.css';
+import './lib/styles/modals.css';
 
-if (typeof GM_registerMenuCommand === 'function') {
-  GM_registerMenuCommand('LearnableMeta - Reset Meta Window Layout', () => {
-    if (confirm('Reset the LearnableMeta window position and size?')) {
-      resetContainerPosition();
-      resetContainerDimensions();
-      window.location.reload();
+let resetDialogApp: Record<string, any> | null = null;
+
+function openResetLayoutDialog() {
+  if (resetDialogApp) return;
+
+  const target = document.createElement('div');
+  target.id = 'learnablemeta-reset-layout-dialog';
+  document.body.appendChild(target);
+
+  function closeDialog() {
+    if (resetDialogApp) unmount(resetDialogApp);
+    resetDialogApp = null;
+    target.remove();
+  }
+
+  resetDialogApp = mount(ResetLayoutConfirmation, {
+    target,
+    props: {
+      onCancel: closeDialog,
+      onConfirm: () => {
+        resetContainerPosition();
+        resetContainerDimensions();
+        closeDialog();
+        window.location.reload();
+      }
     }
   });
+}
+
+if (typeof GM_registerMenuCommand === 'function') {
+  GM_registerMenuCommand('LearnableMeta - Reset Meta Window Layout', openResetLayoutDialog);
 }
 
 initURLChangeEvent();

--- a/userscript/tests/mapFingerprint.test.ts
+++ b/userscript/tests/mapFingerprint.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  canonicalizeMapCoordinates,
+  fingerprintMapCoordinates
+} from '../src/lib/utils/mapFingerprint';
+
+const coordinates = [
+  { panoId: 'pano-a', lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5 },
+  { panoId: 'pano-b', lat: 6, lng: 7, heading: 8, pitch: 9, zoom: 10 }
+];
+
+describe('userscript map fingerprint', () => {
+  test('matches the API canonical test vector regardless of order', async () => {
+    expect(canonicalizeMapCoordinates([...coordinates].reverse())).toBe(
+      '[["pano-a",1,2,3,4,5],["pano-b",6,7,8,9,10]]'
+    );
+    expect(await fingerprintMapCoordinates([...coordinates].reverse())).toBe(
+      '4a2121be5c5e4a594afa0a8bea69118650531865e779f5f338671b0423cf126f'
+    );
+  });
+
+  test.each(['panoId', 'lat', 'lng', 'heading', 'pitch', 'zoom'] as const)(
+    'detects a change to %s',
+    async (field) => {
+      const changed = coordinates.map((coordinate) => ({ ...coordinate }));
+      changed[0] = {
+        ...changed[0],
+        [field]: field === 'panoId' ? 'different' : changed[0][field] + 0.5
+      };
+      expect(await fingerprintMapCoordinates(changed)).not.toBe(
+        await fingerprintMapCoordinates(coordinates)
+      );
+    }
+  );
+});

--- a/userscript/vite.config.ts
+++ b/userscript/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
       entry: 'src/main.ts',
       userscript: {
         icon: 'https://learnablemeta.com/favicon.png',
-        version: '0.90',
+        version: '0.91',
         namespace: 'geometa',
         name: 'GeoGuessr Learnable Meta',
         description: 'UserScript for GeoGuessr Learnable Meta maps',


### PR DESCRIPTION
## Changes

- remove the legacy server-side map auto-update state
- detect synchronized coordinate changes and expose permission-scoped map-group manifests and locations to the userscript
- let users select and update multiple GeoGuessr maps after a group sync or from Creator Hub
- reject stale map manifests before returning locations
- use consistent LearnableMeta dialogs, buttons, and styling across userscript interfaces
- update the userscript changelog and generated distribution files