### PR TITLE
fix(userscript): support party live challenges

### DIFF
--- a/apps/api/src/routes/userscript.db.test.ts
+++ b/apps/api/src/routes/userscript.db.test.ts
@@ -816,7 +816,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(await response.json()).toEqual({
       mapFound: true,
       isPersonal: true,
-      userscriptVersion: '0.92',
+      userscriptVersion: '0.93',
     });
   });
 
@@ -840,7 +840,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(await response.json()).toEqual({
       mapFound: true,
       isPersonal: false,
-      userscriptVersion: '0.92',
+      userscriptVersion: '0.93',
     });
   });
 
@@ -860,7 +860,7 @@ describe('GET /api/userscript/map/:geoguessrId', () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({
       mapFound: false,
-      userscriptVersion: '0.92',
+      userscriptVersion: '0.93',
     });
   });
 });

--- a/apps/api/src/routes/userscript.ts
+++ b/apps/api/src/routes/userscript.ts
@@ -15,7 +15,7 @@ import { generateFooter } from '@api/lib/userscript/utils';
 import { and, asc, eq, isNotNull, sql } from 'drizzle-orm';
 import { Elysia, t } from 'elysia';
 
-const userscriptVersion = '0.92';
+const userscriptVersion = '0.93';
 
 const mapInfoQuery = db.query.maps
   .findFirst({

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Learnable Meta
 // @namespace    geometa
-// @version      0.92
+// @version      0.93
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
 // @downloadURL  https://github.com/likeon/geometa/raw/main/userscript/dist/geometa.user.js
@@ -22,6 +22,10 @@
 
 /*
 # Changelog
+
+## [0.93]
+
+- Added live challenge support for the new GeoGuessr party lobby
 
 ## [0.92]
 
@@ -4062,6 +4066,75 @@ context.l
     );
     return l.u ??= { a: [], b: [], m: [] };
   }
+  const LIVE_CHALLENGE_PATH = /^\/(?:api\/)?live-challenge\/([^/?#]+)\/?$/;
+  const PARTY_LOBBY_PATH = /^\/party\/lobby\/[^/?#]+\/?$/;
+  let trackedPartyChallenge = null;
+  let resourceObserver = null;
+  function pathnameFromUrl(url) {
+    try {
+      return new URL(url, "https://www.geoguessr.com").pathname;
+    } catch {
+      return null;
+    }
+  }
+  function extractLiveChallengeId(url) {
+    const pathname = pathnameFromUrl(url);
+    return pathname?.match(LIVE_CHALLENGE_PATH)?.[1] ?? null;
+  }
+  function isPartyLobbyPath(pathname) {
+    return PARTY_LOBBY_PATH.test(pathname);
+  }
+  function findPartyLiveChallengeId(pathname, resourceUrls) {
+    if (!isPartyLobbyPath(pathname)) {
+      return null;
+    }
+    for (let i = resourceUrls.length - 1; i >= 0; i--) {
+      const id = extractLiveChallengeId(resourceUrls[i]);
+      if (id) {
+        return id;
+      }
+    }
+    return null;
+  }
+  function trackResource(url) {
+    if (!isPartyLobbyPath(location.pathname)) {
+      return;
+    }
+    const id = extractLiveChallengeId(url);
+    if (id) {
+      trackedPartyChallenge = { id, partyLobbyPath: location.pathname };
+    }
+  }
+  function initLiveChallengeIdTracking() {
+    if (resourceObserver || typeof PerformanceObserver === "undefined") {
+      return;
+    }
+    for (const entry of performance.getEntriesByType("resource")) {
+      trackResource(entry.name);
+    }
+    resourceObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        trackResource(entry.name);
+      }
+    });
+    resourceObserver.observe({ entryTypes: ["resource"] });
+  }
+  function getLiveChallengeId(pathname = location.pathname) {
+    const routeId = extractLiveChallengeId(pathname);
+    if (routeId) {
+      return routeId;
+    }
+    if (!isPartyLobbyPath(pathname)) {
+      return null;
+    }
+    if (trackedPartyChallenge?.partyLobbyPath === pathname) {
+      return trackedPartyChallenge.id;
+    }
+    return findPartyLiveChallengeId(
+      pathname,
+      performance.getEntriesByType("resource").map((entry) => entry.name)
+    );
+  }
   function waitForElement(selector) {
     return new Promise((resolve) => {
       try {
@@ -4205,14 +4278,7 @@ context.l
   function wasHelpMessageRead() {
     return _unsafeWindow.localStorage.getItem("geometa:help-message-read") == "true";
   }
-  const getChallengeId = () => {
-    const regexp = /.*\/live-challenge\/(.*)/;
-    const matches = location.pathname.match(regexp);
-    if (matches && matches.length > 1) {
-      return matches[1];
-    }
-    return null;
-  };
+  const getChallengeId = getLiveChallengeId;
   async function getChallengeInfo(id) {
     const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;
     const response = await fetch(url, {
@@ -5324,6 +5390,7 @@ context.l
       pinChanged = true;
       const challengeId = getChallengeId();
       if (!challengeId) {
+        pinChanged = false;
         return;
       }
       try {
@@ -6723,6 +6790,7 @@ roundNumber: 4,
     _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", openResetLayoutDialog);
   }
   initURLChangeEvent();
+  initLiveChallengeIdTracking();
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", setupLearnableMetaFeatures);
   } else {

--- a/dist/geometa.user.js
+++ b/dist/geometa.user.js
@@ -4084,7 +4084,7 @@ context.l
   function isPartyLobbyPath(pathname) {
     return PARTY_LOBBY_PATH.test(pathname);
   }
-  function findPartyLiveChallengeId(pathname, resourceUrls) {
+  function findPartyLiveChallengeId(pathname, resourceUrls, trackedChallenge = null) {
     if (!isPartyLobbyPath(pathname)) {
       return null;
     }
@@ -4094,7 +4094,7 @@ context.l
         return id;
       }
     }
-    return null;
+    return trackedChallenge?.partyLobbyPath === pathname ? trackedChallenge.id : null;
   }
   function trackResource(url) {
     if (!isPartyLobbyPath(location.pathname)) {
@@ -4127,12 +4127,10 @@ context.l
     if (!isPartyLobbyPath(pathname)) {
       return null;
     }
-    if (trackedPartyChallenge?.partyLobbyPath === pathname) {
-      return trackedPartyChallenge.id;
-    }
     return findPartyLiveChallengeId(
       pathname,
-      performance.getEntriesByType("resource").map((entry) => entry.name)
+      performance.getEntriesByType("resource").map((entry) => entry.name),
+      trackedPartyChallenge
     );
   }
   function waitForElement(selector) {

--- a/userscript/CHANGELOG.md
+++ b/userscript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.93]
+
+- Added live challenge support for the new GeoGuessr party lobby
+
 ## [0.92]
 
 - Fixed updated maps still appearing as changed after publishing

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GeoGuessr Learnable Meta
 // @namespace    geometa
-// @version      0.92
+// @version      0.93
 // @description  UserScript for GeoGuessr Learnable Meta maps
 // @icon         https://learnablemeta.com/favicon.png
 // @downloadURL  https://github.com/likeon/geometa/raw/main/userscript/dist/geometa.user.js
@@ -22,6 +22,10 @@
 
 /*
 # Changelog
+
+## [0.93]
+
+- Added live challenge support for the new GeoGuessr party lobby
 
 ## [0.92]
 
@@ -4062,6 +4066,75 @@ context.l
     );
     return l.u ??= { a: [], b: [], m: [] };
   }
+  const LIVE_CHALLENGE_PATH = /^\/(?:api\/)?live-challenge\/([^/?#]+)\/?$/;
+  const PARTY_LOBBY_PATH = /^\/party\/lobby\/[^/?#]+\/?$/;
+  let trackedPartyChallenge = null;
+  let resourceObserver = null;
+  function pathnameFromUrl(url) {
+    try {
+      return new URL(url, "https://www.geoguessr.com").pathname;
+    } catch {
+      return null;
+    }
+  }
+  function extractLiveChallengeId(url) {
+    const pathname = pathnameFromUrl(url);
+    return pathname?.match(LIVE_CHALLENGE_PATH)?.[1] ?? null;
+  }
+  function isPartyLobbyPath(pathname) {
+    return PARTY_LOBBY_PATH.test(pathname);
+  }
+  function findPartyLiveChallengeId(pathname, resourceUrls) {
+    if (!isPartyLobbyPath(pathname)) {
+      return null;
+    }
+    for (let i = resourceUrls.length - 1; i >= 0; i--) {
+      const id = extractLiveChallengeId(resourceUrls[i]);
+      if (id) {
+        return id;
+      }
+    }
+    return null;
+  }
+  function trackResource(url) {
+    if (!isPartyLobbyPath(location.pathname)) {
+      return;
+    }
+    const id = extractLiveChallengeId(url);
+    if (id) {
+      trackedPartyChallenge = { id, partyLobbyPath: location.pathname };
+    }
+  }
+  function initLiveChallengeIdTracking() {
+    if (resourceObserver || typeof PerformanceObserver === "undefined") {
+      return;
+    }
+    for (const entry of performance.getEntriesByType("resource")) {
+      trackResource(entry.name);
+    }
+    resourceObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        trackResource(entry.name);
+      }
+    });
+    resourceObserver.observe({ entryTypes: ["resource"] });
+  }
+  function getLiveChallengeId(pathname = location.pathname) {
+    const routeId = extractLiveChallengeId(pathname);
+    if (routeId) {
+      return routeId;
+    }
+    if (!isPartyLobbyPath(pathname)) {
+      return null;
+    }
+    if (trackedPartyChallenge?.partyLobbyPath === pathname) {
+      return trackedPartyChallenge.id;
+    }
+    return findPartyLiveChallengeId(
+      pathname,
+      performance.getEntriesByType("resource").map((entry) => entry.name)
+    );
+  }
   function waitForElement(selector) {
     return new Promise((resolve) => {
       try {
@@ -4205,14 +4278,7 @@ context.l
   function wasHelpMessageRead() {
     return _unsafeWindow.localStorage.getItem("geometa:help-message-read") == "true";
   }
-  const getChallengeId = () => {
-    const regexp = /.*\/live-challenge\/(.*)/;
-    const matches = location.pathname.match(regexp);
-    if (matches && matches.length > 1) {
-      return matches[1];
-    }
-    return null;
-  };
+  const getChallengeId = getLiveChallengeId;
   async function getChallengeInfo(id) {
     const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;
     const response = await fetch(url, {
@@ -5324,6 +5390,7 @@ context.l
       pinChanged = true;
       const challengeId = getChallengeId();
       if (!challengeId) {
+        pinChanged = false;
         return;
       }
       try {
@@ -6723,6 +6790,7 @@ roundNumber: 4,
     _GM_registerMenuCommand("LearnableMeta - Reset Meta Window Layout", openResetLayoutDialog);
   }
   initURLChangeEvent();
+  initLiveChallengeIdTracking();
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", setupLearnableMetaFeatures);
   } else {

--- a/userscript/dist/geometa.user.js
+++ b/userscript/dist/geometa.user.js
@@ -4084,7 +4084,7 @@ context.l
   function isPartyLobbyPath(pathname) {
     return PARTY_LOBBY_PATH.test(pathname);
   }
-  function findPartyLiveChallengeId(pathname, resourceUrls) {
+  function findPartyLiveChallengeId(pathname, resourceUrls, trackedChallenge = null) {
     if (!isPartyLobbyPath(pathname)) {
       return null;
     }
@@ -4094,7 +4094,7 @@ context.l
         return id;
       }
     }
-    return null;
+    return trackedChallenge?.partyLobbyPath === pathname ? trackedChallenge.id : null;
   }
   function trackResource(url) {
     if (!isPartyLobbyPath(location.pathname)) {
@@ -4127,12 +4127,10 @@ context.l
     if (!isPartyLobbyPath(pathname)) {
       return null;
     }
-    if (trackedPartyChallenge?.partyLobbyPath === pathname) {
-      return trackedPartyChallenge.id;
-    }
     return findPartyLiveChallengeId(
       pathname,
-      performance.getEntriesByType("resource").map((entry) => entry.name)
+      performance.getEntriesByType("resource").map((entry) => entry.name),
+      trackedPartyChallenge
     );
   }
   function waitForElement(selector) {

--- a/userscript/src/lib/liveChallenge.ts
+++ b/userscript/src/lib/liveChallenge.ts
@@ -21,6 +21,9 @@ export function initLiveChallenge() {
     pinChanged = true;
     const challengeId = getChallengeId();
     if (!challengeId) {
+      // A party game may render before its live-challenge request has been
+      // observed. Keep trying while the result view changes.
+      pinChanged = false;
       return;
     }
     try {

--- a/userscript/src/lib/utils/liveChallengeId.ts
+++ b/userscript/src/lib/utils/liveChallengeId.ts
@@ -28,7 +28,8 @@ export function isPartyLobbyPath(pathname: string): boolean {
 
 export function findPartyLiveChallengeId(
   pathname: string,
-  resourceUrls: readonly string[]
+  resourceUrls: readonly string[],
+  trackedChallenge: TrackedChallenge | null = null
 ): string | null {
   if (!isPartyLobbyPath(pathname)) {
     return null;
@@ -40,7 +41,8 @@ export function findPartyLiveChallengeId(
       return id;
     }
   }
-  return null;
+
+  return trackedChallenge?.partyLobbyPath === pathname ? trackedChallenge.id : null;
 }
 
 function trackResource(url: string) {
@@ -86,12 +88,9 @@ export function getLiveChallengeId(pathname: string = location.pathname): string
     return null;
   }
 
-  if (trackedPartyChallenge?.partyLobbyPath === pathname) {
-    return trackedPartyChallenge.id;
-  }
-
   return findPartyLiveChallengeId(
     pathname,
-    performance.getEntriesByType('resource').map((entry) => entry.name)
+    performance.getEntriesByType('resource').map((entry) => entry.name),
+    trackedPartyChallenge
   );
 }

--- a/userscript/src/lib/utils/liveChallengeId.ts
+++ b/userscript/src/lib/utils/liveChallengeId.ts
@@ -1,0 +1,97 @@
+const LIVE_CHALLENGE_PATH = /^\/(?:api\/)?live-challenge\/([^/?#]+)\/?$/;
+const PARTY_LOBBY_PATH = /^\/party\/lobby\/[^/?#]+\/?$/;
+
+type TrackedChallenge = {
+  id: string;
+  partyLobbyPath: string;
+};
+
+let trackedPartyChallenge: TrackedChallenge | null = null;
+let resourceObserver: PerformanceObserver | null = null;
+
+function pathnameFromUrl(url: string): string | null {
+  try {
+    return new URL(url, 'https://www.geoguessr.com').pathname;
+  } catch {
+    return null;
+  }
+}
+
+export function extractLiveChallengeId(url: string): string | null {
+  const pathname = pathnameFromUrl(url);
+  return pathname?.match(LIVE_CHALLENGE_PATH)?.[1] ?? null;
+}
+
+export function isPartyLobbyPath(pathname: string): boolean {
+  return PARTY_LOBBY_PATH.test(pathname);
+}
+
+export function findPartyLiveChallengeId(
+  pathname: string,
+  resourceUrls: readonly string[]
+): string | null {
+  if (!isPartyLobbyPath(pathname)) {
+    return null;
+  }
+
+  for (let i = resourceUrls.length - 1; i >= 0; i--) {
+    const id = extractLiveChallengeId(resourceUrls[i]);
+    if (id) {
+      return id;
+    }
+  }
+  return null;
+}
+
+function trackResource(url: string) {
+  if (!isPartyLobbyPath(location.pathname)) {
+    return;
+  }
+
+  const id = extractLiveChallengeId(url);
+  if (id) {
+    trackedPartyChallenge = { id, partyLobbyPath: location.pathname };
+  }
+}
+
+/**
+ * Remembers live-challenge API requests made while GeoGuessr keeps the browser
+ * on a /party/lobby/... URL. This observes request URLs only; response bodies
+ * and party access tokens are never read.
+ */
+export function initLiveChallengeIdTracking() {
+  if (resourceObserver || typeof PerformanceObserver === 'undefined') {
+    return;
+  }
+
+  for (const entry of performance.getEntriesByType('resource')) {
+    trackResource(entry.name);
+  }
+
+  resourceObserver = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      trackResource(entry.name);
+    }
+  });
+  resourceObserver.observe({ entryTypes: ['resource'] });
+}
+
+export function getLiveChallengeId(pathname: string = location.pathname): string | null {
+  const routeId = extractLiveChallengeId(pathname);
+  if (routeId) {
+    return routeId;
+  }
+
+  if (!isPartyLobbyPath(pathname)) {
+    return null;
+  }
+
+  if (trackedPartyChallenge?.partyLobbyPath === pathname) {
+    return trackedPartyChallenge.id;
+  }
+
+  return findPartyLiveChallengeId(
+    pathname,
+    performance.getEntriesByType('resource').map((entry) => entry.name)
+  );
+}

--- a/userscript/src/lib/utils/main.ts
+++ b/userscript/src/lib/utils/main.ts
@@ -1,4 +1,5 @@
 import { GM_xmlhttpRequest, unsafeWindow, GM_info } from '$';
+import { getLiveChallengeId } from './liveChallengeId';
 
 /**
  * Waits and returns an element with the specified selector.
@@ -184,14 +185,7 @@ export function wasHelpMessageRead(): boolean {
   return unsafeWindow.localStorage.getItem('geometa:help-message-read') == 'true';
 }
 
-export const getChallengeId = () => {
-  const regexp = /.*\/live-challenge\/(.*)/;
-  const matches = location.pathname.match(regexp);
-  if (matches && matches.length > 1) {
-    return matches[1];
-  }
-  return null;
-};
+export const getChallengeId = getLiveChallengeId;
 
 export async function getChallengeInfo(id: string) {
   const url = `https://game-server.geoguessr.com/api/live-challenge/${id}`;

--- a/userscript/src/main.ts
+++ b/userscript/src/main.ts
@@ -9,6 +9,7 @@ import { initChallengeResults } from './lib/challengeResults';
 import { resetContainerPosition } from './lib/utils/dragging';
 import { resetContainerDimensions } from './lib/utils/resizing';
 import { initMapGroupUpdate } from './lib/mapGroupUpdate';
+import { initLiveChallengeIdTracking } from './lib/utils/liveChallengeId';
 import ResetLayoutConfirmation from './lib/components/ResetLayoutConfirmation.svelte';
 import './lib/styles/theme.css';
 import './lib/styles/buttons.css';
@@ -48,6 +49,7 @@ if (typeof GM_registerMenuCommand === 'function') {
 }
 
 initURLChangeEvent();
+initLiveChallengeIdTracking();
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', setupLearnableMetaFeatures);

--- a/userscript/tests/liveChallengeId.test.ts
+++ b/userscript/tests/liveChallengeId.test.ts
@@ -32,6 +32,25 @@ describe('live challenge IDs', () => {
     ).toBe('current-game');
   });
 
+  test('prefers the newest request over a cached game from the same party lobby', () => {
+    expect(
+      findPartyLiveChallengeId(
+        '/party/lobby/WGUL5',
+        ['https://game-server.geoguessr.com/api/live-challenge/current-game'],
+        { id: 'previous-game', partyLobbyPath: '/party/lobby/WGUL5' }
+      )
+    ).toBe('current-game');
+  });
+
+  test('falls back to the cached game when its request is no longer recorded', () => {
+    expect(
+      findPartyLiveChallengeId('/party/lobby/WGUL5', [], {
+        id: 'current-game',
+        partyLobbyPath: '/party/lobby/WGUL5'
+      })
+    ).toBe('current-game');
+  });
+
   test('does not reuse observed game requests outside a party lobby', () => {
     expect(
       findPartyLiveChallengeId('/maps/map-id', [

--- a/userscript/tests/liveChallengeId.test.ts
+++ b/userscript/tests/liveChallengeId.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  extractLiveChallengeId,
+  findPartyLiveChallengeId,
+  isPartyLobbyPath
+} from '../src/lib/utils/liveChallengeId';
+
+describe('live challenge IDs', () => {
+  test('extracts an ID from the public live-challenge route', () => {
+    expect(extractLiveChallengeId('/live-challenge/game-id')).toBe('game-id');
+  });
+
+  test('extracts an ID from the game-server API request', () => {
+    expect(
+      extractLiveChallengeId('https://game-server.geoguessr.com/api/live-challenge/game-id')
+    ).toBe('game-id');
+  });
+
+  test('recognizes party lobby routes with query strings', () => {
+    expect(isPartyLobbyPath(new URL('https://www.geoguessr.com/party/lobby/WGUL5?j=1').pathname)).toBe(
+      true
+    );
+  });
+
+  test('uses the newest live-challenge request while on a party lobby route', () => {
+    expect(
+      findPartyLiveChallengeId('/party/lobby/WGUL5', [
+        'https://game-server.geoguessr.com/api/live-challenge/old-game',
+        'https://game-server.geoguessr.com/api/parties/v2/party-id/lobby',
+        'https://game-server.geoguessr.com/api/live-challenge/current-game'
+      ])
+    ).toBe('current-game');
+  });
+
+  test('does not reuse observed game requests outside a party lobby', () => {
+    expect(
+      findPartyLiveChallengeId('/maps/map-id', [
+        'https://game-server.geoguessr.com/api/live-challenge/game-id'
+      ])
+    ).toBeNull();
+  });
+});

--- a/userscript/vite.config.ts
+++ b/userscript/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
       entry: 'src/main.ts',
       userscript: {
         icon: 'https://learnablemeta.com/favicon.png',
-        version: '0.92',
+        version: '0.93',
         namespace: 'geometa',
         name: 'GeoGuessr Learnable Meta',
         description: 'UserScript for GeoGuessr Learnable Meta maps',


### PR DESCRIPTION
Fixes Learnable Meta support for GeoGuessr Live Challenges launched from the new party lobby, where the page remains on /party/lobby instead of navigating to /live-challenge. Also releases userscript version 0.93 and updates the generated distribution files.