### PR TITLE
fix: correct map update detection and sync count

### DIFF
--- a/apps/api/src/lib/userscript/map-snapshots.ts
+++ b/apps/api/src/lib/userscript/map-snapshots.ts
@@ -63,16 +63,16 @@ export async function getSynchronizedGroupMapSnapshots(groupId: number) {
   });
 }
 
-export function havePublishableMapLocationsChanged(
+export function countPublishableMapLocationChanges(
   before: Awaited<ReturnType<typeof getSynchronizedGroupMapSnapshots>>,
   after: Awaited<ReturnType<typeof getSynchronizedGroupMapSnapshots>>,
 ) {
   const oldFingerprintByMapId = new Map(
     before.map((map) => [map.mapId, map.fingerprint]),
   );
-  return after.some(
+  return after.filter(
     (map) =>
       map.locationCount > 0 &&
       oldFingerprintByMapId.get(map.mapId) !== map.fingerprint,
-  );
+  ).length;
 }

--- a/apps/api/src/routes/internal/map-groups.db.test.ts
+++ b/apps/api/src/routes/internal/map-groups.db.test.ts
@@ -1172,7 +1172,10 @@ describe('POST /api/internal/map-groups/:id/sync', () => {
     const after = Math.floor(Date.now() / 1000);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ hasMapUpdates: true });
+    expect(await response.json()).toEqual({
+      hasMapUpdates: true,
+      mapUpdatesCount: 1,
+    });
 
     // the source meta is mirrored into the synced tables with its exact
     // rendered payload
@@ -1244,7 +1247,32 @@ describe('POST /api/internal/map-groups/:id/sync', () => {
     const response = await syncRequest('sync-mapless-owner', groupId);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ hasMapUpdates: false });
+    expect(await response.json()).toEqual({
+      hasMapUpdates: false,
+      mapUpdatesCount: 0,
+    });
+  });
+
+  test('returns the number of maps whose managed locations changed', async () => {
+    await seedUser('sync-map-count-owner');
+    const { groupId } = await seedSyncFixture(
+      'sync-map-count-owner',
+      'Map count group',
+      'sync-map-count-one',
+    );
+    await db.insert(maps).values({
+      mapGroupId: groupId,
+      name: 'Second sync map',
+      geoguessrId: 'sync-map-count-two',
+    });
+
+    const response = await syncRequest('sync-map-count-owner', groupId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      hasMapUpdates: true,
+      mapUpdatesCount: 2,
+    });
   });
 
   test('ignores meta-only syncs but advertises managed location changes', async () => {
@@ -1268,7 +1296,10 @@ describe('POST /api/internal/map-groups/:id/sync', () => {
     const metaOnlyResponse = await syncRequest('sync-change-owner', groupId);
 
     expect(metaOnlyResponse.status).toBe(200);
-    expect(await metaOnlyResponse.json()).toEqual({ hasMapUpdates: false });
+    expect(await metaOnlyResponse.json()).toEqual({
+      hasMapUpdates: false,
+      mapUpdatesCount: 0,
+    });
 
     const secondGroup = await getGroup(groupId);
     await db.insert(mapGroupLocations).values({
@@ -1302,7 +1333,10 @@ describe('POST /api/internal/map-groups/:id/sync', () => {
           ),
         ),
     ).toEqual([{ lat: 9 }]);
-    expect(await locationResponse.json()).toEqual({ hasMapUpdates: true });
+    expect(await locationResponse.json()).toEqual({
+      hasMapUpdates: true,
+      mapUpdatesCount: 1,
+    });
   });
 
   test('editor is denied with source and synced state unchanged', async () => {

--- a/apps/api/src/routes/internal/map-groups.ts
+++ b/apps/api/src/routes/internal/map-groups.ts
@@ -23,8 +23,8 @@ import { ensureOwner, ensurePermissions } from '@api/lib/internal/permissions';
 import { syncMapGroup } from '@api/lib/internal/sync';
 import { geoguessrMapJson } from '@api/lib/internal/utils';
 import {
+  countPublishableMapLocationChanges,
   getSynchronizedGroupMapSnapshots,
-  havePublishableMapLocationsChanged,
 } from '@api/lib/userscript/map-snapshots';
 import { isPgError } from '@api/lib/utils/common';
 import {
@@ -994,11 +994,13 @@ export const mapGroupsRouter = new Elysia({ prefix: '/map-groups' })
         operation: 'update',
         createdAt: syncedAt,
       });
+      const mapUpdatesCount = countPublishableMapLocationChanges(
+        snapshotsBeforeSync,
+        snapshotsAfterSync,
+      );
       return {
-        hasMapUpdates: havePublishableMapLocationsChanged(
-          snapshotsBeforeSync,
-          snapshotsAfterSync,
-        ),
+        hasMapUpdates: mapUpdatesCount > 0,
+        mapUpdatesCount,
       };
     },
     {

--- a/apps/api/src/routes/userscript.db.test.ts
+++ b/apps/api/src/routes/userscript.db.test.ts
@@ -816,7 +816,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(await response.json()).toEqual({
       mapFound: true,
       isPersonal: true,
-      userscriptVersion: '0.91',
+      userscriptVersion: '0.92',
     });
   });
 
@@ -840,7 +840,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(await response.json()).toEqual({
       mapFound: true,
       isPersonal: false,
-      userscriptVersion: '0.91',
+      userscriptVersion: '0.92',
     });
   });
 
@@ -860,7 +860,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({
       mapFound: false,
-      userscriptVersion: '0.91',
+      userscriptVersion: '0.92',
     });
   });
 });

--- a/apps/api/src/routes/userscript.ts
+++ b/apps/api/src/routes/userscript.ts
@@ -15,7 +15,7 @@ import { generateFooter } from '@api/lib/userscript/utils';
 import { and, asc, eq, isNotNull, sql } from 'drizzle-orm';
 import { Elysia, t } from 'elysia';
 
-const userscriptVersion = '0.91';
+const userscriptVersion = '0.92';
 
 const mapInfoQuery = db.query.maps
   .findFirst({

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.server.ts
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.server.ts
@@ -485,6 +485,9 @@ export const actions = {
     if (apiError) {
       error(500);
     }
-    return { hasMapUpdates: data?.hasMapUpdates ?? false };
+    return {
+      hasMapUpdates: data?.hasMapUpdates ?? false,
+      mapUpdatesCount: data?.mapUpdatesCount ?? null
+    };
   }
 };

--- a/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
+++ b/apps/frontend/src/routes/(admin)/map-making/groups/[id]/+page.svelte
@@ -88,6 +88,7 @@
 
   let syncingUserScript = $state(false);
   let showMapUpdatePrompt = $state(false);
+  let mapUpdatesCount = $state<number | null>(null);
   let sharingMetas = $state(false);
 
   // Dialog state for adding levels
@@ -195,6 +196,9 @@
               toast.push('Userscript data synchronized', {
                 duration: 10000
               });
+              const resultMapUpdatesCount = result.data?.mapUpdatesCount;
+              mapUpdatesCount =
+                typeof resultMapUpdatesCount === 'number' ? resultMapUpdatesCount : null;
               showMapUpdatePrompt = result.data?.hasMapUpdates === true;
             } else if (result.type === 'failure') {
               const errorMessage = result.data?.message || 'Something went wrong';
@@ -410,14 +414,25 @@
 <Dialog.Root bind:open={showMapUpdatePrompt}>
   <Dialog.Content>
     <Dialog.Header>
-      <Dialog.Title>Update your GeoGuessr maps?</Dialog.Title>
+      <Dialog.Title>
+        {#if mapUpdatesCount === null}
+          Update your GeoGuessr maps?
+        {:else}
+          {mapUpdatesCount} GeoGuessr {mapUpdatesCount === 1 ? 'map has' : 'maps have'} updates
+        {/if}
+      </Dialog.Title>
       <Dialog.Description>
-        LearnableMeta has finished synchronizing this group. Continue to GeoGuessr to compare and
-        publish changed map locations with the LearnableMeta userscript.
+        {#if mapUpdatesCount === null}
+          LearnableMeta has finished synchronizing this group.
+        {:else}
+          Synchronization changed the managed locations for {mapUpdatesCount}
+          {mapUpdatesCount === 1 ? 'map' : 'maps'}.
+        {/if}
+        Continue to GeoGuessr to compare and publish changed map locations with the LearnableMeta userscript.
       </Dialog.Description>
     </Dialog.Header>
     <p class="text-sm text-muted-foreground">
-      This requires userscript version 0.91 or newer. You can review every map and deselect any you
+      This requires userscript version 0.92 or newer. You can review every map and deselect any you
       do not want to update before publishing.
     </p>
     <Dialog.Footer>

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Learnable Meta
 // @namespace    geometa
-// @version      0.91
+// @version      0.92
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
 // @downloadURL  https://github.com/likeon/geometa/raw/main/userscript/dist/geometa.user.js
@@ -22,6 +22,10 @@
 
 /*
 # Changelog
+
+## [0.92]
+
+- Fixed updated maps still appearing as changed after publishing
 
 ## [0.91]
 
@@ -5996,6 +6000,11 @@ roundNumber: 4,
     const digest = await crypto.subtle.digest("SHA-256", bytes);
     return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
   }
+  function getGeoguessrDraftCoordinates(draft) {
+    if (Array.isArray(draft.coordinates)) return draft.coordinates;
+    if (Array.isArray(draft.customCoordinates)) return draft.customCoordinates;
+    return [];
+  }
   var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
   var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
   var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="learnablemeta-modal-input" data-modal-initial-focus=""/> <!> <div class="learnablemeta-modal-actions token-actions svelte-axobi4"><button class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button class="learnablemeta-button learnablemeta-button--primary">Save and continue</button></div></div>`);
@@ -6157,7 +6166,7 @@ roundNumber: 4,
       replaceRow(row.geoguessrId, { status: "scanning", error: void 0, selected: false });
       try {
         const draft = await getGeoguessrDraft(row.geoguessrId);
-        const fingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        const fingerprint = await fingerprintMapCoordinates(getGeoguessrDraftCoordinates(draft));
         const changed = fingerprint !== row.fingerprint;
         replaceRow(row.geoguessrId, { status: changed ? "changed" : "current", selected: changed });
       } catch (error) {
@@ -6188,7 +6197,7 @@ roundNumber: 4,
       let draft;
       try {
         draft = await getGeoguessrDraft(row.geoguessrId);
-        const currentFingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        const currentFingerprint = await fingerprintMapCoordinates(getGeoguessrDraftCoordinates(draft));
         if (currentFingerprint === row.fingerprint) {
           replaceRow(row.geoguessrId, { status: "current", selected: false });
           return;

--- a/userscript/CHANGELOG.md
+++ b/userscript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.92]
+
+- Fixed updated maps still appearing as changed after publishing
+
 ## [0.91]
 
 - Added map-group updates after syncing and from Creator Hub

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Learnable Meta
 // @namespace    geometa
-// @version      0.91
+// @version      0.92
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
 // @downloadURL  https://github.com/likeon/geometa/raw/main/userscript/dist/geometa.user.js
@@ -22,6 +22,10 @@
 
 /*
 # Changelog
+
+## [0.92]
+
+- Fixed updated maps still appearing as changed after publishing
 
 ## [0.91]
 
@@ -5996,6 +6000,11 @@ roundNumber: 4,
     const digest = await crypto.subtle.digest("SHA-256", bytes);
     return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
   }
+  function getGeoguessrDraftCoordinates(draft) {
+    if (Array.isArray(draft.coordinates)) return draft.coordinates;
+    if (Array.isArray(draft.customCoordinates)) return draft.customCoordinates;
+    return [];
+  }
   var root_1 = from_html(`<p class="subtitle svelte-axobi4"> </p>`);
   var root_3 = from_html(`<p class="error-text svelte-axobi4"> </p>`);
   var root_2 = from_html(`<div class="token-form svelte-axobi4"><p class="svelte-axobi4">Paste your LearnableMeta API token to load maps you can manage.</p> <p class="small svelte-axobi4">Generate or replace it on your <a target="_blank" rel="noopener noreferrer" class="svelte-axobi4">token page</a>.</p> <input type="password" placeholder="LearnableMeta API token" aria-label="LearnableMeta API token" class="learnablemeta-modal-input" data-modal-initial-focus=""/> <!> <div class="learnablemeta-modal-actions token-actions svelte-axobi4"><button class="learnablemeta-button learnablemeta-button--outline">Cancel</button> <button class="learnablemeta-button learnablemeta-button--primary">Save and continue</button></div></div>`);
@@ -6157,7 +6166,7 @@ roundNumber: 4,
       replaceRow(row.geoguessrId, { status: "scanning", error: void 0, selected: false });
       try {
         const draft = await getGeoguessrDraft(row.geoguessrId);
-        const fingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        const fingerprint = await fingerprintMapCoordinates(getGeoguessrDraftCoordinates(draft));
         const changed = fingerprint !== row.fingerprint;
         replaceRow(row.geoguessrId, { status: changed ? "changed" : "current", selected: changed });
       } catch (error) {
@@ -6188,7 +6197,7 @@ roundNumber: 4,
       let draft;
       try {
         draft = await getGeoguessrDraft(row.geoguessrId);
-        const currentFingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+        const currentFingerprint = await fingerprintMapCoordinates(getGeoguessrDraftCoordinates(draft));
         if (currentFingerprint === row.fingerprint) {
           replaceRow(row.geoguessrId, { status: "current", selected: false });
           return;

--- a/userscript/src/lib/components/MapGroupUpdate.svelte
+++ b/userscript/src/lib/components/MapGroupUpdate.svelte
@@ -10,6 +10,7 @@
     type MapGroupManifest
   } from '../utils/learnableMetaApi';
   import { fingerprintMapCoordinates } from '../utils/mapFingerprint';
+  import { getGeoguessrDraftCoordinates } from '../utils/geoguessrDraft';
   import { modalDialog } from '../utils/modalDialog';
   import { getGeoguessrDraft, publishGeoguessrDraft, updateGeoguessrDraft } from '../utils/upload';
 
@@ -186,7 +187,7 @@
     replaceRow(row.geoguessrId, { status: 'scanning', error: undefined, selected: false });
     try {
       const draft = await getGeoguessrDraft(row.geoguessrId);
-      const fingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+      const fingerprint = await fingerprintMapCoordinates(getGeoguessrDraftCoordinates(draft));
       const changed = fingerprint !== row.fingerprint;
       replaceRow(row.geoguessrId, {
         status: changed ? 'changed' : 'current',
@@ -226,7 +227,9 @@
     let draft;
     try {
       draft = await getGeoguessrDraft(row.geoguessrId);
-      const currentFingerprint = await fingerprintMapCoordinates(draft.customCoordinates ?? []);
+      const currentFingerprint = await fingerprintMapCoordinates(
+        getGeoguessrDraftCoordinates(draft)
+      );
       if (currentFingerprint === row.fingerprint) {
         replaceRow(row.geoguessrId, { status: 'current', selected: false });
         return;

--- a/userscript/src/lib/utils/geoguessrDraft.ts
+++ b/userscript/src/lib/utils/geoguessrDraft.ts
@@ -1,0 +1,16 @@
+import type { ManagedMapCoordinate } from './mapFingerprint';
+
+export type GeoGuessrDraftCoordinates = {
+  coordinates?: ManagedMapCoordinate[];
+  // Compatibility fallback in case GeoGuessr changes the draft response to
+  // match the customCoordinates field accepted by its update endpoint.
+  customCoordinates?: ManagedMapCoordinate[];
+};
+
+export function getGeoguessrDraftCoordinates(
+  draft: GeoGuessrDraftCoordinates
+): ManagedMapCoordinate[] {
+  if (Array.isArray(draft.coordinates)) return draft.coordinates;
+  if (Array.isArray(draft.customCoordinates)) return draft.customCoordinates;
+  return [];
+}

--- a/userscript/src/lib/utils/upload.ts
+++ b/userscript/src/lib/utils/upload.ts
@@ -1,5 +1,5 @@
 import { fetchSyncedMapLocations, type SyncedMapCoordinate } from './learnableMetaApi';
-import type { ManagedMapCoordinate } from './mapFingerprint';
+import type { GeoGuessrDraftCoordinates } from './geoguessrDraft';
 
 export async function geoguessrAPIFetch(url: string, options: RequestInit = {}): Promise<Response> {
   const { method = 'GET', headers: initialHeaders, body, ...restOptions } = options;
@@ -49,13 +49,12 @@ export async function geoguessrAPIFetch(url: string, options: RequestInit = {}):
   return response;
 }
 
-export type GeoGuessrDraft = {
+export type GeoGuessrDraft = GeoGuessrDraftCoordinates & {
   avatar: unknown;
   description: string;
   highlighted: boolean;
   name: string;
   version: number;
-  customCoordinates: ManagedMapCoordinate[];
 };
 
 function draftUrl(geoguessrId: string) {

--- a/userscript/tests/geoguessrDraft.test.ts
+++ b/userscript/tests/geoguessrDraft.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { getGeoguessrDraftCoordinates } from '../src/lib/utils/geoguessrDraft';
+
+const coordinates = [
+  { panoId: 'pano-a', lat: 1, lng: 2, heading: 3, pitch: 4, zoom: 5 }
+];
+
+describe('GeoGuessr draft coordinates', () => {
+  test('reads coordinates from the field returned by the draft endpoint', () => {
+    expect(getGeoguessrDraftCoordinates({ coordinates })).toBe(coordinates);
+  });
+
+  test('supports the customCoordinates response shape as a fallback', () => {
+    expect(getGeoguessrDraftCoordinates({ customCoordinates: coordinates })).toBe(coordinates);
+  });
+
+  test('prefers the current coordinates field and safely handles a missing field', () => {
+    expect(
+      getGeoguessrDraftCoordinates({ coordinates, customCoordinates: [] })
+    ).toBe(coordinates);
+    expect(getGeoguessrDraftCoordinates({})).toEqual([]);
+  });
+});

--- a/userscript/vite.config.ts
+++ b/userscript/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
       entry: 'src/main.ts',
       userscript: {
         icon: 'https://learnablemeta.com/favicon.png',
-        version: '0.91',
+        version: '0.92',
         namespace: 'geometa',
         name: 'GeoGuessr Learnable Meta',
         description: 'UserScript for GeoGuessr Learnable Meta maps',


### PR DESCRIPTION
## Changes

- compare synchronized locations against the `coordinates` field returned by GeoGuessr drafts
- prevent successfully published maps from continuing to appear changed
- release userscript 0.92 with updated generated distributions and changelog
- return the number of maps changed by synchronization and show it in the frontend update prompt